### PR TITLE
Improve config loading error handling

### DIFF
--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -25,6 +25,7 @@ export function openConfigModal (template = DEFAULT_CONFIG_TEMPLATE) {
   logger.log('Opening config modal')
   const modal = document.createElement('div')
   modal.id = 'config-modal'
+  modal.setAttribute('role', 'dialog')
 
   const textarea = document.createElement('textarea')
   textarea.id = 'config-json'
@@ -42,7 +43,7 @@ export function openConfigModal (template = DEFAULT_CONFIG_TEMPLATE) {
       setTimeout(() => location.reload(), 500)
     } catch (e) {
       logger.error('Invalid JSON in config modal:', e)
-      showNotification('Invalid JSON, please correct and try again')
+      showNotification('Invalid JSON format')
     }
   })
 

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -24,6 +24,7 @@ async function fetchJson (url) {
       } else {
         showNotification('Invalid configuration from URL')
       }
+      openConfigModal(DEFAULT_CONFIG_TEMPLATE)
       return null
     }
     try {
@@ -31,11 +32,13 @@ async function fetchJson (url) {
     } catch (err) {
       logger.error('Failed to parse remote config JSON:', err)
       showNotification('Invalid configuration JSON. Please check the remote URL.')
+      openConfigModal(DEFAULT_CONFIG_TEMPLATE)
       return null
     }
   } catch (e) {
     logger.error('Failed to fetch config from URL:', e)
     showNotification('Invalid configuration from URL')
+    openConfigModal(DEFAULT_CONFIG_TEMPLATE)
     return null
   }
 }


### PR DESCRIPTION
## Summary
- trigger config modal when remote config fetch fails
- mark modal as `role="dialog"`
- show a clearer message when invalid JSON is entered

## Testing
- `npm test -- --grep dynamicConfig.spec.ts` *(fails: shows 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_685ed29df40c832594755c98dd1d44a8