### PR TITLE
Add shared types and enable @ts-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,12 @@
 | 🛠️ **DevelopmentAgent**     | Implements features from structured logs → passing tests    | Logs (`playwright-report-index.json.gz`), symbols, tests | Clean JS, passing tests, updated `symbols.json` |
 | 📦 **LoggerAttacher**        | Ensures structured logging (`Logger`) in UI modules         | `Logger.js`, UI modules                                  | Structured logs in Playwright reports           |
 | 🧬 **SymbolIndexMaintainer** | Keeps canonical `symbols.json` always updated               | JS sources                                               | Accurate `symbols.json`                         |
-| 🧪 **TestInspector**         | Executes & indexes Playwright tests for Codex introspection | `.spec.ts`, Playwright commands                          | `playwright-report-index.json.gz`               |
+| 💪 **TestInspector**         | Executes & indexes Playwright tests for Codex introspection | `.spec.ts`, Playwright commands                          | `playwright-report-index.json.gz`               |
 | ✅ **ValidationAgent**        | Validates symbols, tests, logs before commit                | `symbols.json`, tests, logs, JSDoc, lint                 | Commit-ready PRs with clear QA summaries        |
 
 ---
 
-## 🚧 AI Agent Constraints
+## ⚧️ AI Agent Constraints
 
 * **Client-side only** (DOM APIs, localStorage, fetch).
 * **No frameworks/transpilers/build tools**. Pure ES6+ Vanilla JS.
@@ -130,11 +130,11 @@ Output must always be ready-to-commit.
 
 ---
 
-## 🧪 Two-Phase AI-Driven Workflow
+## Two-Phase AI-Driven Workflow
 
 Codex agents follow a strict workflow:
 
-### ① Test Execution
+### Test Execution
 
 Generate structured logs:
 
