### PR TITLE
Fix type errors with DOM casts

### DIFF
--- a/src/component/board/boardDropdown.js
+++ b/src/component/board/boardDropdown.js
@@ -107,6 +107,6 @@ function handleDeleteBoard () {
  * @returns {string}
  */
 function getSelectedBoardId () {
-  const boardSelector = document.getElementById('board-selector')
+  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   return boardSelector.value
 }

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -136,7 +136,15 @@ export async function switchView (boardId, viewId) {
       clearWidgetContainer()
       logger.log(`Rendering widgets for view ${viewId}:`, view.widgetState)
       for (const widget of view.widgetState) {
-        await addWidget(widget.url, widget.columns, widget.rows, widget.type, boardId, viewId, widget.dataid)
+        await addWidget(
+          widget.url,
+          Number(widget.columns),
+          Number(widget.rows),
+          widget.type,
+          boardId,
+          viewId,
+          widget.dataid
+        )
       }
       window.asd.currentViewId = viewId
       localStorage.setItem('lastUsedViewId', viewId)
@@ -158,7 +166,7 @@ export async function switchView (boardId, viewId) {
  * @returns {void}
  */
 export function updateViewSelector (boardId) {
-  const viewSelector = document.getElementById('view-selector')
+  const viewSelector = /** @type {HTMLSelectElement|null} */(document.getElementById('view-selector'))
   if (!viewSelector) {
     logger.error('View selector element not found')
     return
@@ -250,6 +258,7 @@ export function initializeBoards () {
     }
   }).catch(error => {
     logger.error('Error initializing boards:', error)
+    return undefined
   })
 }
 
@@ -262,7 +271,7 @@ export function initializeBoards () {
  * @returns {void}
  */
 export function addBoardToUI (board) {
-  const boardSelector = document.getElementById('board-selector')
+  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   const option = document.createElement('option')
   option.value = board.id
   option.textContent = board.name
@@ -407,7 +416,7 @@ export function resetView (boardId, viewId) {
 }
 
 function updateBoardSelector () {
-  const boardSelector = document.getElementById('board-selector')
+  const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   boardSelector.innerHTML = ''
   boards.forEach(board => {
     const option = document.createElement('option')

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,8 +36,8 @@ function initializeDashboardMenu () {
   document.addEventListener('services-updated', populateServiceDropdown)
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
-    const serviceSelector = document.getElementById('service-selector')
-    const widgetUrlInput = document.getElementById('widget-url')
+    const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
+    const widgetUrlInput = /** @type {HTMLInputElement} */(document.getElementById('widget-url'))
     const boardElement = document.querySelector('.board')
     const viewElement = document.querySelector('.board-view')
     const selectedServiceUrl = serviceSelector.value
@@ -74,7 +74,8 @@ function initializeDashboardMenu () {
   })
 
   document.getElementById('board-selector').addEventListener('change', (event) => {
-    const selectedBoardId = event.target.value
+    const target = /** @type {HTMLSelectElement} */(event.target)
+    const selectedBoardId = target.value
     const currentBoardId = getCurrentBoardId()
     saveWidgetState(currentBoardId) // Save the state of the current board before switching
     switchBoard(selectedBoardId)
@@ -83,7 +84,8 @@ function initializeDashboardMenu () {
 
   document.getElementById('view-selector').addEventListener('change', (event) => {
     const selectedBoardId = getCurrentBoardId()
-    const selectedViewId = event.target.value
+    const target = /** @type {HTMLSelectElement} */(event.target)
+    const selectedViewId = target.value
     logger.log(`Switching to selected view ${selectedViewId} in board ${selectedBoardId}`)
     switchView(selectedBoardId, selectedViewId)
   })

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -13,7 +13,7 @@ import emojiList from '../../ui/unicodeEmoji.js'
  * @returns {void}
  */
 function initSW () {
-  const swToggle = document.getElementById('sw-toggle')
+  const swToggle = /** @type {HTMLInputElement} */(document.getElementById('sw-toggle'))
   const swIcon = document.querySelector('.sw-icon')
   const swCheckbox = document.querySelector('.icon-checkbox')
   const swEnabled = localStorage.getItem('swEnabled') === 'true'
@@ -76,7 +76,7 @@ function initSW () {
 
     swToggle.addEventListener('change', function () {
       const isEnabled = swToggle.checked
-      localStorage.setItem('swEnabled', isEnabled)
+      localStorage.setItem('swEnabled', String(isEnabled))
       updateServiceWorkerUI(isEnabled)
 
       if (isEnabled) {

--- a/src/component/modal/localStorageModal.js
+++ b/src/component/modal/localStorageModal.js
@@ -81,7 +81,7 @@ export function openLocalStorageModal () {
         let invalid = false
         for (const [key] of Object.entries(data)) {
           if (key.includes('swEnabled') || key.includes('config')) continue
-          const val = document.getElementById(`localStorage-${key}`).value
+          const val = /** @type {HTMLTextAreaElement} */(document.getElementById(`localStorage-${key}`)).value
           try {
             updated[key] = JSON.parse(val)
           } catch {

--- a/src/component/utils/dropDownUtils.js
+++ b/src/component/utils/dropDownUtils.js
@@ -23,7 +23,8 @@ export function initializeDropdown (dropdownElement, handlers) {
   }
 
   dropdownElement.addEventListener('click', (event) => {
-    const action = event.target.dataset.action // Assuming the action is stored in a data attribute
+    const target = /** @type {HTMLElement} */(event.target)
+    const action = target.dataset.action // Assuming the action is stored in a data attribute
     logger.log('Dropdown action clicked:', action)
 
     if (handlers && typeof handlers[action] === 'function') {

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -29,7 +29,7 @@ function handleDragStart (e, draggedWidgetWrapper) {
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
     if (widget !== draggedWidgetWrapper) {
-      addDragOverlay(widget)
+      addDragOverlay(/** @type {HTMLElement} */(widget))
     }
   })
 }
@@ -45,7 +45,7 @@ function handleDragEnd (e) {
   const widgetContainer = document.getElementById('widget-container')
   const widgets = Array.from(widgetContainer.children)
   widgets.forEach(widget => {
-    removeDragOverlay(widget)
+    removeDragOverlay(/** @type {HTMLElement} */(widget))
     widget.classList.remove('drag-over')
   })
 }
@@ -117,7 +117,7 @@ function handleDrop (e, targetWidgetWrapper) {
   logger.log(`Drop event: draggedOrder=${draggedOrder}, targetOrder=${targetOrder}`)
 
   const widgetContainer = document.getElementById('widget-container')
-  const draggedWidget = widgetContainer.querySelector(`[data-order='${draggedOrder}']`)
+  const draggedWidget = /** @type {HTMLElement|null} */(widgetContainer.querySelector(`[data-order='${draggedOrder}']`))
 
   if (!draggedWidget) {
     logger.error('Invalid dragged widget element', 3000, 'error')
@@ -125,7 +125,7 @@ function handleDrop (e, targetWidgetWrapper) {
   }
 
   if (targetOrder !== null) {
-    const targetWidget = widgetContainer.querySelector(`[data-order='${targetOrder}']`)
+    const targetWidget = /** @type {HTMLElement|null} */(widgetContainer.querySelector(`[data-order='${targetOrder}']`))
     if (!targetWidget) {
       logger.error('Invalid target widget element', 3000, 'error')
       return
@@ -149,7 +149,7 @@ function handleDrop (e, targetWidgetWrapper) {
     }
   } else {
     // Calculate nearest available grid position
-    const gridColumnCount = parseInt(getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length, 10)
+    const gridColumnCount = getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length
     let targetColumn = Math.floor(e.clientX / draggedWidget.offsetWidth)
     let targetRow = Math.floor(e.clientY / draggedWidget.offsetHeight)
 
@@ -158,8 +158,8 @@ function handleDrop (e, targetWidgetWrapper) {
     targetColumn = Math.max(targetColumn, 0)
     targetRow = Math.max(targetRow, 0)
 
-    draggedWidget.style.gridColumnStart = targetColumn + 1
-    draggedWidget.style.gridRowStart = targetRow + 1
+    draggedWidget.style.gridColumnStart = String(targetColumn + 1)
+    draggedWidget.style.gridRowStart = String(targetRow + 1)
 
     logger.log('Widget moved to new grid position:', {
       column: targetColumn + 1,
@@ -235,14 +235,14 @@ function initializeDragAndDrop () {
   const widgetContainer = document.getElementById('widget-container')
   widgetContainer.addEventListener('dragover', (e) => {
     e.preventDefault()
-    const dragOverTarget = e.target.closest('.widget-wrapper')
+    const dragOverTarget = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
     if (dragOverTarget) {
       dragOverTarget.classList.add('drag-over', 'highlight-drop-area')
     }
   })
 
   widgetContainer.addEventListener('dragleave', (e) => {
-    const dragLeaveTarget = e.target.closest('.widget-wrapper')
+    const dragLeaveTarget = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
     if (dragLeaveTarget) {
       dragLeaveTarget.classList.remove('drag-over', 'highlight-drop-area')
     }
@@ -251,24 +251,24 @@ function initializeDragAndDrop () {
   widgetContainer.addEventListener('drop', (e) => {
     e.preventDefault()
     const draggedOrder = e.dataTransfer.getData('text/plain')
-    const targetWidgetWrapper = e.target.closest('.widget-wrapper')
+    const targetWidgetWrapper = /** @type {HTMLElement} */(e.target).closest('.widget-wrapper')
     const targetOrder = targetWidgetWrapper ? targetWidgetWrapper.getAttribute('data-order') : null
 
     if (draggedOrder !== null) {
       const widgets = Array.from(widgetContainer.children)
-      const draggedWidget = widgets.find(widget => widget.getAttribute('data-order') === draggedOrder)
+      const draggedWidget = /** @type {HTMLElement}|undefined */(widgets.find(widget => widget.getAttribute('data-order') === draggedOrder))
 
       if (draggedWidget) {
         if (targetOrder !== null) {
-          const targetWidget = widgets.find(widget => widget.getAttribute('data-order') === targetOrder)
+          const targetWidget = /** @type {HTMLElement}|undefined */(widgets.find(widget => widget.getAttribute('data-order') === targetOrder))
           if (targetWidget) {
             // Swap orders
             draggedWidget.setAttribute('data-order', targetOrder)
             targetWidget.setAttribute('data-order', draggedOrder)
 
             // Update CSS order
-            draggedWidget.style.order = targetOrder
-            targetWidget.style.order = draggedOrder
+            draggedWidget.style.order = String(targetOrder)
+            targetWidget.style.order = String(draggedOrder)
           }
         } else {
           // Handle drop in open space

--- a/src/component/widget/events/fullscreenToggle.js
+++ b/src/component/widget/events/fullscreenToggle.js
@@ -40,7 +40,7 @@ function handleEscapeKey (event) {
   if (event.key === 'Escape') {
     const fullScreenWidget = document.querySelector('.widget-wrapper.fullscreen')
     if (fullScreenWidget) {
-      toggleFullScreen(fullScreenWidget)
+      toggleFullScreen(/** @type {HTMLElement} */(fullScreenWidget))
     }
   }
 }

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -33,7 +33,7 @@ export function initializeResizeHandles () {
 
     resizeHandle.addEventListener('mousedown', (event) => {
       event.preventDefault()
-      handleResizeStart(event, widget)
+      handleResizeStart(event, /** @type {HTMLElement} */(widget))
     })
   })
 }
@@ -42,11 +42,11 @@ function createResizeOverlay () {
   const overlay = document.createElement('div')
   overlay.className = 'resize-overlay'
   overlay.style.position = 'fixed'
-  overlay.style.top = 0
-  overlay.style.left = 0
+  overlay.style.top = '0'
+  overlay.style.left = '0'
   overlay.style.width = '100%'
   overlay.style.height = '100%'
-  overlay.style.zIndex = 1000 // Ensure it is above all other elements
+  overlay.style.zIndex = '1000' // Ensure it is above all other elements
   document.body.appendChild(overlay)
   return overlay
 }
@@ -90,8 +90,8 @@ async function handleResizeStart (event, widget) {
 
       widget.style.gridColumn = `span ${snappedWidth}`
       widget.style.gridRow = `span ${snappedHeight}`
-      widget.dataset.columns = snappedWidth
-      widget.dataset.rows = snappedHeight
+      widget.dataset.columns = String(snappedWidth)
+      widget.dataset.rows = String(snappedHeight)
 
       logger.info(`Widget resized to columns: ${snappedWidth}, rows: ${snappedHeight}`)
     } catch (error) {

--- a/src/component/widget/menu/resizeMenu.js
+++ b/src/component/widget/menu/resizeMenu.js
@@ -34,7 +34,7 @@ async function resizeHorizontally (widget, increase = true) {
       widget.classList.remove('below-min', 'exceeding-max')
     }
 
-    widget.dataset.columns = newSpan
+    widget.dataset.columns = String(newSpan)
     widget.style.gridColumn = `span ${newSpan}`
     logger.log(`Widget resized horizontally to span ${newSpan} columns`)
     saveWidgetState()
@@ -75,7 +75,7 @@ async function resizeVertically (widget, increase = true) {
       widget.classList.remove('below-min', 'exceeding-max')
     }
 
-    widget.dataset.rows = newSpan
+    widget.dataset.rows = String(newSpan)
     widget.style.gridRow = `span ${newSpan}`
     logger.log(`Widget resized vertically to span ${newSpan} rows`)
     saveWidgetState()
@@ -264,8 +264,8 @@ async function adjustWidgetSize (widgetWrapper, columns, rows) {
     columns = Math.min(Math.max(columns, minColumns), maxColumns)
     rows = Math.min(Math.max(rows, minRows), maxRows)
 
-    widgetWrapper.dataset.columns = columns
-    widgetWrapper.dataset.rows = rows
+    widgetWrapper.dataset.columns = String(columns)
+    widgetWrapper.dataset.rows = String(rows)
     widgetWrapper.style.gridColumn = `span ${columns}`
     widgetWrapper.style.gridRow = `span ${rows}`
     logger.log(`Widget resized to ${columns} columns and ${rows} rows`)

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* global HTMLElement */
 /**
  * Widget creation and management functions.
  *
@@ -57,8 +58,8 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
 
   widgetWrapper.style.gridColumn = `span ${gridColumnSpan}`
   widgetWrapper.style.gridRow = `span ${gridRowSpan}`
-  widgetWrapper.dataset.columns = gridColumnSpan
-  widgetWrapper.dataset.rows = gridRowSpan
+  widgetWrapper.dataset.columns = String(gridColumnSpan)
+  widgetWrapper.dataset.rows = String(gridRowSpan)
 
   const iframe = document.createElement('iframe')
   iframe.src = url
@@ -121,7 +122,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   resizeMenuIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu icon')
     const related = event.relatedTarget
-    if (!related || !related.closest('.resize-menu')) {
+    if (!(related instanceof HTMLElement) || !related.closest('.resize-menu')) {
       debouncedHideResizeMenu(resizeMenuIcon)
     }
   })
@@ -136,7 +137,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   resizeMenuBlockIcon.addEventListener('mouseleave', (event) => {
     logger.log('Mouse left resize menu block icon')
     const related = event.relatedTarget
-    if (!related || !related.closest('.resize-menu-block')) {
+    if (!(related instanceof HTMLElement) || !related.closest('.resize-menu-block')) {
       debouncedHideResizeMenuBlock(widgetWrapper)
     }
   })
@@ -219,7 +220,7 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   logger.log('Extracted service:', service)
 
   const widgetWrapper = await createWidget(service, url, columns, rows, dataid)
-  widgetWrapper.setAttribute('data-order', widgetContainer.children.length)
+  widgetWrapper.setAttribute('data-order', String(widgetContainer.children.length))
   widgetContainer.appendChild(widgetWrapper)
 
   logger.log('Widget appended to container:', widgetWrapper)
@@ -292,10 +293,11 @@ function updateWidgetOrders () {
   const widgets = Array.from(widgetContainer.children)
 
   widgets.forEach((widget, index) => {
-    widget.setAttribute('data-order', index)
-    widget.style.order = index
+    const element = /** @type {HTMLElement} */(widget)
+    element.setAttribute('data-order', String(index))
+    element.style.order = String(index)
     logger.log('Updated widget order:', {
-      dataid: widget.dataset.dataid,
+      dataid: element.dataset.dataid,
       order: index
     })
   })

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,11 @@ const logger = new Logger('main.js')
 
 window.asd = {
   services: [],
-  config: {},
+  config: /** @type {import('./types.js').DashboardConfig} */ ({
+    globalSettings: {},
+    boards: [],
+    styling: { widget: { minColumns: 1, maxColumns: 1, minRows: 1, maxRows: 1 } }
+  }),
   boards: [],
   currentBoardId: null,
   currentViewId: null

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -5,6 +5,12 @@
  *
  * @module serviceWorker
  */
+/**
+ * @typedef {Event & {waitUntil: (p: Promise<any>) => void}} SWExtendableEvent
+ */
+/**
+ * @typedef {SWExtendableEvent & {request: Request, respondWith: (r: Promise<Response>|Response) => void}} SWFetchEvent
+ */
 const CACHE_NAME = 'my-cache-v3' // Make sure this matches the cache name in the main.js file
 // self.addEventListener('fetch', (event) => {
 //   const testUrls = [
@@ -23,7 +29,7 @@ const CACHE_NAME = 'my-cache-v3' // Make sure this matches the cache name in the
 //   }
 // });
 
-self.addEventListener('install', function (event) {
+self.addEventListener('install', function (/** @type {SWExtendableEvent} */ event) {
   console.log('[Service Worker] Installed')
   event.waitUntil(
     caches.open(CACHE_NAME).then(function (cache) {
@@ -36,7 +42,7 @@ self.addEventListener('install', function (event) {
   )
 })
 
-self.addEventListener('fetch', function (event) {
+self.addEventListener('fetch', function (/** @type {SWFetchEvent} */ event) {
   console.log('[Service Worker] Fetching: ', event.request.url)
   event.respondWith(
     caches.match(event.request).then(function (response) {
@@ -57,7 +63,7 @@ self.addEventListener('fetch', function (event) {
   )
 })
 
-self.addEventListener('activate', function (event) {
+self.addEventListener('activate', function (/** @type {SWExtendableEvent} */ event) {
   console.log('[Service Worker] Activating and cleaning up old caches')
   const cacheWhitelist = [CACHE_NAME] // Only keep the current cache
   event.waitUntil(

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -59,8 +59,8 @@ function serializeWidgetState (widget) {
  * and view identifiers in localStorage. Each widget is saved with its order,
  * dimensions, URL and any metadata/settings.
  *
- * @param {string} boardId - Board identifier. Defaults to the current board element id.
- * @param {string} viewId - View identifier. Defaults to the current view element id.
+ * @param {?string} [boardId] - Board identifier. Defaults to the current board element id.
+ * @param {?string} [viewId] - View identifier. Defaults to the current view element id.
  * @function saveWidgetState
  * @returns {Promise<void>}
  */
@@ -79,7 +79,7 @@ async function saveWidgetState (boardId, viewId) {
     }
     const widgetContainer = document.getElementById('widget-container')
     const widgets = Array.from(widgetContainer.children)
-    const widgetState = widgets.map(widget => serializeWidgetState(widget))
+    const widgetState = widgets.map(widget => serializeWidgetState(/** @type {HTMLElement} */(widget)))
     const boards = await loadBoardState()
     logger.info(`Loaded board state from localStorage: ${boards}`)
     const board = boards.find(b => b.id === boardId)
@@ -130,7 +130,7 @@ async function loadWidgetState (boardId, viewId) {
         logger.info('Found widget state in view:', view.widgetState)
         const savedState = view.widgetState
         const widgetContainer = document.getElementById('widget-container')
-        const existingWidgetIds = Array.from(widgetContainer.children).map(w => w.dataset.dataid)
+        const existingWidgetIds = Array.from(widgetContainer.children).map(w => /** @type {HTMLElement} */(w).dataset.dataid)
 
         for (const widgetData of savedState) {
           if (!existingWidgetIds.includes(widgetData.dataid)) {
@@ -139,12 +139,12 @@ async function loadWidgetState (boardId, viewId) {
             const widgetWrapper = await createWidget(
               service,
               widgetData.url,
-              widgetData.columns,
-              widgetData.rows,
+              Number(widgetData.columns),
+              Number(widgetData.rows),
               widgetData.dataid // Ensure dataid is passed to maintain widget identity
             )
-            widgetWrapper.dataset.order = widgetData.order
-            widgetWrapper.style.order = widgetData.order
+            widgetWrapper.dataset.order = String(widgetData.order)
+            widgetWrapper.style.order = String(widgetData.order)
             widgetWrapper.dataset.type = widgetData.type
             widgetWrapper.dataset.metadata = JSON.stringify(widgetData.metadata)
             widgetWrapper.dataset.settings = JSON.stringify(widgetData.settings)

--- a/src/types.js
+++ b/src/types.js
@@ -53,6 +53,8 @@
  * @typedef {Object} DashboardConfig
  * @property {object} globalSettings
  * @property {Array<Board>} boards
+ * @property {object} [styling]
+ * @property {{minColumns:number,maxColumns:number,minRows:number,maxRows:number}} [styling.widget]
  */
 
 /**

--- a/symbols.json
+++ b/symbols.json
@@ -7,12 +7,12 @@
     "params": [
       {
         "name": "boardId",
-        "type": "string",
+        "type": "?string",
         "desc": "- Board identifier. Defaults to the current board element id."
       },
       {
         "name": "viewId",
-        "type": "string",
+        "type": "?string",
         "desc": "- View identifier. Defaults to the current view element id."
       }
     ],


### PR DESCRIPTION
## Summary
- cast DOM elements in board dropdown, board management, menus, and widgets
- make service worker event types explicit
- allow optional params for `saveWidgetState`
- extend `DashboardConfig` typedef
- regenerate symbol index

## Testing
- `npm run lint-fix`
- `just check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_6861e493b0dc8325b918405f29af2ff2