### PR TITLE
Add workflow to run just commands from issue comments

### DIFF
--- a/.github/workflows/justfile-comment-runner.yml
+++ b/.github/workflows/justfile-comment-runner.yml
@@ -18,9 +18,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Only allow org admins (repo admins for orgs, or repo owner)
+            // ↳ Ensure core is imported before setOutput
+            const core = require('@actions/core');
             let allowed = false;
             const actor = context.actor;
+
             if (context.payload.repository.owner.type === "Organization") {
               try {
                 const { data } = await github.orgs.getMembershipForUser({
@@ -28,18 +30,23 @@ jobs:
                   username: actor,
                 });
                 allowed = data.role === "admin";
-              } catch (e) {}
+              } catch {
+                allowed = false;
+              }
             } else {
               allowed = (actor === context.repo.owner);
             }
-            core.setOutput('allowed', allowed);
+
+            // ↳ Always emit a string
+            core.setOutput('allowed', allowed ? 'true' : 'false');
+
       - name: Exit if not admin
         if: steps.is_admin.outputs.allowed != 'true'
         run: |
           echo "User ${{ github.actor }} is not authorized to run commands."
           exit 1
 
-      - name: Install just (Justfile runner)
+      - name: Install just
         run: |
           sudo apt-get update
           sudo apt-get install -y just
@@ -48,38 +55,45 @@ jobs:
         env:
           COMMENT: ${{ github.event.comment.body }}
         run: |
-          #!/usr/bin/env bash
-          set -e
+          set -euo pipefail
 
-          # Remove the '/run' prefix, trim whitespace
-          body="${COMMENT#\/run}"
+          # ↳ Strip the literal prefix '/run' (no stray quotes!)
+          body="${COMMENT#/run}"
           body="$(echo "$body" | xargs)"
 
-          # Split commands on '&&' or ';'
-          IFS=$'\n' read -rd '' -a commands <<<"$(echo "$body" | sed 's/&&/\n/g; s/;/\n/g' | sed '/^\s*$/d' | sed 's/^\s*//; s/\s*$//')"
+          # ↳ Split on && or ;
+          IFS=$'\n' read -rd '' -a cmds <<<"$(
+            printf '%s\n' "$body" \
+              | sed 's/&&/\n/g; s/;/\n/g' \
+              | sed '/^\s*$/d; s/^\s*//; s/\s*$//'
+          )"
 
           results=""
-          for cmd in "${commands[@]}"; do
-            justcmd="$(echo "$cmd" | awk '{print $1}')"
-            if [[ ! "$justcmd" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-              echo "Refusing to run suspicious just command: $justcmd"
+          for cmd in "${cmds[@]}"; do
+            # ↳ Extract subcommand, whitelist safe chars
+            justcmd="${cmd%% *}"
+            if [[ ! "$justcmd" =~ ^[A-Za-z0-9_-]+$ ]]; then
+              echo "Refusing suspicious just command: $justcmd"
               exit 1
             fi
-            args="${cmd#"$justcmd"}"
-            echo "::group::Running: just $justcmd$args"
-            if output=$(just $justcmd $args 2>&1); then
-              results+="✅ just $justcmd$args\n$output\n\n"
+
+            # ↳ Trim args
+            args="$(printf '%s' "${cmd#"$justcmd"}" | xargs)"
+            echo "::group::Running: just $justcmd $args"
+            if output=$(just "$justcmd" $args 2>&1); then
+              results+="✅ just $justcmd $args\n$output\n\n"
             else
-              results+="❌ just $justcmd$args\n$output\n\n"
+              results+="❌ just $justcmd $args\n$output\n\n"
               echo "::endgroup::"
               break
             fi
             echo "::endgroup::"
           done
 
-          echo -e "$results" > results.txt
+          # ↳ Save for comment step
+          printf "%b" "$results" > results.txt
 
-      - name: Comment results (optional)
+      - name: Comment results
         if: always()
         uses: peter-evans/create-or-update-comment@v4
         with:

--- a/.github/workflows/justfile-comment-runner.yml
+++ b/.github/workflows/justfile-comment-runner.yml
@@ -1,0 +1,87 @@
+name: Justfile Comment Runner
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  run_justfile_commands:
+    if: startsWith(github.event.comment.body, '/run')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate user is admin
+        id: is_admin
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Only allow org admins (repo admins for orgs, or repo owner)
+            let allowed = false;
+            const actor = context.actor;
+            if (context.payload.repository.owner.type === "Organization") {
+              try {
+                const { data } = await github.orgs.getMembershipForUser({
+                  org: context.repo.owner,
+                  username: actor,
+                });
+                allowed = data.role === "admin";
+              } catch (e) {}
+            } else {
+              allowed = (actor === context.repo.owner);
+            }
+            core.setOutput('allowed', allowed);
+      - name: Exit if not admin
+        if: steps.is_admin.outputs.allowed != 'true'
+        run: |
+          echo "User ${{ github.actor }} is not authorized to run commands."
+          exit 1
+
+      - name: Install just (Justfile runner)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+
+      - name: Parse and run Justfile commands
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+        run: |
+          #!/usr/bin/env bash
+          set -e
+
+          # Remove the '/run' prefix, trim whitespace
+          body="${COMMENT#\/run}"
+          body="$(echo "$body" | xargs)"
+
+          # Split commands on '&&' or ';'
+          IFS=$'\n' read -rd '' -a commands <<<"$(echo "$body" | sed 's/&&/\n/g; s/;/\n/g' | sed '/^\s*$/d' | sed 's/^\s*//; s/\s*$//')"
+
+          results=""
+          for cmd in "${commands[@]}"; do
+            justcmd="$(echo "$cmd" | awk '{print $1}')"
+            if [[ ! "$justcmd" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+              echo "Refusing to run suspicious just command: $justcmd"
+              exit 1
+            fi
+            args="${cmd#"$justcmd"}"
+            echo "::group::Running: just $justcmd$args"
+            if output=$(just $justcmd $args 2>&1); then
+              results+="✅ just $justcmd$args\n$output\n\n"
+            else
+              results+="❌ just $justcmd$args\n$output\n\n"
+              echo "::endgroup::"
+              break
+            fi
+            echo "::endgroup::"
+          done
+
+          echo -e "$results" > results.txt
+
+      - name: Comment results (optional)
+        if: always()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body-file: results.txt

--- a/.github/workflows/linting-checks.yml
+++ b/.github/workflows/linting-checks.yml
@@ -1,0 +1,38 @@
+# .github/workflows/lint-and-typecheck.yml
+name: Lint & Type Check
+
+on:
+  push:
+
+jobs:
+  lint_and_typecheck:
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: linting-${{ github.head_ref || github.ref }}
+      cancel-in-progress: true
+
+    strategy:
+      matrix:
+        node-version: [lts/*]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint with StandardJS
+        run: npx standard
+
+      - name: Type check
+        run: npm run check

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
-    concurrency:                                    # <-- de-dented: must align with other job keys
+    concurrency:
       group: playwright-${{ github.head_ref || github.ref }}
       cancel-in-progress: true
 


### PR DESCRIPTION
## Summary
- run `just` commands via comments using GitHub Actions
- restrict execution to repo/organization admins
- report success or failure back to the triggering comment

## Testing
- `just extract-symbols`
- `just test`
- `node scripts/playwright-indexer.js`

------
https://chatgpt.com/codex/tasks/task_b_6861eed6708083258f25b1fe5d35e252