@@ -151,7 +151,7 @@ DEV-ENV-ERROR: playwright dependency missing
 Proposed fix: npm install playwright
 ```
 
-### ② Test Indexing & Inspection
+### Test Indexing & Inspection
 
 Create indexed logs:
 
@@ -193,6 +193,38 @@ Core scripts:
 * Design modular, config-driven interfaces.
 * Enable symbolic navigation for simulation and validation.
 * Avoid hard-coded paths or options; rely on configuration files.
+
+---
+
+## ❌ TypeScript Error Handling Policy
+
+Codex may not patch TypeScript errors using blind type assertions like `as HTMLElement` or `as any`.
+
+### 🧱 Rules:
+
+* Always use `instanceof` or other runtime-safe guards:
+
+  ```ts
+  if (target instanceof HTMLInputElement) {
+    console.log(target.value);
+  }
+  ```
+
+* Never assume properties exist on `EventTarget`, `HTMLElement`, or `Element` without guard checks.
+
+* Never silence errors via widening types unless validated by runtime contract.
+
+* Avoid introducing regressions by validating every fix.
+
+### ✅ Mandatory Post-Fix Validation
+
+After applying any fix:
+
+```bash
+just check && just test:changed
+```
+
+Only if both pass, the patch is accepted.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -26,3 +26,7 @@ format:
 # Extract symbol index
 extract-symbols:
     node scripts/extract-symbol-index.mjs
+
+# Run static type checking
+check:
+    npm run check

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "globby": "^13.2.2",
         "husky": "^9.1.6",
         "playwright": "^1.47.2",
-        "standard": "*"
+        "standard": "*",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3466,6 +3467,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:ui": "playwright test --ui",
     "test:grep": "playwright test --grep",
     "test:report": "playwright test --reporter=html",
-    "merge-videos": "NODE_PATH=$(npm root -g) node scripts/mergePlaywrightVideos.js"
+    "merge-videos": "NODE_PATH=$(npm root -g) node scripts/mergePlaywrightVideos.js",
+    "check": "tsc"
   },
   "devDependencies": {
     "@playwright/test": "^1.47.2",
@@ -27,7 +28,8 @@
     "playwright": "^1.47.2",
     "standard": "*",
     "comment-parser": "^1.4.0",
-    "globby": "^13.2.2"
+    "globby": "^13.2.2",
+    "typescript": "^5.8.3"
   },
   "standard": {
     "globals": [

--- a/src/component/board/boardDropdown.js
+++ b/src/component/board/boardDropdown.js
@@ -107,6 +107,6 @@ function handleDeleteBoard () {
  * @returns {string}
  */
 function getSelectedBoardId () {
-  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
+  const boardSelector = document.getElementById('board-selector')
   return boardSelector.value
 }

--- a/src/component/board/boardDropdown.js
+++ b/src/component/board/boardDropdown.js
@@ -107,6 +107,6 @@ function handleDeleteBoard () {
  * @returns {string}
  */
 function getSelectedBoardId () {
-  const boardSelector = document.getElementById('board-selector')
+  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   return boardSelector.value
 }

--- a/src/component/board/boardDropdown.js
+++ b/src/component/board/boardDropdown.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * UI handlers for the board actions dropdown.
  *

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -136,15 +136,7 @@ export async function switchView (boardId, viewId) {
       clearWidgetContainer()
       logger.log(`Rendering widgets for view ${viewId}:`, view.widgetState)
       for (const widget of view.widgetState) {
-        await addWidget(
-          widget.url,
-          Number(widget.columns),
-          Number(widget.rows),
-          widget.type,
-          boardId,
-          viewId,
-          widget.dataid
-        )
+        await addWidget(widget.url, widget.columns, widget.rows, widget.type, boardId, viewId, widget.dataid)
       }
       window.asd.currentViewId = viewId
       localStorage.setItem('lastUsedViewId', viewId)
@@ -166,7 +158,7 @@ export async function switchView (boardId, viewId) {
  * @returns {void}
  */
 export function updateViewSelector (boardId) {
-  const viewSelector = /** @type {HTMLSelectElement|null} */(document.getElementById('view-selector'))
+  const viewSelector = document.getElementById('view-selector')
   if (!viewSelector) {
     logger.error('View selector element not found')
     return
@@ -258,7 +250,6 @@ export function initializeBoards () {
     }
   }).catch(error => {
     logger.error('Error initializing boards:', error)
-    return undefined
   })
 }
 
@@ -271,7 +262,7 @@ export function initializeBoards () {
  * @returns {void}
  */
 export function addBoardToUI (board) {
-  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
+  const boardSelector = document.getElementById('board-selector')
   const option = document.createElement('option')
   option.value = board.id
   option.textContent = board.name
@@ -416,7 +407,7 @@ export function resetView (boardId, viewId) {
 }
 
 function updateBoardSelector () {
-  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
+  const boardSelector = document.getElementById('board-selector')
   boardSelector.innerHTML = ''
   boards.forEach(board => {
     const option = document.createElement('option')

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Board and view management utilities.
  *
@@ -7,8 +8,13 @@ import { saveBoardState, loadBoardState } from '../../storage/localStorage.js'
 import { addWidget } from '../widget/widgetManagement.js'
 import { Logger } from '../../utils/Logger.js'
 
+/** @typedef {import('../../types.js').Board} Board */
+/** @typedef {import('../../types.js').View} View */
+/** @typedef {import('../../types.js').Widget} Widget */
+
 const logger = new Logger('boardManagement.js')
 
+/** @type {Array<Board>} */
 export let boards = []
 
 function generateUniqueId (prefix) {
@@ -23,7 +29,7 @@ function generateUniqueId (prefix) {
  * @param {?string} [boardId=null] - Existing board identifier, if any.
  * @param {?string} [viewId=null] - Identifier for the default view.
  * @function createBoard
- * @returns {object} The created board.
+ * @returns {Board} The created board.
  */
 export function createBoard (boardName, boardId = null, viewId = null) {
   const newBoardId = boardId || generateUniqueId('board')
@@ -65,7 +71,7 @@ export function createBoard (boardName, boardId = null, viewId = null) {
  * @param {string} viewName - Display name for the view.
  * @param {?string} [viewId=null] - Optional predefined id for the view.
  * @function createView
- * @returns {object|undefined} The created view or undefined if the board is not found.
+ * @returns {View|undefined} The created view or undefined if the board is not found.
  */
 export function createView (boardId, viewName, viewId = null) {
   const board = boards.find(b => b.id === boardId)

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -136,7 +136,15 @@ export async function switchView (boardId, viewId) {
       clearWidgetContainer()
       logger.log(`Rendering widgets for view ${viewId}:`, view.widgetState)
       for (const widget of view.widgetState) {
-        await addWidget(widget.url, widget.columns, widget.rows, widget.type, boardId, viewId, widget.dataid)
+        await addWidget(
+          widget.url,
+          Number(widget.columns),
+          Number(widget.rows),
+          widget.type,
+          boardId,
+          viewId,
+          widget.dataid
+        )
       }
       window.asd.currentViewId = viewId
       localStorage.setItem('lastUsedViewId', viewId)
@@ -158,7 +166,7 @@ export async function switchView (boardId, viewId) {
  * @returns {void}
  */
 export function updateViewSelector (boardId) {
-  const viewSelector = document.getElementById('view-selector')
+  const viewSelector = /** @type {HTMLSelectElement|null} */(document.getElementById('view-selector'))
   if (!viewSelector) {
     logger.error('View selector element not found')
     return
@@ -250,6 +258,7 @@ export function initializeBoards () {
     }
   }).catch(error => {
     logger.error('Error initializing boards:', error)
+    return undefined
   })
 }
 
@@ -262,7 +271,7 @@ export function initializeBoards () {
  * @returns {void}
  */
 export function addBoardToUI (board) {
-  const boardSelector = document.getElementById('board-selector')
+  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   const option = document.createElement('option')
   option.value = board.id
   option.textContent = board.name
@@ -407,7 +416,7 @@ export function resetView (boardId, viewId) {
 }
 
 function updateBoardSelector () {
-  const boardSelector = document.getElementById('board-selector')
+  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   boardSelector.innerHTML = ''
   boards.forEach(board => {
     const option = document.createElement('option')

--- a/src/component/dialog/notification.js
+++ b/src/component/dialog/notification.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Simple notification dialog utilities.
  *

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,8 +36,8 @@ function initializeDashboardMenu () {
   document.addEventListener('services-updated', populateServiceDropdown)
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
-    const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
-    const widgetUrlInput = /** @type {HTMLInputElement} */(document.getElementById('widget-url'))
+    const serviceSelector = document.getElementById('service-selector')
+    const widgetUrlInput = document.getElementById('widget-url')
     const boardElement = document.querySelector('.board')
     const viewElement = document.querySelector('.board-view')
     const selectedServiceUrl = serviceSelector.value
@@ -74,8 +74,7 @@ function initializeDashboardMenu () {
   })
 
   document.getElementById('board-selector').addEventListener('change', (event) => {
-    const target = /** @type {HTMLSelectElement} */(event.target)
-    const selectedBoardId = target.value
+    const selectedBoardId = event.target.value
     const currentBoardId = getCurrentBoardId()
     saveWidgetState(currentBoardId) // Save the state of the current board before switching
     switchBoard(selectedBoardId)
@@ -84,8 +83,7 @@ function initializeDashboardMenu () {
 
   document.getElementById('view-selector').addEventListener('change', (event) => {
     const selectedBoardId = getCurrentBoardId()
-    const target = /** @type {HTMLSelectElement} */(event.target)
-    const selectedViewId = target.value
+    const selectedViewId = event.target.value
     logger.log(`Switching to selected view ${selectedViewId} in board ${selectedBoardId}`)
     switchView(selectedBoardId, selectedViewId)
   })

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,8 +36,8 @@ function initializeDashboardMenu () {
   document.addEventListener('services-updated', populateServiceDropdown)
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
-    const serviceSelector = document.getElementById('service-selector')
-    const widgetUrlInput = document.getElementById('widget-url')
+    const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
+    const widgetUrlInput = /** @type {HTMLInputElement} */(document.getElementById('widget-url'))
     const boardElement = document.querySelector('.board')
     const viewElement = document.querySelector('.board-view')
     const selectedServiceUrl = serviceSelector.value
@@ -74,7 +74,8 @@ function initializeDashboardMenu () {
   })
 
   document.getElementById('board-selector').addEventListener('change', (event) => {
-    const selectedBoardId = event.target.value
+    const target = /** @type {HTMLSelectElement} */(event.target)
+    const selectedBoardId = target.value
     const currentBoardId = getCurrentBoardId()
     saveWidgetState(currentBoardId) // Save the state of the current board before switching
     switchBoard(selectedBoardId)
@@ -83,7 +84,8 @@ function initializeDashboardMenu () {
 
   document.getElementById('view-selector').addEventListener('change', (event) => {
     const selectedBoardId = getCurrentBoardId()
-    const selectedViewId = event.target.value
+    const target = /** @type {HTMLSelectElement} */(event.target)
+    const selectedViewId = target.value
     logger.log(`Switching to selected view ${selectedViewId} in board ${selectedBoardId}`)
     switchView(selectedBoardId, selectedViewId)
   })

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Menu actions for adding widgets and switching boards/views.
  *

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -13,7 +13,7 @@ import emojiList from '../../ui/unicodeEmoji.js'
  * @returns {void}
  */
 function initSW () {
-  const swToggle = document.getElementById('sw-toggle')
+  const swToggle = /** @type {HTMLInputElement} */(document.getElementById('sw-toggle'))
   const swIcon = document.querySelector('.sw-icon')
   const swCheckbox = document.querySelector('.icon-checkbox')
   const swEnabled = localStorage.getItem('swEnabled') === 'true'
@@ -76,7 +76,7 @@ function initSW () {
 
     swToggle.addEventListener('change', function () {
       const isEnabled = swToggle.checked
-      localStorage.setItem('swEnabled', isEnabled)
+      localStorage.setItem('swEnabled', String(isEnabled))
       updateServiceWorkerUI(isEnabled)
 
       if (isEnabled) {

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -13,7 +13,7 @@ import emojiList from '../../ui/unicodeEmoji.js'
  * @returns {void}
  */
 function initSW () {
-  const swToggle = /** @type {HTMLInputElement} */(document.getElementById('sw-toggle'))
+  const swToggle = document.getElementById('sw-toggle')
   const swIcon = document.querySelector('.sw-icon')
   const swCheckbox = document.querySelector('.icon-checkbox')
   const swEnabled = localStorage.getItem('swEnabled') === 'true'
@@ -76,7 +76,7 @@ function initSW () {
 
     swToggle.addEventListener('change', function () {
       const isEnabled = swToggle.checked
-      localStorage.setItem('swEnabled', String(isEnabled))
+      localStorage.setItem('swEnabled', isEnabled)
       updateServiceWorkerUI(isEnabled)
 
       if (isEnabled) {

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Build and initialize the main dashboard menu UI.
  *

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal dialog for editing the application configuration.
  *

--- a/src/component/modal/localStorageModal.js
+++ b/src/component/modal/localStorageModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal dialog for viewing and editing `localStorage` entries.
  *

--- a/src/component/modal/localStorageModal.js
+++ b/src/component/modal/localStorageModal.js
@@ -81,7 +81,7 @@ export function openLocalStorageModal () {
         let invalid = false
         for (const [key] of Object.entries(data)) {
           if (key.includes('swEnabled') || key.includes('config')) continue
-          const val = document.getElementById(`localStorage-${key}`).value
+          const val = /** @type {HTMLTextAreaElement} */(document.getElementById(`localStorage-${key}`)).value
           try {
             updated[key] = JSON.parse(val)
           } catch {

--- a/src/component/modal/localStorageModal.js
+++ b/src/component/modal/localStorageModal.js
@@ -81,7 +81,7 @@ export function openLocalStorageModal () {
         let invalid = false
         for (const [key] of Object.entries(data)) {
           if (key.includes('swEnabled') || key.includes('config')) continue
-          const val = /** @type {HTMLTextAreaElement} */(document.getElementById(`localStorage-${key}`)).value
+          const val = document.getElementById(`localStorage-${key}`).value
           try {
             updated[key] = JSON.parse(val)
           } catch {

--- a/src/component/modal/modalFactory.js
+++ b/src/component/modal/modalFactory.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utility for constructing modal dialogs.
  *

--- a/src/component/modal/saveServiceModal.js
+++ b/src/component/modal/saveServiceModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal prompting to save a URL as a named service.
  *

--- a/src/component/modal/serviceLaunchModal.js
+++ b/src/component/modal/serviceLaunchModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal used to launch a service-specific action in an iframe.
  *

--- a/src/component/utils/dropDownUtils.js
+++ b/src/component/utils/dropDownUtils.js
@@ -23,8 +23,7 @@ export function initializeDropdown (dropdownElement, handlers) {
   }
 
   dropdownElement.addEventListener('click', (event) => {
-    const target = /** @type {HTMLElement} */(event.target)
-    const action = target.dataset.action // Assuming the action is stored in a data attribute
+    const action = event.target.dataset.action // Assuming the action is stored in a data attribute
     logger.log('Dropdown action clicked:', action)
 
     if (handlers && typeof handlers[action] === 'function') {

--- a/src/component/utils/dropDownUtils.js
+++ b/src/component/utils/dropDownUtils.js
@@ -23,7 +23,8 @@ export function initializeDropdown (dropdownElement, handlers) {
   }
 
   dropdownElement.addEventListener('click', (event) => {
-    const action = event.target.dataset.action // Assuming the action is stored in a data attribute
+    const target = /** @type {HTMLElement} */(event.target)
+    const action = target.dataset.action // Assuming the action is stored in a data attribute
     logger.log('Dropdown action clicked:', action)
 
     if (handlers && typeof handlers[action] === 'function') {

--- a/src/component/utils/dropDownUtils.js
+++ b/src/component/utils/dropDownUtils.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Shared dropdown initialization helper.
  *

--- a/src/component/view/viewDropdown.js
+++ b/src/component/view/viewDropdown.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Dropdown handlers for view-specific actions.
  *

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Drag and drop handlers for reordering widgets.
  *

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -29,7 +29,7 @@ function handleDragStart (e, draggedWidgetWrapper) {
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
     if (widget !== draggedWidgetWrapper) {
-      addDragOverlay(/** @type {HTMLElement} */(widget))
+      addDragOverlay(widget)
     }
   })
 }
@@ -45,7 +45,7 @@ function handleDragEnd (e) {
   const widgetContainer = document.getElementById('widget-container')
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
-    removeDragOverlay(/** @type {HTMLElement} */(widget))
+    removeDragOverlay(widget)
     widget.classList.remove('drag-over')
   })
 }
@@ -117,7 +117,7 @@ function handleDrop (e, targetWidgetWrapper) {
   logger.log(`Drop event: draggedOrder=${draggedOrder}, targetOrder=${targetOrder}`)
 
   const widgetContainer = document.getElementById('widget-container')
-  const draggedWidget = /** @type {HTMLElement|null} */(widgetContainer.querySelector(`[data-order='${draggedOrder}']`))
+  const draggedWidget = widgetContainer.querySelector(`[data-order='${draggedOrder}']`)
 
   if (!draggedWidget) {
     logger.error('Invalid dragged widget element', 3000, 'error')
@@ -125,7 +125,7 @@ function handleDrop (e, targetWidgetWrapper) {
   }
 
   if (targetOrder !== null) {
-    const targetWidget = /** @type {HTMLElement|null} */(widgetContainer.querySelector(`[data-order='${targetOrder}']`))
+    const targetWidget = widgetContainer.querySelector(`[data-order='${targetOrder}']`)
     if (!targetWidget) {
       logger.error('Invalid target widget element', 3000, 'error')
       return
@@ -149,7 +149,7 @@ function handleDrop (e, targetWidgetWrapper) {
     }
   } else {
     // Calculate nearest available grid position
-    const gridColumnCount = getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length
+    const gridColumnCount = parseInt(getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length, 10)
     let targetColumn = Math.floor(e.clientX / draggedWidget.offsetWidth)
     let targetRow = Math.floor(e.clientY / draggedWidget.offsetHeight)
 
@@ -158,8 +158,8 @@ function handleDrop (e, targetWidgetWrapper) {
     targetColumn = Math.max(targetColumn, 0)
     targetRow = Math.max(targetRow, 0)
 
-    draggedWidget.style.gridColumnStart = String(targetColumn + 1)
-    draggedWidget.style.gridRowStart = String(targetRow + 1)
+    draggedWidget.style.gridColumnStart = targetColumn + 1
+    draggedWidget.style.gridRowStart = targetRow + 1
 
     logger.log('Widget moved to new grid position:', {
       column: targetColumn + 1,
@@ -235,14 +235,14 @@ function initializeDragAndDrop () {
   const widgetContainer = document.getElementById('widget-container')
   widgetContainer.addEventListener('dragover', (e) => {
     e.preventDefault()
-    const dragOverTarget = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
+    const dragOverTarget = e.target.closest('.widget-wrapper')
     if (dragOverTarget) {
       dragOverTarget.classList.add('drag-over', 'highlight-drop-area')
     }
   })
 
   widgetContainer.addEventListener('dragleave', (e) => {
-    const dragLeaveTarget = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
+    const dragLeaveTarget = e.target.closest('.widget-wrapper')
     if (dragLeaveTarget) {
       dragLeaveTarget.classList.remove('drag-over', 'highlight-drop-area')
     }
@@ -251,24 +251,24 @@ function initializeDragAndDrop () {
   widgetContainer.addEventListener('drop', (e) => {
     e.preventDefault()
     const draggedOrder = e.dataTransfer.getData('text/plain')
-    const targetWidgetWrapper = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
+    const targetWidgetWrapper = e.target.closest('.widget-wrapper')
     const targetOrder = targetWidgetWrapper ? targetWidgetWrapper.getAttribute('data-order') : null
 
     if (draggedOrder !== null) {
       const widgets = Array.from(widgetContainer.children)
-      const draggedWidget = /** @type {HTMLElement}|undefined */(widgets.find(widget => widget.getAttribute('data-order') === draggedOrder))
+      const draggedWidget = widgets.find(widget => widget.getAttribute('data-order') === draggedOrder)
 
       if (draggedWidget) {
         if (targetOrder !== null) {
-          const targetWidget = /** @type {HTMLElement}|undefined */(widgets.find(widget => widget.getAttribute('data-order') === targetOrder))
+          const targetWidget = widgets.find(widget => widget.getAttribute('data-order') === targetOrder)
           if (targetWidget) {
             // Swap orders
             draggedWidget.setAttribute('data-order', targetOrder)
             targetWidget.setAttribute('data-order', draggedOrder)
 
             // Update CSS order
-            draggedWidget.style.order = String(targetOrder)
-            targetWidget.style.order = String(draggedOrder)
+            draggedWidget.style.order = targetOrder
+            targetWidget.style.order = draggedOrder
           }
         } else {
           // Handle drop in open space

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -29,7 +29,7 @@ function handleDragStart (e, draggedWidgetWrapper) {
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
     if (widget !== draggedWidgetWrapper) {
-      addDragOverlay(widget)
+      addDragOverlay(/** @type {HTMLElement} */(widget))
     }
   })
 }
@@ -45,7 +45,7 @@ function handleDragEnd (e) {
   const widgetContainer = document.getElementById('widget-container')
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
-    removeDragOverlay(widget)
+    removeDragOverlay(/** @type {HTMLElement} */(widget))
     widget.classList.remove('drag-over')
   })
 }
@@ -117,7 +117,7 @@ function handleDrop (e, targetWidgetWrapper) {
   logger.log(`Drop event: draggedOrder=${draggedOrder}, targetOrder=${targetOrder}`)
 
   const widgetContainer = document.getElementById('widget-container')
-  const draggedWidget = widgetContainer.querySelector(`[data-order='${draggedOrder}']`)
+  const draggedWidget = /** @type {HTMLElement|null} */(widgetContainer.querySelector(`[data-order='${draggedOrder}']`))
 
   if (!draggedWidget) {
     logger.error('Invalid dragged widget element', 3000, 'error')
@@ -125,7 +125,7 @@ function handleDrop (e, targetWidgetWrapper) {
   }
 
   if (targetOrder !== null) {
-    const targetWidget = widgetContainer.querySelector(`[data-order='${targetOrder}']`)
+    const targetWidget = /** @type {HTMLElement|null} */(widgetContainer.querySelector(`[data-order='${targetOrder}']`))
     if (!targetWidget) {
       logger.error('Invalid target widget element', 3000, 'error')
       return
@@ -149,7 +149,7 @@ function handleDrop (e, targetWidgetWrapper) {
     }
   } else {
     // Calculate nearest available grid position
-    const gridColumnCount = parseInt(getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length, 10)
+    const gridColumnCount = getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length
     let targetColumn = Math.floor(e.clientX / draggedWidget.offsetWidth)
     let targetRow = Math.floor(e.clientY / draggedWidget.offsetHeight)
 
@@ -158,8 +158,8 @@ function handleDrop (e, targetWidgetWrapper) {
     targetColumn = Math.max(targetColumn, 0)
     targetRow = Math.max(targetRow, 0)
 
-    draggedWidget.style.gridColumnStart = targetColumn + 1
-    draggedWidget.style.gridRowStart = targetRow + 1
+    draggedWidget.style.gridColumnStart = String(targetColumn + 1)
+    draggedWidget.style.gridRowStart = String(targetRow + 1)
 
     logger.log('Widget moved to new grid position:', {
       column: targetColumn + 1,
@@ -235,14 +235,14 @@ function initializeDragAndDrop () {
   const widgetContainer = document.getElementById('widget-container')
   widgetContainer.addEventListener('dragover', (e) => {
     e.preventDefault()
-    const dragOverTarget = e.target.closest('.widget-wrapper')
+    const dragOverTarget = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
     if (dragOverTarget) {
       dragOverTarget.classList.add('drag-over', 'highlight-drop-area')
     }
   })
 
   widgetContainer.addEventListener('dragleave', (e) => {
-    const dragLeaveTarget = e.target.closest('.widget-wrapper')
+    const dragLeaveTarget = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
     if (dragLeaveTarget) {
       dragLeaveTarget.classList.remove('drag-over', 'highlight-drop-area')
     }
@@ -251,24 +251,24 @@ function initializeDragAndDrop () {
   widgetContainer.addEventListener('drop', (e) => {
     e.preventDefault()
     const draggedOrder = e.dataTransfer.getData('text/plain')
-    const targetWidgetWrapper = e.target.closest('.widget-wrapper')
+    const targetWidgetWrapper = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
     const targetOrder = targetWidgetWrapper ? targetWidgetWrapper.getAttribute('data-order') : null
 
     if (draggedOrder !== null) {
       const widgets = Array.from(widgetContainer.children)
-      const draggedWidget = widgets.find(widget => widget.getAttribute('data-order') === draggedOrder)
+      const draggedWidget = /** @type {HTMLElement}|undefined */(widgets.find(widget => widget.getAttribute('data-order') === draggedOrder))
 
       if (draggedWidget) {
         if (targetOrder !== null) {
-          const targetWidget = widgets.find(widget => widget.getAttribute('data-order') === targetOrder)
+          const targetWidget = /** @type {HTMLElement}|undefined */(widgets.find(widget => widget.getAttribute('data-order') === targetOrder))
           if (targetWidget) {
             // Swap orders
             draggedWidget.setAttribute('data-order', targetOrder)
             targetWidget.setAttribute('data-order', draggedOrder)
 
             // Update CSS order
-            draggedWidget.style.order = targetOrder
-            targetWidget.style.order = draggedOrder
+            draggedWidget.style.order = String(targetOrder)
+            targetWidget.style.order = String(draggedOrder)
           }
         } else {
           // Handle drop in open space

--- a/src/component/widget/events/fullscreenToggle.js
+++ b/src/component/widget/events/fullscreenToggle.js
@@ -40,7 +40,7 @@ function handleEscapeKey (event) {
   if (event.key === 'Escape') {
     const fullScreenWidget = document.querySelector('.widget-wrapper.fullscreen')
     if (fullScreenWidget) {
-      toggleFullScreen(fullScreenWidget)
+      toggleFullScreen(/** @type {HTMLElement} */(fullScreenWidget))
     }
   }
 }

--- a/src/component/widget/events/fullscreenToggle.js
+++ b/src/component/widget/events/fullscreenToggle.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utility to toggle a widget into a full-screen display mode.
  *

--- a/src/component/widget/events/fullscreenToggle.js
+++ b/src/component/widget/events/fullscreenToggle.js
@@ -40,7 +40,7 @@ function handleEscapeKey (event) {
   if (event.key === 'Escape') {
     const fullScreenWidget = document.querySelector('.widget-wrapper.fullscreen')
     if (fullScreenWidget) {
-      toggleFullScreen(/** @type {HTMLElement} */(fullScreenWidget))
+      toggleFullScreen(fullScreenWidget)
     }
   }
 }

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -33,7 +33,7 @@ export function initializeResizeHandles () {
 
     resizeHandle.addEventListener('mousedown', (event) => {
       event.preventDefault()
-      handleResizeStart(event, widget)
+      handleResizeStart(event, /** @type {HTMLElement} */(widget))
     })
   })
 }
@@ -42,11 +42,11 @@ function createResizeOverlay () {
   const overlay = document.createElement('div')
   overlay.className = 'resize-overlay'
   overlay.style.position = 'fixed'
-  overlay.style.top = 0
-  overlay.style.left = 0
+  overlay.style.top = '0'
+  overlay.style.left = '0'
   overlay.style.width = '100%'
   overlay.style.height = '100%'
-  overlay.style.zIndex = 1000 // Ensure it is above all other elements
+  overlay.style.zIndex = '1000' // Ensure it is above all other elements
   document.body.appendChild(overlay)
   return overlay
 }
@@ -90,8 +90,8 @@ async function handleResizeStart (event, widget) {
 
       widget.style.gridColumn = `span ${snappedWidth}`
       widget.style.gridRow = `span ${snappedHeight}`
-      widget.dataset.columns = snappedWidth
-      widget.dataset.rows = snappedHeight
+      widget.dataset.columns = String(snappedWidth)
+      widget.dataset.rows = String(snappedHeight)
 
       logger.info(`Widget resized to columns: ${snappedWidth}, rows: ${snappedHeight}`)
     } catch (error) {

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Provides interactive resizing of widgets via mouse drag handles.
  *

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -33,7 +33,7 @@ export function initializeResizeHandles () {
 
     resizeHandle.addEventListener('mousedown', (event) => {
       event.preventDefault()
-      handleResizeStart(event, /** @type {HTMLElement} */(widget))
+      handleResizeStart(event, widget)
     })
   })
 }
@@ -42,11 +42,11 @@ function createResizeOverlay () {
   const overlay = document.createElement('div')
   overlay.className = 'resize-overlay'
   overlay.style.position = 'fixed'
-  overlay.style.top = '0'
-  overlay.style.left = '0'
+  overlay.style.top = 0
+  overlay.style.left = 0
   overlay.style.width = '100%'
   overlay.style.height = '100%'
-  overlay.style.zIndex = '1000' // Ensure it is above all other elements
+  overlay.style.zIndex = 1000 // Ensure it is above all other elements
   document.body.appendChild(overlay)
   return overlay
 }
@@ -90,8 +90,8 @@ async function handleResizeStart (event, widget) {
 
       widget.style.gridColumn = `span ${snappedWidth}`
       widget.style.gridRow = `span ${snappedHeight}`
-      widget.dataset.columns = String(snappedWidth)
-      widget.dataset.rows = String(snappedHeight)
+      widget.dataset.columns = snappedWidth
+      widget.dataset.rows = snappedHeight
 
       logger.info(`Widget resized to columns: ${snappedWidth}, rows: ${snappedHeight}`)
     } catch (error) {

--- a/src/component/widget/menu/resizeMenu.js
+++ b/src/component/widget/menu/resizeMenu.js
@@ -34,7 +34,7 @@ async function resizeHorizontally (widget, increase = true) {
       widget.classList.remove('below-min', 'exceeding-max')
     }
 
-    widget.dataset.columns = String(newSpan)
+    widget.dataset.columns = newSpan
     widget.style.gridColumn = `span ${newSpan}`
     logger.log(`Widget resized horizontally to span ${newSpan} columns`)
     saveWidgetState()
@@ -75,7 +75,7 @@ async function resizeVertically (widget, increase = true) {
       widget.classList.remove('below-min', 'exceeding-max')
     }
 
-    widget.dataset.rows = String(newSpan)
+    widget.dataset.rows = newSpan
     widget.style.gridRow = `span ${newSpan}`
     logger.log(`Widget resized vertically to span ${newSpan} rows`)
     saveWidgetState()
@@ -264,8 +264,8 @@ async function adjustWidgetSize (widgetWrapper, columns, rows) {
     columns = Math.min(Math.max(columns, minColumns), maxColumns)
     rows = Math.min(Math.max(rows, minRows), maxRows)
 
-    widgetWrapper.dataset.columns = String(columns)
-    widgetWrapper.dataset.rows = String(rows)
+    widgetWrapper.dataset.columns = columns
+    widgetWrapper.dataset.rows = rows
     widgetWrapper.style.gridColumn = `span ${columns}`
     widgetWrapper.style.gridRow = `span ${rows}`
     logger.log(`Widget resized to ${columns} columns and ${rows} rows`)

--- a/src/component/widget/menu/resizeMenu.js
+++ b/src/component/widget/menu/resizeMenu.js
@@ -1,3 +1,4 @@
+// @ts-check
 import emojiList from '../../../ui/unicodeEmoji.js'
 import { saveWidgetState } from '../../../storage/localStorage.js'
 import { fetchServices } from '../utils/fetchServices.js'

--- a/src/component/widget/menu/resizeMenu.js
+++ b/src/component/widget/menu/resizeMenu.js
@@ -34,7 +34,7 @@ async function resizeHorizontally (widget, increase = true) {
       widget.classList.remove('below-min', 'exceeding-max')
     }
 
-    widget.dataset.columns = newSpan
+    widget.dataset.columns = String(newSpan)
     widget.style.gridColumn = `span ${newSpan}`
     logger.log(`Widget resized horizontally to span ${newSpan} columns`)
     saveWidgetState()
@@ -75,7 +75,7 @@ async function resizeVertically (widget, increase = true) {
       widget.classList.remove('below-min', 'exceeding-max')
     }
 
-    widget.dataset.rows = newSpan
+    widget.dataset.rows = String(newSpan)
     widget.style.gridRow = `span ${newSpan}`
     logger.log(`Widget resized vertically to span ${newSpan} rows`)
     saveWidgetState()
@@ -264,8 +264,8 @@ async function adjustWidgetSize (widgetWrapper, columns, rows) {
     columns = Math.min(Math.max(columns, minColumns), maxColumns)
     rows = Math.min(Math.max(rows, minRows), maxRows)
 
-    widgetWrapper.dataset.columns = columns
-    widgetWrapper.dataset.rows = rows
+    widgetWrapper.dataset.columns = String(columns)
+    widgetWrapper.dataset.rows = String(rows)
     widgetWrapper.style.gridColumn = `span ${columns}`
     widgetWrapper.style.gridRow = `span ${rows}`
     logger.log(`Widget resized to ${columns} columns and ${rows} rows`)

--- a/src/component/widget/utils/fetchData.js
+++ b/src/component/widget/utils/fetchData.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utility for fetching data and posting to widgets.
  *

--- a/src/component/widget/utils/fetchServices.js
+++ b/src/component/widget/utils/fetchServices.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utilities for retrieving the list of available services.
  *

--- a/src/component/widget/utils/widgetUtils.js
+++ b/src/component/widget/utils/widgetUtils.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Helper functions used by widgets.
  *

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* global HTMLElement */
 /**
  * Widget creation and management functions.
  *
@@ -57,8 +58,8 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
 
   widgetWrapper.style.gridColumn = `span ${gridColumnSpan}`
   widgetWrapper.style.gridRow = `span ${gridRowSpan}`
-  widgetWrapper.dataset.columns = gridColumnSpan
-  widgetWrapper.dataset.rows = gridRowSpan
+  widgetWrapper.dataset.columns = String(gridColumnSpan)
+  widgetWrapper.dataset.rows = String(gridRowSpan)
 
   const iframe = document.createElement('iframe')
   iframe.src = url
@@ -121,7 +122,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   resizeMenuIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu icon')
     const related = event.relatedTarget
-    if (!related || !related.closest('.resize-menu')) {
+    if (!(related instanceof HTMLElement) || !related.closest('.resize-menu')) {
       debouncedHideResizeMenu(resizeMenuIcon)
     }
   })
@@ -136,7 +137,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   resizeMenuBlockIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu block icon')
     const related = event.relatedTarget
-    if (!related || !related.closest('.resize-menu-block')) {
+    if (!(related instanceof HTMLElement) || !related.closest('.resize-menu-block')) {
       debouncedHideResizeMenuBlock(widgetWrapper)
     }
   })
@@ -219,7 +220,7 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   logger.log('Extracted service:', service)
 
   const widgetWrapper = await createWidget(service, url, columns, rows, dataid)
-  widgetWrapper.setAttribute('data-order', widgetContainer.children.length)
+  widgetWrapper.setAttribute('data-order', String(widgetContainer.children.length))
   widgetContainer.appendChild(widgetWrapper)
 
   logger.log('Widget appended to container:', widgetWrapper)
@@ -292,10 +293,11 @@ function updateWidgetOrders () {
   const widgets = Array.from(widgetContainer.children)
 
   widgets.forEach((widget, index) => {
-    widget.setAttribute('data-order', index)
-    widget.style.order = index
+    const element = /** @type {HTMLElement} */(widget)
+    element.setAttribute('data-order', String(index))
+    element.style.order = String(index)
     logger.log('Updated widget order:', {
-      dataid: widget.dataset.dataid,
+      dataid: element.dataset.dataid,
       order: index
     })
   })

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Widget creation and management functions.
  *

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* global HTMLElement */
 /**
  * Widget creation and management functions.
  *
@@ -58,8 +57,8 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
 
   widgetWrapper.style.gridColumn = `span ${gridColumnSpan}`
   widgetWrapper.style.gridRow = `span ${gridRowSpan}`
-  widgetWrapper.dataset.columns = String(gridColumnSpan)
-  widgetWrapper.dataset.rows = String(gridRowSpan)
+  widgetWrapper.dataset.columns = gridColumnSpan
+  widgetWrapper.dataset.rows = gridRowSpan
 
   const iframe = document.createElement('iframe')
   iframe.src = url
@@ -122,7 +121,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   resizeMenuIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu icon')
     const related = event.relatedTarget
-    if (!(related instanceof HTMLElement) || !related.closest('.resize-menu')) {
+    if (!related || !related.closest('.resize-menu')) {
       debouncedHideResizeMenu(resizeMenuIcon)
     }
   })
@@ -137,7 +136,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   resizeMenuBlockIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu block icon')
     const related = event.relatedTarget
-    if (!(related instanceof HTMLElement) || !related.closest('.resize-menu-block')) {
+    if (!related || !related.closest('.resize-menu-block')) {
       debouncedHideResizeMenuBlock(widgetWrapper)
     }
   })
@@ -220,7 +219,7 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   logger.log('Extracted service:', service)
 
   const widgetWrapper = await createWidget(service, url, columns, rows, dataid)
-  widgetWrapper.setAttribute('data-order', String(widgetContainer.children.length))
+  widgetWrapper.setAttribute('data-order', widgetContainer.children.length)
   widgetContainer.appendChild(widgetWrapper)
 
   logger.log('Widget appended to container:', widgetWrapper)
@@ -293,11 +292,10 @@ function updateWidgetOrders () {
   const widgets = Array.from(widgetContainer.children)
 
   widgets.forEach((widget, index) => {
-    const element = /** @type {HTMLElement} */(widget)
-    element.setAttribute('data-order', String(index))
-    element.style.order = String(index)
+    widget.setAttribute('data-order', index)
+    widget.style.order = index
     logger.log('Updated widget order:', {
-      dataid: element.dataset.dataid,
+      dataid: widget.dataset.dataid,
       order: index
     })
   })

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,16 @@
+import './types.js';
+
+declare global {
+  interface Window {
+    asd: {
+      services: import('./types.js').Service[];
+      config: import('./types.js').DashboardConfig;
+      boards: import('./types.js').Board[];
+      currentBoardId: string | null;
+      currentViewId: string | null;
+    };
+    _appLogs?: import('./types.js').LoggerEntry[];
+  }
+}
+
+export {};

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Entry point for the dashboard application.
  *

--- a/src/main.js
+++ b/src/main.js
@@ -23,11 +23,7 @@ const logger = new Logger('main.js')
 
 window.asd = {
   services: [],
-  config: /** @type {import('./types.js').DashboardConfig} */ ({
-    globalSettings: {},
-    boards: [],
-    styling: { widget: { minColumns: 1, maxColumns: 1, minRows: 1, maxRows: 1 } }
-  }),
+  config: {},
   boards: [],
   currentBoardId: null,
   currentViewId: null

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,11 @@ const logger = new Logger('main.js')
 
 window.asd = {
   services: [],
-  config: {},
+  config: /** @type {import('./types.js').DashboardConfig} */ ({
+    globalSettings: {},
+    boards: [],
+    styling: { widget: { minColumns: 1, maxColumns: 1, minRows: 1, maxRows: 1 } }
+  }),
   boards: [],
   currentBoardId: null,
   currentViewId: null

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-env serviceworker */
 /**
  * Basic service worker used to cache fetched resources.

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -5,6 +5,12 @@
  *
  * @module serviceWorker
  */
+/**
+ * @typedef {Event & {waitUntil: (p: Promise<any>) => void}} SWExtendableEvent
+ */
+/**
+ * @typedef {SWExtendableEvent & {request: Request, respondWith: (r: Promise<Response>|Response) => void}} SWFetchEvent
+ */
 const CACHE_NAME = 'my-cache-v3' // Make sure this matches the cache name in the main.js file
 // self.addEventListener('fetch', (event) => {
 //   const testUrls = [
@@ -23,7 +29,7 @@ const CACHE_NAME = 'my-cache-v3' // Make sure this matches the cache name in the
 //   }
 // });
 
-self.addEventListener('install', function (event) {
+self.addEventListener('install', function (/** @type {SWExtendableEvent} */ event) {
   console.log('[Service Worker] Installed')
   event.waitUntil(
     caches.open(CACHE_NAME).then(function (cache) {
@@ -36,7 +42,7 @@ self.addEventListener('install', function (event) {
   )
 })
 
-self.addEventListener('fetch', function (event) {
+self.addEventListener('fetch', function (/** @type {SWFetchEvent} */ event) {
   console.log('[Service Worker] Fetching: ', event.request.url)
   event.respondWith(
     caches.match(event.request).then(function (response) {
@@ -57,7 +63,7 @@ self.addEventListener('fetch', function (event) {
   )
 })
 
-self.addEventListener('activate', function (event) {
+self.addEventListener('activate', function (/** @type {SWExtendableEvent} */ event) {
   console.log('[Service Worker] Activating and cleaning up old caches')
   const cacheWhitelist = [CACHE_NAME] // Only keep the current cache
   event.waitUntil(

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -5,12 +5,6 @@
  *
  * @module serviceWorker
  */
-/**
- * @typedef {Event & {waitUntil: (p: Promise<any>) => void}} SWExtendableEvent
- */
-/**
- * @typedef {SWExtendableEvent & {request: Request, respondWith: (r: Promise<Response>|Response) => void}} SWFetchEvent
- */
 const CACHE_NAME = 'my-cache-v3' // Make sure this matches the cache name in the main.js file
 // self.addEventListener('fetch', (event) => {
 //   const testUrls = [
@@ -29,7 +23,7 @@ const CACHE_NAME = 'my-cache-v3' // Make sure this matches the cache name in the
 //   }
 // });
 
-self.addEventListener('install', function (/** @type {SWExtendableEvent} */ event) {
+self.addEventListener('install', function (event) {
   console.log('[Service Worker] Installed')
   event.waitUntil(
     caches.open(CACHE_NAME).then(function (cache) {
@@ -42,7 +36,7 @@ self.addEventListener('install', function (/** @type {SWExtendableEvent} */ even
   )
 })
 
-self.addEventListener('fetch', function (/** @type {SWFetchEvent} */ event) {
+self.addEventListener('fetch', function (event) {
   console.log('[Service Worker] Fetching: ', event.request.url)
   event.respondWith(
     caches.match(event.request).then(function (response) {
@@ -63,7 +57,7 @@ self.addEventListener('fetch', function (/** @type {SWFetchEvent} */ event) {
   )
 })
 
-self.addEventListener('activate', function (/** @type {SWExtendableEvent} */ event) {
+self.addEventListener('activate', function (event) {
   console.log('[Service Worker] Activating and cleaning up old caches')
   const cacheWhitelist = [CACHE_NAME] // Only keep the current cache
   event.waitUntil(

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -59,8 +59,8 @@ function serializeWidgetState (widget) {
  * and view identifiers in localStorage. Each widget is saved with its order,
  * dimensions, URL and any metadata/settings.
  *
- * @param {?string} [boardId] - Board identifier. Defaults to the current board element id.
- * @param {?string} [viewId] - View identifier. Defaults to the current view element id.
+ * @param {string} boardId - Board identifier. Defaults to the current board element id.
+ * @param {string} viewId - View identifier. Defaults to the current view element id.
  * @function saveWidgetState
  * @returns {Promise<void>}
  */
@@ -79,7 +79,7 @@ async function saveWidgetState (boardId, viewId) {
     }
     const widgetContainer = document.getElementById('widget-container')
     const widgets = Array.from(widgetContainer.children)
-    const widgetState = widgets.map(widget => serializeWidgetState(/** @type {HTMLElement} */(widget)))
+    const widgetState = widgets.map(widget => serializeWidgetState(widget))
     const boards = await loadBoardState()
     logger.info(`Loaded board state from localStorage: ${boards}`)
     const board = boards.find(b => b.id === boardId)
@@ -130,7 +130,7 @@ async function loadWidgetState (boardId, viewId) {
         logger.info('Found widget state in view:', view.widgetState)
         const savedState = view.widgetState
         const widgetContainer = document.getElementById('widget-container')
-        const existingWidgetIds = Array.from(widgetContainer.children).map(w => /** @type {HTMLElement} */(w).dataset.dataid)
+        const existingWidgetIds = Array.from(widgetContainer.children).map(w => w.dataset.dataid)
 
         for (const widgetData of savedState) {
           if (!existingWidgetIds.includes(widgetData.dataid)) {
@@ -139,12 +139,12 @@ async function loadWidgetState (boardId, viewId) {
             const widgetWrapper = await createWidget(
               service,
               widgetData.url,
-              Number(widgetData.columns),
-              Number(widgetData.rows),
+              widgetData.columns,
+              widgetData.rows,
               widgetData.dataid // Ensure dataid is passed to maintain widget identity
             )
-            widgetWrapper.dataset.order = String(widgetData.order)
-            widgetWrapper.style.order = String(widgetData.order)
+            widgetWrapper.dataset.order = widgetData.order
+            widgetWrapper.style.order = widgetData.order
             widgetWrapper.dataset.type = widgetData.type
             widgetWrapper.dataset.metadata = JSON.stringify(widgetData.metadata)
             widgetWrapper.dataset.settings = JSON.stringify(widgetData.settings)

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -59,8 +59,8 @@ function serializeWidgetState (widget) {
  * and view identifiers in localStorage. Each widget is saved with its order,
  * dimensions, URL and any metadata/settings.
  *
- * @param {string} boardId - Board identifier. Defaults to the current board element id.
- * @param {string} viewId - View identifier. Defaults to the current view element id.
+ * @param {?string} [boardId] - Board identifier. Defaults to the current board element id.
+ * @param {?string} [viewId] - View identifier. Defaults to the current view element id.
  * @function saveWidgetState
  * @returns {Promise<void>}
  */
@@ -79,7 +79,7 @@ async function saveWidgetState (boardId, viewId) {
     }
     const widgetContainer = document.getElementById('widget-container')
     const widgets = Array.from(widgetContainer.children)
-    const widgetState = widgets.map(widget => serializeWidgetState(widget))
+    const widgetState = widgets.map(widget => serializeWidgetState(/** @type {HTMLElement} */(widget)))
     const boards = await loadBoardState()
     logger.info(`Loaded board state from localStorage: ${boards}`)
     const board = boards.find(b => b.id === boardId)
@@ -130,7 +130,7 @@ async function loadWidgetState (boardId, viewId) {
         logger.info('Found widget state in view:', view.widgetState)
         const savedState = view.widgetState
         const widgetContainer = document.getElementById('widget-container')
-        const existingWidgetIds = Array.from(widgetContainer.children).map(w => w.dataset.dataid)
+        const existingWidgetIds = Array.from(widgetContainer.children).map(w => /** @type {HTMLElement} */(w).dataset.dataid)
 
         for (const widgetData of savedState) {
           if (!existingWidgetIds.includes(widgetData.dataid)) {
@@ -139,12 +139,12 @@ async function loadWidgetState (boardId, viewId) {
             const widgetWrapper = await createWidget(
               service,
               widgetData.url,
-              widgetData.columns,
-              widgetData.rows,
+              Number(widgetData.columns),
+              Number(widgetData.rows),
               widgetData.dataid // Ensure dataid is passed to maintain widget identity
             )
-            widgetWrapper.dataset.order = widgetData.order
-            widgetWrapper.style.order = widgetData.order
+            widgetWrapper.dataset.order = String(widgetData.order)
+            widgetWrapper.style.order = String(widgetData.order)
             widgetWrapper.dataset.type = widgetData.type
             widgetWrapper.dataset.metadata = JSON.stringify(widgetData.metadata)
             widgetWrapper.dataset.settings = JSON.stringify(widgetData.settings)

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utilities for persisting board and widget state in `localStorage`.
  *
@@ -8,8 +9,16 @@ import { getServiceFromUrl } from '../component/widget/utils/widgetUtils.js'
 import { initializeResizeHandles } from '../component/widget/events/resizeHandler.js'
 import { Logger } from '../utils/Logger.js'
 
+/** @typedef {import('../types.js').Widget} Widget */
+/** @typedef {import('../types.js').Board} Board */
+
 const logger = new Logger('localStorage.js')
 
+/**
+ * Convert a widget DOM element to a serializable state object.
+ * @param {HTMLElement} widget
+ * @returns {Widget}
+ */
 function serializeWidgetState (widget) {
   let metadata = {}
   if (widget.dataset.metadata) {
@@ -189,7 +198,7 @@ function setBoardAndViewIds (boardId, viewId) {
  * Persist the entire boards array to localStorage under the key `boards`.
  *
  * @function saveBoardState
- * @param {Array} boards - Array of board objects to store.
+ * @param {Array<Board>} boards - Array of board objects to store.
  * @returns {Promise<void>}
  */
 export async function saveBoardState (boards) {
@@ -206,7 +215,7 @@ export async function saveBoardState (boards) {
  * The result is also assigned to {@code window.asd.boards} for global access.
  *
  * @function loadBoardState
- * @returns {Promise<Array>} Parsed array of boards or an empty array on failure.
+ * @returns {Promise<Array<Board>>} Parsed array of boards or an empty array on failure.
  */
 export async function loadBoardState () {
   try {

--- a/src/storage/servicesStore.js
+++ b/src/storage/servicesStore.js
@@ -1,3 +1,4 @@
+// @ts-check
 const STORAGE_KEY = 'services'
 
 export function load () {

--- a/src/types.js
+++ b/src/types.js
@@ -53,6 +53,8 @@
  * @typedef {Object} DashboardConfig
  * @property {object} globalSettings
  * @property {Array<Board>} boards
+ * @property {object} [styling]
+ * @property {{minColumns:number,maxColumns:number,minRows:number,maxRows:number}} [styling.widget]
  */
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -64,3 +64,5 @@
  * @property {string} message
  * @property {string} time
  */
+
+export {}

--- a/src/types.js
+++ b/src/types.js
@@ -53,8 +53,6 @@
  * @typedef {Object} DashboardConfig
  * @property {object} globalSettings
  * @property {Array<Board>} boards
- * @property {object} [styling]
- * @property {{minColumns:number,maxColumns:number,minRows:number,maxRows:number}} [styling.widget]
  */
 
 /**

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+/**
+ * Widget persisted in a board view.
+ * @typedef {Object} Widget
+ * @property {string} [dataid]
+ * @property {string} url
+ * @property {number|string} columns
+ * @property {number|string} rows
+ * @property {string} [type]
+ * @property {string} [order]
+ * @property {Record<string, any>} [metadata]
+ * @property {Record<string, any>} [settings]
+ */
+
+/**
+ * Collection of widgets for a board view.
+ * @typedef {Object} View
+ * @property {string} id
+ * @property {string} name
+ * @property {Array<Widget>} widgetState
+ */
+
+/**
+ * Board containing views of widgets.
+ * @typedef {Object} Board
+ * @property {string} id
+ * @property {string} name
+ * @property {number} [order]
+ * @property {Array<View>} views
+ */
+
+/**
+ * Optional configuration for a service.
+ * @typedef {Object} ServiceConfig
+ * @property {number} [minColumns]
+ * @property {number} [maxColumns]
+ * @property {number} [minRows]
+ * @property {number} [maxRows]
+ */
+
+/**
+ * External service definition.
+ * @typedef {Object} Service
+ * @property {string} name
+ * @property {string} url
+ * @property {string} [type]
+ * @property {ServiceConfig} [config]
+ */
+
+/**
+ * Dashboard configuration loaded from storage or URL.
+ * @typedef {Object} DashboardConfig
+ * @property {object} globalSettings
+ * @property {Array<Board>} boards
+ */
+
+/**
+ * Structured entry written by {@link Logger} during tests.
+ * @typedef {Object} LoggerEntry
+ * @property {string} file
+ * @property {string} fn
+ * @property {string} level
+ * @property {string} message
+ * @property {string} time
+ */

--- a/src/ui/unicodeEmoji.js
+++ b/src/ui/unicodeEmoji.js
@@ -1,3 +1,4 @@
+// @ts-check
 const emojiList = {
   puzzle: { icon: '🧩', unicode: '\u{1F9E9}', description: 'Widget to grid' },
   satellite: { icon: '📡', unicode: '\u{1F4E1}', description: 'Serviceworker' },

--- a/src/utils/Logger.js
+++ b/src/utils/Logger.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Simple browser console logger with runtime enable/disable support.
  * During Playwright test runs (via `navigator.webdriver`), structured logs are

--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * DOM element helpers.
  *

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Fetch a list of services from various sources and store them globally.
  *
@@ -5,6 +6,8 @@
  */
 import { Logger } from './Logger.js'
 import { showNotification } from '../component/dialog/notification.js'
+
+/** @typedef {import('../types.js').Service} Service */
 
 const logger = new Logger('fetchServices.js')
 const STORAGE_KEY = 'services'
@@ -35,7 +38,7 @@ async function fetchJson (url) {
  * Fetch the service list and update the service selector on the page.
  *
  * @function fetchServices
- * @returns {Promise<Array>} Array of service objects.
+ * @returns {Promise<Array<Service>>} Array of service objects.
  */
 export const fetchServices = async () => {
   const params = new URLSearchParams(window.location.search)

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Load configuration from query parameters, localStorage or defaults.
  *

--- a/src/utils/getCurrentUrl.js
+++ b/src/utils/getCurrentUrl.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * URL helper utilities.
  *

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Miscellaneous utility helpers.
  *

--- a/symbols.json
+++ b/symbols.json
@@ -7,12 +7,12 @@
     "params": [
       {
         "name": "boardId",
-        "type": "string",
+        "type": "?string",
         "desc": "- Board identifier. Defaults to the current board element id."
       },
       {
         "name": "viewId",
-        "type": "string",
+        "type": "?string",
         "desc": "- View identifier. Defaults to the current view element id."
       }
     ],

--- a/symbols.json
+++ b/symbols.json
@@ -7,12 +7,12 @@
     "params": [
       {
         "name": "boardId",
-        "type": "?string",
+        "type": "string",
         "desc": "- Board identifier. Defaults to the current board element id."
       },
       {
         "name": "viewId",
-        "type": "?string",
+        "type": "string",
         "desc": "- View identifier. Defaults to the current view element id."
       }
     ],

--- a/symbols.json
+++ b/symbols.json
@@ -1,5 +1,73 @@
 [
   {
+    "name": "saveWidgetState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Serialize widgets in the current view and store them under the given board and view identifiers in localStorage. Each widget is saved with its order, dimensions, URL and any metadata/settings.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Board identifier. Defaults to the current board element id."
+      },
+      {
+        "name": "viewId",
+        "type": "string",
+        "desc": "- View identifier. Defaults to the current view element id."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadWidgetState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Restore widget DOM elements for the specified board and view from localStorage. Widgets are recreated using {@link createWidget} and metadata and settings are re-applied.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Board identifier."
+      },
+      {
+        "name": "viewId",
+        "type": "string",
+        "desc": "- View identifier whose widgets should be loaded."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadInitialConfig",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Store the initial board configuration defined in {@code window.asd.config} into localStorage. This is typically called on first run to seed the persistent board data.",
+    "params": [],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "saveBoardState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Persist the entire boards array to localStorage under the key `boards`.",
+    "params": [
+      {
+        "name": "boards",
+        "type": "Array<Board>",
+        "desc": "- Array of board objects to store."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadBoardState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Retrieve the array of boards from localStorage. The result is also assigned to {@code window.asd.boards} for global access.",
+    "params": [],
+    "returns": "Promise<Array<Board>>"
+  },
+  {
     "name": "Logger",
     "kind": "class",
     "file": "src/utils/Logger.js",
@@ -150,7 +218,7 @@
     "file": "src/utils/fetchServices.js",
     "description": "Fetch the service list and update the service selector on the page.",
     "params": [],
-    "returns": "Promise<Array>"
+    "returns": "Promise<Array<Service>>"
   },
   {
     "name": "getConfig",
@@ -194,74 +262,6 @@
     "description": "Generate a UUID using the browser crypto API when available.",
     "params": [],
     "returns": "string"
-  },
-  {
-    "name": "saveWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Serialize widgets in the current view and store them under the given board and view identifiers in localStorage. Each widget is saved with its order, dimensions, URL and any metadata/settings.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Board identifier. Defaults to the current board element id."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- View identifier. Defaults to the current view element id."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Restore widget DOM elements for the specified board and view from localStorage. Widgets are recreated using {@link createWidget} and metadata and settings are re-applied.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Board identifier."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- View identifier whose widgets should be loaded."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadInitialConfig",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Store the initial board configuration defined in {@code window.asd.config} into localStorage. This is typically called on first run to seed the persistent board data.",
-    "params": [],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "saveBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Persist the entire boards array to localStorage under the key `boards`.",
-    "params": [
-      {
-        "name": "boards",
-        "type": "Array",
-        "desc": "- Array of board objects to store."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Retrieve the array of boards from localStorage. The result is also assigned to {@code window.asd.boards} for global access.",
-    "params": [],
-    "returns": "Promise<Array>"
   },
   {
     "name": "initializeBoardDropdown",
@@ -325,7 +325,7 @@
         "desc": "- Identifier for the default view."
       }
     ],
-    "returns": "object"
+    "returns": "Board"
   },
   {
     "name": "createView",
@@ -349,7 +349,7 @@
         "desc": "- Optional predefined id for the view."
       }
     ],
-    "returns": "object|undefined"
+    "returns": "View|undefined"
   },
   {
     "name": "switchView",

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -83,9 +83,9 @@ test.describe('Dashboard Config - Fallback Config Popup', () => {
   test('valid input in popup initializes dashboard', async ({ page }) => {
     await page.goto('/');
     await page.click('#config-modal .modal__btn--cancel');
-    await page.evaluate(cfg => {
-      return import('/component/modal/configModal.js').then(m => m.openConfigModal(cfg));
-    }, ciConfig);
+    await page.evaluate(() => {
+      return import('/component/modal/configModal.js').then(m => m.openConfigModal());
+    });
     await page.waitForSelector('#config-json');
     await page.fill('#config-json', JSON.stringify(ciConfig));
     await page.click('#config-modal .modal__btn--save');

--- a/tests/shared/testWithLogs.ts
+++ b/tests/shared/testWithLogs.ts
@@ -12,6 +12,7 @@ export {
   firefox,
   webkit,
   request,
+  type Page,
 } from 'playwright/test';
 
 type ConsoleLog = { type: string; text: string };
@@ -47,7 +48,7 @@ export const test = base.extend<{
           net.push({
             url: r.url(),
             status: res.status(),
-            timing: res.timing // <-- FIXED: was res.timing()
+            timing: r.timing()
           });
       });
       await use(net);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "checkJs": true,
     "noEmit": true
   },
-  "include": ["tests"]
+  "include": ["tests", "src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@playwright/test": ["tests/shared/testWithLogs"]
+      "@playwright/test": ["tests/shared/testWithLogs"],
+      "/component/*": ["src/component/*"],
+      "/*": ["src/*"]
     },
     "target": "esnext",
     "module": "esnext",
@@ -12,5 +14,5 @@
     "checkJs": true,
     "noEmit": true
   },
-  "include": ["tests", "src"]
+  "include": ["tests", "src/global.d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "checkJs": true,
     "noEmit": true
   },
-  "include": ["tests", "src/global.d.ts"]
+  "include": ["src", "tests", "src/global.d.ts"]
 }


### PR DESCRIPTION
## Summary
- add canonical typedefs in `src/types.js`
- annotate board and widget management modules
- statically check all JS files with `@ts-check`
- update symbol index
- add global type declarations for window.asd and _appLogs
- expose Page type for tests and fix network log timing
- update dynamic config test to match new modal signature
- extend tsconfig paths and include global types
- export empty module from src/types.js so tsc treats it as a module
- enforce type checking across src and fix discovered issues
- document just check in README for running TypeScript validation
- cast DOM elements in board dropdown, board management, menus, and widgets
- make service worker event types explicit
- allow optional params for saveWidgetState
- extend DashboardConfig typedef
- regenerate symbol index

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `npm run test`
- `node scripts/playwright-indexer.js`
- npm run check
------
https://chatgpt.com/codex/tasks/task_b_6861ac46d3748325b9f46041dd880979