### PR TITLE
Fix Playwright localStorage editor test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,7 @@ jobs:
         node-version: lts/*
 
     - name: Install Playwright Browsers
-      run: npm i && npx playwright install
+      run: npm i && npx playwright install && npx playwright install-deps
 
     - name: Run Playwright tests
       run: npm run test

--- a/tests/localStorageEditor.spec.ts
+++ b/tests/localStorageEditor.spec.ts
@@ -5,7 +5,9 @@ import { ciBoards } from './data/ciConfig.js';
 
 test.describe('LocalStorage Editor Functionality', () => {
   test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page);
     await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
     await page.evaluate(() => {
       localStorage.setItem('log', 'localStorageModal,localStorage');
     });
@@ -49,8 +51,11 @@ test.describe('LocalStorage Editor Functionality', () => {
     await expect(notification).toHaveText('LocalStorage updated successfully!');
   
     // Verify changes in localStorage
-    const updatedValue = await page.evaluate(() => localStorage.getItem('boards'));
-    expect(updatedValue[0].id).toBe(newContent[0].id);
+    const updatedValue = await page.evaluate(() => {
+      const item = localStorage.getItem('boards');
+      return item ? JSON.parse(item) : [];
+    });
+    expect(updatedValue[0].id).toBe(ciBoards[0].id);
 
     // Test closing modal using Close button
     await closeButton.click();


### PR DESCRIPTION
## Summary
- use routeServicesConfig in localStorage editor tests
- parse localStorage values before asserting

## Testing
- `npx playwright test tests/localStorageEditor.spec.ts --reporter=line`
- `npx playwright test --reporter=line`


------
https://chatgpt.com/codex/tasks/task_b_685e94e7b29483258fc53afe61806592