### PR TITLE
Add shared types and enable @ts-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,17 @@ Follow these steps to set up and run the ASD Dashboard:
    npm install
    ```
 
-3. Start the application:
+3. Run static type checks:
+   ```bash
+   just check
+   ```
+
+4. Start the application:
    ```bash
    npm run start
    ```
 
-4. Open your browser and navigate to `http://localhost:8000` to access the dashboard.
+5. Open your browser and navigate to `http://localhost:8000` to access the dashboard.
 
 ## AI-Enhanced Test Infrastructure
 

--- a/justfile
+++ b/justfile
@@ -26,3 +26,7 @@ format:
 # Extract symbol index
 extract-symbols:
     node scripts/extract-symbol-index.mjs
+
+# Run static type checking
+check:
+    npm run check

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "globby": "^13.2.2",
         "husky": "^9.1.6",
         "playwright": "^1.47.2",
-        "standard": "*"
+        "standard": "*",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3466,6 +3467,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:ui": "playwright test --ui",
     "test:grep": "playwright test --grep",
     "test:report": "playwright test --reporter=html",
-    "merge-videos": "NODE_PATH=$(npm root -g) node scripts/mergePlaywrightVideos.js"
+    "merge-videos": "NODE_PATH=$(npm root -g) node scripts/mergePlaywrightVideos.js",
+    "check": "tsc"
   },
   "devDependencies": {
     "@playwright/test": "^1.47.2",
@@ -27,7 +28,8 @@
     "playwright": "^1.47.2",
     "standard": "*",
     "comment-parser": "^1.4.0",
-    "globby": "^13.2.2"
+    "globby": "^13.2.2",
+    "typescript": "^5.8.3"
   },
   "standard": {
     "globals": [

--- a/src/component/board/boardDropdown.js
+++ b/src/component/board/boardDropdown.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * UI handlers for the board actions dropdown.
  *
@@ -106,6 +107,6 @@ function handleDeleteBoard () {
  * @returns {string}
  */
 function getSelectedBoardId () {
-  const boardSelector = document.getElementById('board-selector')
+  const boardSelector = /** @type {HTMLSelectElement} */ (document.getElementById('board-selector'))
   return boardSelector.value
 }

--- a/src/component/dialog/notification.js
+++ b/src/component/dialog/notification.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Simple notification dialog utilities.
  *

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Menu actions for adding widgets and switching boards/views.
  *
@@ -35,8 +36,8 @@ function initializeDashboardMenu () {
   document.addEventListener('services-updated', populateServiceDropdown)
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
-    const serviceSelector = document.getElementById('service-selector')
-    const widgetUrlInput = document.getElementById('widget-url')
+    const serviceSelector = /** @type {HTMLSelectElement} */ (document.getElementById('service-selector'))
+    const widgetUrlInput = /** @type {HTMLInputElement} */ (document.getElementById('widget-url'))
     const boardElement = document.querySelector('.board')
     const viewElement = document.querySelector('.board-view')
     const selectedServiceUrl = serviceSelector.value
@@ -73,16 +74,17 @@ function initializeDashboardMenu () {
   })
 
   document.getElementById('board-selector').addEventListener('change', (event) => {
-    const selectedBoardId = event.target.value
+    const selectedBoardId = /** @type {HTMLSelectElement} */(event.target).value
     const currentBoardId = getCurrentBoardId()
-    saveWidgetState(currentBoardId) // Save the state of the current board before switching
+    const currentViewId = document.querySelector('.board-view').id
+    saveWidgetState(currentBoardId, currentViewId) // Save current board state before switching
     switchBoard(selectedBoardId)
     updateViewSelector(selectedBoardId)
   })
 
   document.getElementById('view-selector').addEventListener('change', (event) => {
     const selectedBoardId = getCurrentBoardId()
-    const selectedViewId = event.target.value
+    const selectedViewId = /** @type {HTMLSelectElement} */(event.target).value
     logger.log(`Switching to selected view ${selectedViewId} in board ${selectedBoardId}`)
     switchView(selectedBoardId, selectedViewId)
   })

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Build and initialize the main dashboard menu UI.
  *
@@ -12,7 +13,7 @@ import emojiList from '../../ui/unicodeEmoji.js'
  * @returns {void}
  */
 function initSW () {
-  const swToggle = document.getElementById('sw-toggle')
+  const swToggle = /** @type {HTMLInputElement} */ (document.getElementById('sw-toggle'))
   const swIcon = document.querySelector('.sw-icon')
   const swCheckbox = document.querySelector('.icon-checkbox')
   const swEnabled = localStorage.getItem('swEnabled') === 'true'
@@ -75,7 +76,7 @@ function initSW () {
 
     swToggle.addEventListener('change', function () {
       const isEnabled = swToggle.checked
-      localStorage.setItem('swEnabled', isEnabled)
+      localStorage.setItem('swEnabled', String(isEnabled))
       updateServiceWorkerUI(isEnabled)
 
       if (isEnabled) {

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal dialog for editing the application configuration.
  *

--- a/src/component/modal/localStorageModal.js
+++ b/src/component/modal/localStorageModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal dialog for viewing and editing `localStorage` entries.
  *
@@ -80,7 +81,7 @@ export function openLocalStorageModal () {
         let invalid = false
         for (const [key] of Object.entries(data)) {
           if (key.includes('swEnabled') || key.includes('config')) continue
-          const val = document.getElementById(`localStorage-${key}`).value
+          const val = /** @type {HTMLInputElement} */ (document.getElementById(`localStorage-${key}`)).value
           try {
             updated[key] = JSON.parse(val)
           } catch {

--- a/src/component/modal/modalFactory.js
+++ b/src/component/modal/modalFactory.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utility for constructing modal dialogs.
  *

--- a/src/component/modal/saveServiceModal.js
+++ b/src/component/modal/saveServiceModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal prompting to save a URL as a named service.
  *

--- a/src/component/modal/serviceLaunchModal.js
+++ b/src/component/modal/serviceLaunchModal.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Modal used to launch a service-specific action in an iframe.
  *

--- a/src/component/utils/dropDownUtils.js
+++ b/src/component/utils/dropDownUtils.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Shared dropdown initialization helper.
  *
@@ -22,7 +23,7 @@ export function initializeDropdown (dropdownElement, handlers) {
   }
 
   dropdownElement.addEventListener('click', (event) => {
-    const action = event.target.dataset.action // Assuming the action is stored in a data attribute
+    const action = /** @type {HTMLElement} */(event.target).dataset.action // Assuming the action is stored in a data attribute
     logger.log('Dropdown action clicked:', action)
 
     if (handlers && typeof handlers[action] === 'function') {

--- a/src/component/view/viewDropdown.js
+++ b/src/component/view/viewDropdown.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Dropdown handlers for view-specific actions.
  *

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Drag and drop handlers for reordering widgets.
  *
@@ -28,7 +29,7 @@ function handleDragStart (e, draggedWidgetWrapper) {
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
     if (widget !== draggedWidgetWrapper) {
-      addDragOverlay(widget)
+      addDragOverlay(/** @type {HTMLElement} */ (widget))
     }
   })
 }
@@ -44,8 +45,8 @@ function handleDragEnd (e) {
   const widgetContainer = document.getElementById('widget-container')
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
-    removeDragOverlay(widget)
-    widget.classList.remove('drag-over')
+    removeDragOverlay(/** @type {HTMLElement} */ (widget));
+    /** @type {HTMLElement} */ (widget).classList.remove('drag-over')
   })
 }
 
@@ -116,7 +117,7 @@ function handleDrop (e, targetWidgetWrapper) {
   logger.log(`Drop event: draggedOrder=${draggedOrder}, targetOrder=${targetOrder}`)
 
   const widgetContainer = document.getElementById('widget-container')
-  const draggedWidget = widgetContainer.querySelector(`[data-order='${draggedOrder}']`)
+  const draggedWidget = /** @type {HTMLElement} */ (widgetContainer.querySelector(`[data-order='${draggedOrder}']`))
 
   if (!draggedWidget) {
     logger.error('Invalid dragged widget element', 3000, 'error')
@@ -124,7 +125,7 @@ function handleDrop (e, targetWidgetWrapper) {
   }
 
   if (targetOrder !== null) {
-    const targetWidget = widgetContainer.querySelector(`[data-order='${targetOrder}']`)
+    const targetWidget = /** @type {HTMLElement} */ (widgetContainer.querySelector(`[data-order='${targetOrder}']`))
     if (!targetWidget) {
       logger.error('Invalid target widget element', 3000, 'error')
       return
@@ -148,7 +149,7 @@ function handleDrop (e, targetWidgetWrapper) {
     }
   } else {
     // Calculate nearest available grid position
-    const gridColumnCount = parseInt(getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length, 10)
+    const gridColumnCount = getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length
     let targetColumn = Math.floor(e.clientX / draggedWidget.offsetWidth)
     let targetRow = Math.floor(e.clientY / draggedWidget.offsetHeight)
 
@@ -157,8 +158,8 @@ function handleDrop (e, targetWidgetWrapper) {
     targetColumn = Math.max(targetColumn, 0)
     targetRow = Math.max(targetRow, 0)
 
-    draggedWidget.style.gridColumnStart = targetColumn + 1
-    draggedWidget.style.gridRowStart = targetRow + 1
+    draggedWidget.style.gridColumnStart = String(targetColumn + 1)
+    draggedWidget.style.gridRowStart = String(targetRow + 1)
 
     logger.log('Widget moved to new grid position:', {
       column: targetColumn + 1,
@@ -234,14 +235,14 @@ function initializeDragAndDrop () {
   const widgetContainer = document.getElementById('widget-container')
   widgetContainer.addEventListener('dragover', (e) => {
     e.preventDefault()
-    const dragOverTarget = e.target.closest('.widget-wrapper')
+    const dragOverTarget = /** @type {HTMLElement|null} */ (/** @type {HTMLElement} */(e.target).closest('.widget-wrapper'))
     if (dragOverTarget) {
       dragOverTarget.classList.add('drag-over', 'highlight-drop-area')
     }
   })
 
   widgetContainer.addEventListener('dragleave', (e) => {
-    const dragLeaveTarget = e.target.closest('.widget-wrapper')
+    const dragLeaveTarget = /** @type {HTMLElement|null} */ (/** @type {HTMLElement} */(e.target).closest('.widget-wrapper'))
     if (dragLeaveTarget) {
       dragLeaveTarget.classList.remove('drag-over', 'highlight-drop-area')
     }
@@ -250,23 +251,24 @@ function initializeDragAndDrop () {
   widgetContainer.addEventListener('drop', (e) => {
     e.preventDefault()
     const draggedOrder = e.dataTransfer.getData('text/plain')
-    const targetWidgetWrapper = e.target.closest('.widget-wrapper')
+    const targetWidgetWrapper = /** @type {HTMLElement|null} */ (/** @type {HTMLElement} */(e.target).closest('.widget-wrapper'))
     const targetOrder = targetWidgetWrapper ? targetWidgetWrapper.getAttribute('data-order') : null
 
     if (draggedOrder !== null) {
       const widgets = Array.from(widgetContainer.children)
-      const draggedWidget = widgets.find(widget => widget.getAttribute('data-order') === draggedOrder)
+      const draggedWidget = /** @type {HTMLElement|undefined} */ (widgets.find(widget => widget.getAttribute('data-order') === draggedOrder))
 
       if (draggedWidget) {
+        const dragEl = /** @type {HTMLElement} */ (draggedWidget)
         if (targetOrder !== null) {
-          const targetWidget = widgets.find(widget => widget.getAttribute('data-order') === targetOrder)
+          const targetWidget = /** @type {HTMLElement|undefined} */ (widgets.find(widget => widget.getAttribute('data-order') === targetOrder))
           if (targetWidget) {
             // Swap orders
-            draggedWidget.setAttribute('data-order', targetOrder)
+            dragEl.setAttribute('data-order', targetOrder)
             targetWidget.setAttribute('data-order', draggedOrder)
 
             // Update CSS order
-            draggedWidget.style.order = targetOrder
+            dragEl.style.order = targetOrder
             targetWidget.style.order = draggedOrder
           }
         } else {
@@ -275,7 +277,7 @@ function initializeDragAndDrop () {
         }
 
         // Save the new state
-        saveWidgetState()
+        saveWidgetState(window.asd.currentBoardId, window.asd.currentViewId)
       }
     }
   })

--- a/src/component/widget/events/fullscreenToggle.js
+++ b/src/component/widget/events/fullscreenToggle.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utility to toggle a widget into a full-screen display mode.
  *
@@ -39,7 +40,7 @@ function handleEscapeKey (event) {
   if (event.key === 'Escape') {
     const fullScreenWidget = document.querySelector('.widget-wrapper.fullscreen')
     if (fullScreenWidget) {
-      toggleFullScreen(fullScreenWidget)
+      toggleFullScreen(/** @type {HTMLElement} */ (fullScreenWidget))
     }
   }
 }

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Provides interactive resizing of widgets via mouse drag handles.
  *
@@ -32,7 +33,7 @@ export function initializeResizeHandles () {
 
     resizeHandle.addEventListener('mousedown', (event) => {
       event.preventDefault()
-      handleResizeStart(event, widget)
+      handleResizeStart(event, /** @type {HTMLElement} */ (widget))
     })
   })
 }
@@ -41,11 +42,11 @@ function createResizeOverlay () {
   const overlay = document.createElement('div')
   overlay.className = 'resize-overlay'
   overlay.style.position = 'fixed'
-  overlay.style.top = 0
-  overlay.style.left = 0
+  overlay.style.top = '0'
+  overlay.style.left = '0'
   overlay.style.width = '100%'
   overlay.style.height = '100%'
-  overlay.style.zIndex = 1000 // Ensure it is above all other elements
+  overlay.style.zIndex = '1000' // Ensure it is above all other elements
   document.body.appendChild(overlay)
   return overlay
 }
@@ -89,8 +90,8 @@ async function handleResizeStart (event, widget) {
 
       widget.style.gridColumn = `span ${snappedWidth}`
       widget.style.gridRow = `span ${snappedHeight}`
-      widget.dataset.columns = snappedWidth
-      widget.dataset.rows = snappedHeight
+      widget.dataset.columns = String(snappedWidth)
+      widget.dataset.rows = String(snappedHeight)
 
       logger.info(`Widget resized to columns: ${snappedWidth}, rows: ${snappedHeight}`)
     } catch (error) {

--- a/src/component/widget/menu/resizeMenu.js
+++ b/src/component/widget/menu/resizeMenu.js
@@ -1,3 +1,4 @@
+// @ts-check
 import emojiList from '../../../ui/unicodeEmoji.js'
 import { saveWidgetState } from '../../../storage/localStorage.js'
 import { fetchServices } from '../utils/fetchServices.js'
@@ -36,7 +37,7 @@ async function resizeHorizontally (widget, increase = true) {
     widget.dataset.columns = newSpan
     widget.style.gridColumn = `span ${newSpan}`
     logger.log(`Widget resized horizontally to span ${newSpan} columns`)
-    saveWidgetState()
+    saveWidgetState(window.asd.currentBoardId, window.asd.currentViewId)
 
     // Log dimensions and overflow state of widget container
     const widgetContainer = document.getElementById('widget-container')
@@ -77,7 +78,7 @@ async function resizeVertically (widget, increase = true) {
     widget.dataset.rows = newSpan
     widget.style.gridRow = `span ${newSpan}`
     logger.log(`Widget resized vertically to span ${newSpan} rows`)
-    saveWidgetState()
+    saveWidgetState(window.asd.currentBoardId, window.asd.currentViewId)
 
     // Log dimensions and overflow state of widget container
     const widgetContainer = document.getElementById('widget-container')
@@ -210,7 +211,7 @@ async function showResizeMenuBlock (icon, widgetWrapper) {
       button.addEventListener('click', async () => {
         await adjustWidgetSize(widgetWrapper, option.cols, option.rows)
         menu.remove()
-        await saveWidgetState()
+        await saveWidgetState(window.asd.currentBoardId, window.asd.currentViewId)
       })
       menu.appendChild(button)
     })

--- a/src/component/widget/utils/fetchData.js
+++ b/src/component/widget/utils/fetchData.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utility for fetching data and posting to widgets.
  *

--- a/src/component/widget/utils/fetchServices.js
+++ b/src/component/widget/utils/fetchServices.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Utilities for retrieving the list of available services.
  *

--- a/src/component/widget/utils/widgetUtils.js
+++ b/src/component/widget/utils/widgetUtils.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Helper functions used by widgets.
  *

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Widget creation and management functions.
  *
@@ -56,8 +57,8 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
 
   widgetWrapper.style.gridColumn = `span ${gridColumnSpan}`
   widgetWrapper.style.gridRow = `span ${gridRowSpan}`
-  widgetWrapper.dataset.columns = gridColumnSpan
-  widgetWrapper.dataset.rows = gridRowSpan
+  widgetWrapper.dataset.columns = String(gridColumnSpan)
+  widgetWrapper.dataset.rows = String(gridRowSpan)
 
   const iframe = document.createElement('iframe')
   iframe.src = url
@@ -119,7 +120,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
 
   resizeMenuIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu icon')
-    const related = event.relatedTarget
+    const related = /** @type {HTMLElement|null} */ (event.relatedTarget)
     if (!related || !related.closest('.resize-menu')) {
       debouncedHideResizeMenu(resizeMenuIcon)
     }
@@ -134,7 +135,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
 
   resizeMenuBlockIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu block icon')
-    const related = event.relatedTarget
+    const related = /** @type {HTMLElement|null} */ (event.relatedTarget)
     if (!related || !related.closest('.resize-menu-block')) {
       debouncedHideResizeMenuBlock(widgetWrapper)
     }
@@ -218,7 +219,7 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   logger.log('Extracted service:', service)
 
   const widgetWrapper = await createWidget(service, url, columns, rows, dataid)
-  widgetWrapper.setAttribute('data-order', widgetContainer.children.length)
+  widgetWrapper.setAttribute('data-order', String(widgetContainer.children.length))
   widgetContainer.appendChild(widgetWrapper)
 
   logger.log('Widget appended to container:', widgetWrapper)
@@ -291,10 +292,11 @@ function updateWidgetOrders () {
   const widgets = Array.from(widgetContainer.children)
 
   widgets.forEach((widget, index) => {
-    widget.setAttribute('data-order', index)
-    widget.style.order = index
+    const el = /** @type {HTMLElement} */ (widget)
+    el.setAttribute('data-order', String(index))
+    el.style.order = String(index)
     logger.log('Updated widget order:', {
-      dataid: widget.dataset.dataid,
+      dataid: el.dataset.dataid,
       order: index
     })
   })

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,16 @@
+import './types.js';
+
+declare global {
+  interface Window {
+    asd: {
+      services: import('./types.js').Service[];
+      config: import('./types.js').DashboardConfig;
+      boards: import('./types.js').Board[];
+      currentBoardId: string | null;
+      currentViewId: string | null;
+    };
+    _appLogs?: import('./types.js').LoggerEntry[];
+  }
+}
+
+export {};

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Entry point for the dashboard application.
  *
@@ -22,7 +23,11 @@ const logger = new Logger('main.js')
 
 window.asd = {
   services: [],
-  config: {},
+  config: {
+    globalSettings: {},
+    styling: { widget: { minColumns: 1, maxColumns: 6, minRows: 1, maxRows: 6 } },
+    boards: []
+  },
   boards: [],
   currentBoardId: null,
   currentViewId: null

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-env serviceworker */
 /**
  * Basic service worker used to cache fetched resources.
@@ -22,7 +23,7 @@ const CACHE_NAME = 'my-cache-v3' // Make sure this matches the cache name in the
 //   }
 // });
 
-self.addEventListener('install', function (event) {
+self.addEventListener('install', /** @param {any} event */ function (event) {
   console.log('[Service Worker] Installed')
   event.waitUntil(
     caches.open(CACHE_NAME).then(function (cache) {
@@ -35,7 +36,7 @@ self.addEventListener('install', function (event) {
   )
 })
 
-self.addEventListener('fetch', function (event) {
+self.addEventListener('fetch', /** @param {any} event */ function (event) {
   console.log('[Service Worker] Fetching: ', event.request.url)
   event.respondWith(
     caches.match(event.request).then(function (response) {
@@ -56,7 +57,7 @@ self.addEventListener('fetch', function (event) {
   )
 })
 
-self.addEventListener('activate', function (event) {
+self.addEventListener('activate', /** @param {any} event */ function (event) {
   console.log('[Service Worker] Activating and cleaning up old caches')
   const cacheWhitelist = [CACHE_NAME] // Only keep the current cache
   event.waitUntil(

--- a/src/storage/servicesStore.js
+++ b/src/storage/servicesStore.js
@@ -1,3 +1,4 @@
+// @ts-check
 const STORAGE_KEY = 'services'
 
 export function load () {

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,69 @@
+// @ts-check
+
+/**
+ * Widget persisted in a board view.
+ * @typedef {Object} Widget
+ * @property {string} [dataid]
+ * @property {string} url
+ * @property {number|string} columns
+ * @property {number|string} rows
+ * @property {string} [type]
+ * @property {string} [order]
+ * @property {Record<string, any>} [metadata]
+ * @property {Record<string, any>} [settings]
+ */
+
+/**
+ * Collection of widgets for a board view.
+ * @typedef {Object} View
+ * @property {string} id
+ * @property {string} name
+ * @property {Array<Widget>} widgetState
+ */
+
+/**
+ * Board containing views of widgets.
+ * @typedef {Object} Board
+ * @property {string} id
+ * @property {string} name
+ * @property {number} [order]
+ * @property {Array<View>} views
+ */
+
+/**
+ * Optional configuration for a service.
+ * @typedef {Object} ServiceConfig
+ * @property {number} [minColumns]
+ * @property {number} [maxColumns]
+ * @property {number} [minRows]
+ * @property {number} [maxRows]
+ */
+
+/**
+ * External service definition.
+ * @typedef {Object} Service
+ * @property {string} name
+ * @property {string} url
+ * @property {string} [type]
+ * @property {ServiceConfig} [config]
+ */
+
+/**
+ * Dashboard configuration loaded from storage or URL.
+ * @typedef {Object} DashboardConfig
+ * @property {object} globalSettings
+ * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} styling
+ * @property {Array<Board>} boards
+ */
+
+/**
+ * Structured entry written by {@link Logger} during tests.
+ * @typedef {Object} LoggerEntry
+ * @property {string} file
+ * @property {string} fn
+ * @property {string} level
+ * @property {string} message
+ * @property {string} time
+ */
+
+export {}

--- a/src/ui/unicodeEmoji.js
+++ b/src/ui/unicodeEmoji.js
@@ -1,3 +1,4 @@
+// @ts-check
 const emojiList = {
   puzzle: { icon: '🧩', unicode: '\u{1F9E9}', description: 'Widget to grid' },
   satellite: { icon: '📡', unicode: '\u{1F4E1}', description: 'Serviceworker' },

--- a/src/utils/Logger.js
+++ b/src/utils/Logger.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Simple browser console logger with runtime enable/disable support.
  * During Playwright test runs (via `navigator.webdriver`), structured logs are

--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * DOM element helpers.
  *

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Fetch a list of services from various sources and store them globally.
  *
@@ -5,6 +6,8 @@
  */
 import { Logger } from './Logger.js'
 import { showNotification } from '../component/dialog/notification.js'
+
+/** @typedef {import('../types.js').Service} Service */
 
 const logger = new Logger('fetchServices.js')
 const STORAGE_KEY = 'services'
@@ -35,7 +38,7 @@ async function fetchJson (url) {
  * Fetch the service list and update the service selector on the page.
  *
  * @function fetchServices
- * @returns {Promise<Array>} Array of service objects.
+ * @returns {Promise<Array<Service>>} Array of service objects.
  */
 export const fetchServices = async () => {
   const params = new URLSearchParams(window.location.search)

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Load configuration from query parameters, localStorage or defaults.
  *

--- a/src/utils/getCurrentUrl.js
+++ b/src/utils/getCurrentUrl.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * URL helper utilities.
  *

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Miscellaneous utility helpers.
  *

--- a/symbols.json
+++ b/symbols.json
@@ -1,5 +1,73 @@
 [
   {
+    "name": "saveWidgetState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Serialize widgets in the current view and store them under the given board and view identifiers in localStorage. Each widget is saved with its order, dimensions, URL and any metadata/settings.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Board identifier. Defaults to the current board element id."
+      },
+      {
+        "name": "viewId",
+        "type": "string",
+        "desc": "- View identifier. Defaults to the current view element id."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadWidgetState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Restore widget DOM elements for the specified board and view from localStorage. Widgets are recreated using {@link createWidget} and metadata and settings are re-applied.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Board identifier."
+      },
+      {
+        "name": "viewId",
+        "type": "string",
+        "desc": "- View identifier whose widgets should be loaded."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadInitialConfig",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Store the initial board configuration defined in {@code window.asd.config} into localStorage. This is typically called on first run to seed the persistent board data.",
+    "params": [],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "saveBoardState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Persist the entire boards array to localStorage under the key `boards`.",
+    "params": [
+      {
+        "name": "boards",
+        "type": "Array<Board>",
+        "desc": "- Array of board objects to store."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadBoardState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Retrieve the array of boards from localStorage. The result is also assigned to {@code window.asd.boards} for global access.",
+    "params": [],
+    "returns": "Promise<Array<Board>>"
+  },
+  {
     "name": "Logger",
     "kind": "class",
     "file": "src/utils/Logger.js",
@@ -150,7 +218,7 @@
     "file": "src/utils/fetchServices.js",
     "description": "Fetch the service list and update the service selector on the page.",
     "params": [],
-    "returns": "Promise<Array>"
+    "returns": "Promise<Array<Service>>"
   },
   {
     "name": "getConfig",
@@ -194,74 +262,6 @@
     "description": "Generate a UUID using the browser crypto API when available.",
     "params": [],
     "returns": "string"
-  },
-  {
-    "name": "saveWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Serialize widgets in the current view and store them under the given board and view identifiers in localStorage. Each widget is saved with its order, dimensions, URL and any metadata/settings.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Board identifier. Defaults to the current board element id."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- View identifier. Defaults to the current view element id."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Restore widget DOM elements for the specified board and view from localStorage. Widgets are recreated using {@link createWidget} and metadata and settings are re-applied.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Board identifier."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- View identifier whose widgets should be loaded."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadInitialConfig",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Store the initial board configuration defined in {@code window.asd.config} into localStorage. This is typically called on first run to seed the persistent board data.",
-    "params": [],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "saveBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Persist the entire boards array to localStorage under the key `boards`.",
-    "params": [
-      {
-        "name": "boards",
-        "type": "Array",
-        "desc": "- Array of board objects to store."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Retrieve the array of boards from localStorage. The result is also assigned to {@code window.asd.boards} for global access.",
-    "params": [],
-    "returns": "Promise<Array>"
   },
   {
     "name": "initializeBoardDropdown",
@@ -325,7 +325,7 @@
         "desc": "- Identifier for the default view."
       }
     ],
-    "returns": "object"
+    "returns": "Board"
   },
   {
     "name": "createView",
@@ -349,7 +349,7 @@
         "desc": "- Optional predefined id for the view."
       }
     ],
-    "returns": "object|undefined"
+    "returns": "View|undefined"
   },
   {
     "name": "switchView",
@@ -521,30 +521,6 @@
     "returns": "void"
   },
   {
-    "name": "showNotification",
-    "kind": "function",
-    "file": "src/component/dialog/notification.js",
-    "description": "Display a temporary notification message.",
-    "params": [
-      {
-        "name": "message",
-        "type": "string",
-        "desc": "- Text content of the notification."
-      },
-      {
-        "name": "duration",
-        "type": "number",
-        "desc": "- How long to display the notification."
-      },
-      {
-        "name": "type",
-        "type": "('success'|'error')",
-        "desc": "- Visual style of the message."
-      }
-    ],
-    "returns": "void"
-  },
-  {
     "name": "initializeDashboardMenu",
     "kind": "function",
     "file": "src/component/menu/dashboardMenu.js",
@@ -574,6 +550,30 @@
     "file": "src/component/menu/menu.js",
     "description": "Create the main dashboard menu and insert it into the page.",
     "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "showNotification",
+    "kind": "function",
+    "file": "src/component/dialog/notification.js",
+    "description": "Display a temporary notification message.",
+    "params": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "- Text content of the notification."
+      },
+      {
+        "name": "duration",
+        "type": "number",
+        "desc": "- How long to display the notification."
+      },
+      {
+        "name": "type",
+        "type": "('success'|'error')",
+        "desc": "- Visual style of the message."
+      }
+    ],
     "returns": "void"
   },
   {
@@ -860,7 +860,7 @@
     "name": "addDragOverlay",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Insert a transparent overlay to mark a widget as a drop target.",
+    "description": "",
     "params": [
       {
         "name": "widgetWrapper",

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -83,9 +83,9 @@ test.describe('Dashboard Config - Fallback Config Popup', () => {
   test('valid input in popup initializes dashboard', async ({ page }) => {
     await page.goto('/');
     await page.click('#config-modal .modal__btn--cancel');
-    await page.evaluate(cfg => {
-      return import('/component/modal/configModal.js').then(m => m.openConfigModal(cfg));
-    }, ciConfig);
+    await page.evaluate(() => {
+      return import('/component/modal/configModal.js').then(m => m.openConfigModal());
+    });
     await page.waitForSelector('#config-json');
     await page.fill('#config-json', JSON.stringify(ciConfig));
     await page.click('#config-modal .modal__btn--save');

--- a/tests/shared/testWithLogs.ts
+++ b/tests/shared/testWithLogs.ts
@@ -12,6 +12,7 @@ export {
   firefox,
   webkit,
   request,
+  type Page,
 } from 'playwright/test';
 
 type ConsoleLog = { type: string; text: string };
@@ -47,7 +48,7 @@ export const test = base.extend<{
           net.push({
             url: r.url(),
             status: res.status(),
-            timing: res.timing // <-- FIXED: was res.timing()
+            timing: r.timing()
           });
       });
       await use(net);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@playwright/test": ["tests/shared/testWithLogs"]
+      "@playwright/test": ["tests/shared/testWithLogs"],
+      "/component/*": ["src/component/*"],
+      "/*": ["src/*"]
     },
     "target": "esnext",
     "module": "esnext",
@@ -12,5 +14,5 @@
     "checkJs": true,
     "noEmit": true
   },
-  "include": ["tests"]
+  "include": ["src", "tests", "src/global.d.ts"]
 }


### PR DESCRIPTION
## Summary
- add global type declarations for `window.asd` and `_appLogs`
- expose `Page` type for tests and fix network log timing
- update dynamic config test to match new modal signature
- extend tsconfig paths and include global types
- export empty module from `src/types.js` so tsc treats it as a module
- enforce type checking across src and fix discovered issues
- document `just check` in README for running TypeScript validation

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `just test` *(fails: 1 failed, 3 interrupted)*
- `node scripts/playwright-indexer.js`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_6861ac46d3748325b9f46041dd880979