### PR TITLE
Fix config_base64 runtime loading

### DIFF
--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -54,6 +54,10 @@ async function loadFromSources () {
   if (params.has('config_base64')) {
     const cfg = parseBase64(params.get('config_base64'))
     if (cfg) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(cfg))
+      if (Array.isArray(cfg.boards)) {
+        localStorage.setItem('boards', JSON.stringify(cfg.boards))
+      }
       window.history.replaceState(null, '', location.pathname)
       return cfg
     }
@@ -63,6 +67,10 @@ async function loadFromSources () {
   if (params.has('config_url')) {
     const cfgU = await fetchJson(params.get('config_url'))
     if (cfgU) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(cfgU))
+      if (Array.isArray(cfgU.boards)) {
+        localStorage.setItem('boards', JSON.stringify(cfgU.boards))
+      }
       window.history.replaceState(null, '', location.pathname)
       return cfgU
     }

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -15,10 +15,15 @@ async function clearStorage(page) {
 
 test.describe('Dashboard Config - Base64 via URL Params', () => {
   test('loads dashboard from valid config_base64 and services_base64', async ({ page }) => {
-    const config = b64(ciConfig);
+    const cfg = { ...ciConfig, boards: ciBoards };
+    const config = b64(cfg);
     const services = b64(ciServices);
     await page.goto(`/?config_base64=${config}&services_base64=${services}`);
     await expect(page.locator('#service-selector option')).toHaveCount(ciServices.length + 1);
+    const boards = await page.evaluate(() => window.asd.boards);
+    expect(boards.length).toBe(ciBoards.length);
+    const names = await page.$$eval('#board-selector option', opts => opts.map(o => o.textContent));
+    expect(names).toContain(ciBoards[0].name);
   });
 
   test('shows config modal on invalid base64', async ({ page }) => {


### PR DESCRIPTION
## Summary
- persist boards when loading config from URL params
- verify board state is applied at runtime in tests

## Testing
- `npm run lint`
- `just test`
- `node scripts/playwright-indexer.js`

------
https://chatgpt.com/codex/tasks/task_b_68628247d1f883258fc13226608264b9