### PR TITLE
Implement dynamic configuration modal

### DIFF
--- a/src/component/dialog/notification.js
+++ b/src/component/dialog/notification.js
@@ -12,6 +12,14 @@ function generateUUID () {
 
 // Function to show a temporary message like alert with dismiss options
 export function showNotification (message, duration = 3000) {
+  // Remove any existing notifications to avoid duplicates during tests
+  document.querySelectorAll('.user-notification').forEach(el => {
+    try {
+      el.remove()
+    } catch (e) {
+      logger.error('Error removing old notification:', e)
+    }
+  })
   // Generate a unique ID for the dialog
   const dialogId = generateUUID()
 

--- a/src/component/dialog/notification.js
+++ b/src/component/dialog/notification.js
@@ -15,6 +15,7 @@ export function showNotification (message, duration = 3000) {
   // Remove any existing notifications to avoid duplicates during tests
   document.querySelectorAll('.user-notification').forEach(el => {
     try {
+      if (typeof el.close === 'function') el.close()
       el.remove()
     } catch (e) {
       logger.error('Error removing old notification:', e)

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -1,0 +1,56 @@
+import { showNotification } from '../dialog/notification.js'
+import { Logger } from '../../utils/Logger.js'
+
+const logger = new Logger('configModal.js')
+
+export function openConfigModal (initialConfig = '') {
+  if (document.getElementById('config-modal')) {
+    logger.log('Config modal already open')
+    return
+  }
+
+  const modal = document.createElement('div')
+  modal.id = 'config-modal'
+  document.body.appendChild(modal)
+
+  const textarea = document.createElement('textarea')
+  textarea.id = 'config-json'
+  textarea.value = initialConfig
+  modal.appendChild(textarea)
+
+  const buttonContainer = document.createElement('div')
+
+  const saveButton = document.createElement('button')
+  saveButton.textContent = 'Save'
+  saveButton.addEventListener('click', () => {
+    try {
+      const config = JSON.parse(textarea.value)
+      localStorage.setItem('config', JSON.stringify(config))
+      window.asd.config = config
+      location.reload()
+    } catch (err) {
+      logger.error('Invalid JSON provided in config modal')
+      showNotification('Invalid JSON, please correct and try again')
+    }
+  })
+
+  const closeButton = document.createElement('button')
+  closeButton.textContent = 'Close'
+  closeButton.classList.add('lsm-cancel-button')
+  closeButton.addEventListener('click', () => {
+    modal.remove()
+  })
+
+  buttonContainer.appendChild(saveButton)
+  buttonContainer.appendChild(closeButton)
+  modal.appendChild(buttonContainer)
+
+  // allow closing with escape
+  const escListener = e => {
+    if (e.key === 'Escape') {
+      modal.remove()
+      window.removeEventListener('keydown', escListener)
+    }
+  }
+  window.addEventListener('keydown', escListener)
+}

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   logger.log('DOMContentLoaded event fired')
   initializeMainMenu()
   fetchServices()
-  await getConfig()
+  try {
+    await getConfig()
+  } catch (e) {
+    const { showNotification } = await import('./component/dialog/notification.js')
+    showNotification('Invalid configuration data')
+  }
   initializeDashboardMenu()
 
   const boards = await loadBoardState()

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     await getConfig()
   } catch (e) {
     const { showNotification } = await import('./component/dialog/notification.js')
-    showNotification('Invalid configuration data')
+    if (!document.getElementById('config-modal')) {
+      showNotification('Invalid configuration data')
+    }
   }
   initializeDashboardMenu()
 

--- a/src/ui/modal.css
+++ b/src/ui/modal.css
@@ -92,3 +92,37 @@
 #localStorage-modal .lsm-cancel-button:hover {
     background-color: #444444; /* Slightly darker grey on hover */
 }
+
+#config-modal {
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    width: 60vw;
+    height: 60vh;
+    margin: 0 auto;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+    z-index: 1000;
+}
+
+#config-modal textarea {
+    width: 100%;
+    height: 100%;
+    margin-bottom: 10px;
+}
+
+#config-modal button {
+    margin-right: 10px;
+    padding: 8px 12px;
+}
+
+#config-modal .lsm-cancel-button {
+    background-color: #555555;
+    color: white;
+}

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -22,6 +22,8 @@ export const fetchServices = () =>
         serviceSelector.appendChild(option)
       })
     })
-    .catch(error => {
+    .catch(async error => {
       logger.error('Error fetching services:', error)
+      const { showNotification } = await import('../component/dialog/notification.js')
+      showNotification('Invalid services data')
     })

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -38,7 +38,9 @@ async function getConfig () {
       return json
     } catch (err) {
       logger.error('Error fetching remote config:', err)
-      // fallthrough to show modal below
+      const { openConfigModal } = await import('../component/modal/configModal.js')
+      openConfigModal('')
+      throw new Error('Failed to load configuration')
     }
   }
 
@@ -55,12 +57,10 @@ async function getConfig () {
     return config
   } catch (error) {
     logger.error('Error fetching config.json:', error)
+    const { openConfigModal } = await import('../component/modal/configModal.js')
+    openConfigModal('')
+    throw new Error('Failed to load configuration')
   }
-
-  // If all methods failed, show config modal for manual input
-  const { openConfigModal } = await import('../component/modal/configModal.js')
-  openConfigModal('')
-  throw new Error('Failed to load configuration')
 }
 
 export { getConfig }

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -8,19 +8,59 @@ async function getConfig () {
     return window.asd.config
   }
 
+  // 1. Try localStorage
+  const stored = localStorage.getItem('config')
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored)
+      window.asd.config = parsed
+      logger.log('Loaded config from localStorage')
+      return parsed
+    } catch (e) {
+      logger.error('Invalid JSON in localStorage config')
+      localStorage.removeItem('config')
+    }
+  }
+
+  // 2. Check URL param for remote config
+  const params = new URLSearchParams(window.location.search)
+  const remoteUrl = params.get('config_url')
+  if (remoteUrl) {
+    try {
+      const resp = await fetch(remoteUrl)
+      if (!resp.ok) {
+        throw new Error('Network response was not ok')
+      }
+      const json = await resp.json()
+      localStorage.setItem('config', JSON.stringify(json))
+      window.asd.config = json
+      logger.log('Config loaded from remote url')
+      return json
+    } catch (err) {
+      logger.error('Error fetching remote config:', err)
+      // fallthrough to show modal below
+    }
+  }
+
+  // 3. Try default config.json
   try {
     const response = await fetch('config.json')
     if (!response.ok) {
       throw new Error('Network response was not ok')
     }
     const config = await response.json()
-    window.asd.config = config // Cache the configuration
+    window.asd.config = config
+    localStorage.setItem('config', JSON.stringify(config))
     logger.log('Config loaded successfully')
     return config
   } catch (error) {
     logger.error('Error fetching config.json:', error)
-    throw new Error('Failed to load configuration')
   }
+
+  // If all methods failed, show config modal for manual input
+  const { openConfigModal } = await import('../component/modal/configModal.js')
+  openConfigModal('')
+  throw new Error('Failed to load configuration')
 }
 
 export { getConfig }


### PR DESCRIPTION
## Summary
- add modal for manual config entry
- support remote URLs and localStorage in `getConfig`
- notify when config load fails
- show single notifications
- fetch services with user notice on failure
- include modal styles

## Testing
- `npm test` *(fails: npm warns unknown env config; tests ran to completion)*

------
https://chatgpt.com/codex/tasks/task_b_685ec55d3ccc83258e8f844dfa5cce08