### PR TITLE
Add fragment guard for config

### DIFF
--- a/scripts/extract-symbol-index.mjs
+++ b/scripts/extract-symbol-index.mjs
@@ -84,6 +84,13 @@ async function extractSymbols () {
     return true
   })
 
+  // Sort symbols for stable output and reduced git diffs
+  deduped.sort((a, b) => {
+    if (a.name !== b.name) return a.name.localeCompare(b.name)
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind)
+    return a.file.localeCompare(b.file)
+  })
+
   await fs.writeFile('symbols.json', JSON.stringify(deduped, null, 2), 'utf8')
   console.log(`✅ symbols.json generated with ${deduped.length} entries.`)
 }

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -16,6 +16,7 @@ import { saveWidgetState } from '../../storage/localStorage.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 import { showNotification } from '../dialog/notification.js'
 import { Logger } from '../../utils/Logger.js'
+import { clearConfigFragment } from '../../utils/fragmentGuard.js'
 
 const logger = new Logger('dashboardMenu.js')
 
@@ -69,6 +70,7 @@ function initializeDashboardMenu () {
 
     if (confirmed) {
       localStorage.clear()
+      clearConfigFragment()
       location.reload()
     }
   })

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -10,6 +10,8 @@ import { Logger } from '../../utils/Logger.js'
 import { clearConfigFragment } from '../../utils/fragmentGuard.js'
 import { gzipJsonToBase64url } from '../../utils/compression.js'
 
+/** @typedef {import('../../types.js').DashboardConfig} DashboardConfig */
+
 export const DEFAULT_CONFIG_TEMPLATE = {
   globalSettings: {
     theme: 'light',

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -7,6 +7,7 @@
 import { openModal } from './modalFactory.js'
 import { showNotification } from '../dialog/notification.js'
 import { Logger } from '../../utils/Logger.js'
+import { clearConfigFragment } from '../../utils/fragmentGuard.js'
 
 export const DEFAULT_CONFIG_TEMPLATE = {
   globalSettings: {
@@ -87,6 +88,7 @@ export function openConfigModal () {
 
           showNotification('Config saved to localStorage')
           closeModal()
+          clearConfigFragment()
           setTimeout(() => location.reload(), 500)
         } catch (e) {
           logger.error('Invalid JSON:', e)

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -8,6 +8,7 @@ import { openModal } from './modalFactory.js'
 import { showNotification } from '../dialog/notification.js'
 import { Logger } from '../../utils/Logger.js'
 import { clearConfigFragment } from '../../utils/fragmentGuard.js'
+import { gzipJsonToBase64url } from '../../utils/compression.js'
 
 export const DEFAULT_CONFIG_TEMPLATE = {
   globalSettings: {
@@ -26,19 +27,6 @@ export const DEFAULT_CONFIG_TEMPLATE = {
 }
 
 const logger = new Logger('configModal.js')
-
-/**
- * Gzip en base64url encode een string.
- * @param {string} data
- * @returns {Promise<string>}
- */
-async function gzipBase64Url (data) {
-  const cs = new CompressionStream('gzip')
-  const stream = new Blob([data]).stream().pipeThrough(cs)
-  const buffer = await new Response(stream).arrayBuffer()
-  const b64 = btoa(String.fromCharCode(...new Uint8Array(buffer)))
-  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-}
 
 /**
  * Open a modal dialog allowing the user to edit and save configuration JSON.
@@ -115,8 +103,8 @@ export function openConfigModal () {
           }
 
           const [cfgEnc, svcEnc] = await Promise.all([
-            gzipBase64Url(JSON.stringify(cfg)),
-            gzipBase64Url(JSON.stringify(svc))
+            gzipJsonToBase64url(cfg),
+            gzipJsonToBase64url(svc)
           ])
           const url = `${location.origin}${location.pathname}#cfg=${cfgEnc}&svc=${svcEnc}`
           await navigator.clipboard.writeText(url)

--- a/src/component/modal/fragmentDecisionModal.js
+++ b/src/component/modal/fragmentDecisionModal.js
@@ -1,0 +1,114 @@
+// @ts-check
+/**
+ * Modal prompting user to merge or overwrite when config fragment is detected.
+ *
+ * @module fragmentDecisionModal
+ */
+import { openModal } from './modalFactory.js'
+import { clearConfigFragment } from '../../utils/fragmentGuard.js'
+import { gunzipBase64urlToJson } from '../../utils/compression.js'
+import { mergeBoards, mergeServices } from '../../utils/merge.js'
+import { Logger } from '../../utils/Logger.js'
+
+/** @typedef {import('../../types.js').DashboardConfig} DashboardConfig */
+/** @typedef {import('../../types.js').Service} Service */
+/** @typedef {import('../../types.js').Board} Board */
+
+const logger = new Logger('fragmentDecisionModal.js')
+
+/**
+ * Display modal asking user to overwrite or merge fragment data.
+ *
+ * @param {string|null} cfgParam - Encoded config fragment.
+ * @param {string|null} svcParam - Encoded service fragment.
+ * @function openFragmentDecisionModal
+ * @returns {Promise<void>}
+ */
+export function openFragmentDecisionModal (cfgParam, svcParam) {
+  return new Promise(resolve => {
+    openModal({
+      id: 'fragment-decision-modal',
+      showCloseIcon: false,
+      onCloseCallback: () => {
+        clearConfigFragment()
+        logger.log('Fragment decision modal closed')
+        resolve()
+      },
+      buildContent: (modal, closeModal) => {
+        const msg1 = document.createElement('p')
+        msg1.textContent = 'A dashboard configuration was detected in the URL.'
+        const msg2 = document.createElement('p')
+        msg2.textContent = 'What would you like to do?'
+
+        const overwriteBtn = document.createElement('button')
+        overwriteBtn.textContent = '⬇ Overwrite existing data'
+        overwriteBtn.classList.add('modal__btn', 'modal__btn--danger')
+        overwriteBtn.addEventListener('click', async () => {
+          await applyFragment(true)
+        })
+
+        const mergeBtn = document.createElement('button')
+        mergeBtn.textContent = '➕ Merge into current setup'
+        mergeBtn.classList.add('modal__btn', 'modal__btn--save')
+        mergeBtn.addEventListener('click', async () => {
+          await applyFragment(false)
+        })
+
+        const cancelBtn = document.createElement('button')
+        cancelBtn.textContent = '✖ Cancel'
+        cancelBtn.classList.add('modal__btn', 'modal__btn--cancel')
+        cancelBtn.addEventListener('click', closeModal)
+
+        const btnGroup = document.createElement('div')
+        btnGroup.classList.add('modal__btn-group')
+        btnGroup.append(overwriteBtn, mergeBtn, cancelBtn)
+
+        modal.append(msg1, msg2, btnGroup)
+
+        async function applyFragment (overwrite) {
+          try {
+            if (cfgParam) {
+              const cfg = /** @type {DashboardConfig} */(await gunzipBase64urlToJson(cfgParam))
+              if (overwrite) {
+                localStorage.setItem('config', JSON.stringify(cfg))
+                if (Array.isArray(cfg.boards)) {
+                  localStorage.setItem('boards', JSON.stringify(cfg.boards))
+                } else {
+                  localStorage.removeItem('boards')
+                }
+              } else {
+                const existingCfgStr = localStorage.getItem('config')
+                const existingBoardsStr = localStorage.getItem('boards')
+                /** @type {DashboardConfig} */
+                const currentCfg = existingCfgStr ? JSON.parse(existingCfgStr) : {}
+                const currentBoards = existingBoardsStr ? JSON.parse(existingBoardsStr) : []
+                const mergedBoards = mergeBoards(currentBoards, cfg.boards || [])
+                currentCfg.boards = mergedBoards
+                currentCfg.globalSettings = currentCfg.globalSettings || cfg.globalSettings
+                localStorage.setItem('config', JSON.stringify(currentCfg))
+                localStorage.setItem('boards', JSON.stringify(mergedBoards))
+              }
+            }
+
+            if (svcParam) {
+              const svc = /** @type {Array<Service>} */(await gunzipBase64urlToJson(svcParam))
+              if (overwrite) {
+                localStorage.setItem('services', JSON.stringify(svc))
+              } else {
+                const existingStr = localStorage.getItem('services')
+                const existing = existingStr ? JSON.parse(existingStr) : []
+                const merged = mergeServices(existing, svc)
+                localStorage.setItem('services', JSON.stringify(merged))
+              }
+            }
+          } catch (e) {
+            logger.error('Error applying fragment:', e)
+          } finally {
+            closeModal()
+            setTimeout(() => location.reload(), 200)
+          }
+        }
+      }
+    })
+  })
+}

--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,9 @@ window.asd = {
 
 document.addEventListener('DOMContentLoaded', async () => {
   logger.log('DOMContentLoaded event fired')
-  await loadFromFragment()
+  const params = new URLSearchParams(location.search)
+  const force = params.get('force') === 'true'
+  await loadFromFragment(force)
   initializeMainMenu()
   fetchServices()
   try {

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -7,7 +7,7 @@ menu {
 #controls {
     display: flex;
     justify-content: center;
-    gap: 1rem;
+    gap: 0.5rem;
     padding: 0.5rem; 
     background-color: #fff;
     z-index: 1001;
@@ -19,6 +19,8 @@ menu {
     display: flex;
     flex-direction: row; /* Horizontal alignment */
     align-items: center;
+    flex-wrap: wrap;
+    justify-content: space-between;
     gap: 0.3rem; /* Minimize spacing between elements */
     padding: 0.3rem;
     border-radius: 8px;

--- a/src/utils/compression.js
+++ b/src/utils/compression.js
@@ -7,6 +7,8 @@
 
 /**
  * Base64url encode a byte array.
+ *
+ * @function base64UrlEncode
  * @param {Uint8Array} bytes
  * @returns {string}
  */
@@ -21,6 +23,8 @@ function base64UrlEncode (bytes) {
 
 /**
  * Decode a base64url string to bytes.
+ *
+ * @function base64UrlDecode
  * @param {string} str
  * @returns {Uint8Array}
  */
@@ -37,6 +41,8 @@ function base64UrlDecode (str) {
 
 /**
  * Gzip a JavaScript object and encode it as base64url.
+ *
+ * @function gzipJsonToBase64url
  * @param {object} obj
  * @returns {Promise<string>}
  */
@@ -57,6 +63,8 @@ export async function gzipJsonToBase64url (obj) {
 
 /**
  * Decode and gunzip a base64url string to a JavaScript object.
+ *
+ * @function gunzipBase64urlToJson
  * @param {string} str
  * @returns {Promise<object>}
  */
@@ -73,3 +81,21 @@ export async function gunzipBase64urlToJson (str) {
   }
   return JSON.parse(text)
 }
+
+/**
+ * Convenience wrapper for encoding dashboard configuration objects.
+ *
+ * @function encodeConfig
+ * @param {object} cfg
+ * @returns {Promise<string>}
+ */
+export const encodeConfig = gzipJsonToBase64url
+
+/**
+ * Convenience wrapper for decoding dashboard configuration objects.
+ *
+ * @function decodeConfig
+ * @param {string} str
+ * @returns {Promise<object>}
+ */
+export const decodeConfig = gunzipBase64urlToJson

--- a/src/utils/compression.js
+++ b/src/utils/compression.js
@@ -1,0 +1,75 @@
+// @ts-check
+/**
+ * Utility functions for gzip compression and base64url encoding.
+ *
+ * @module compression
+ */
+
+/**
+ * Base64url encode a byte array.
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+function base64UrlEncode (bytes) {
+  let binary = ''
+  bytes.forEach(b => { binary += String.fromCharCode(b) })
+  const b64 = typeof btoa === 'function'
+    ? btoa(binary)
+    : Buffer.from(binary, 'binary').toString('base64')
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * Decode a base64url string to bytes.
+ * @param {string} str
+ * @returns {Uint8Array}
+ */
+function base64UrlDecode (str) {
+  const pad = '===='.slice(0, (4 - str.length % 4) % 4)
+  const b64 = str.replace(/-/g, '+').replace(/_/g, '/') + pad
+  const binary = typeof atob === 'function'
+    ? atob(b64)
+    : Buffer.from(b64, 'base64').toString('binary')
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+/**
+ * Gzip a JavaScript object and encode it as base64url.
+ * @param {object} obj
+ * @returns {Promise<string>}
+ */
+export async function gzipJsonToBase64url (obj) {
+  const json = JSON.stringify(obj)
+  let bytes
+  if (typeof CompressionStream !== 'undefined') {
+    const cs = new CompressionStream('gzip')
+    const stream = new Blob([json]).stream().pipeThrough(cs)
+    const buffer = await new Response(stream).arrayBuffer()
+    bytes = new Uint8Array(buffer)
+  } else {
+    const zlib = await import('zlib')
+    bytes = zlib.gzipSync(Buffer.from(json))
+  }
+  return base64UrlEncode(bytes)
+}
+
+/**
+ * Decode and gunzip a base64url string to a JavaScript object.
+ * @param {string} str
+ * @returns {Promise<object>}
+ */
+export async function gunzipBase64urlToJson (str) {
+  const bytes = base64UrlDecode(str)
+  let text
+  if (typeof DecompressionStream !== 'undefined') {
+    const ds = new DecompressionStream('gzip')
+    const stream = new Blob([bytes]).stream().pipeThrough(ds)
+    text = await new Response(stream).text()
+  } else {
+    const zlib = await import('zlib')
+    text = zlib.gunzipSync(Buffer.from(bytes)).toString()
+  }
+  return JSON.parse(text)
+}

--- a/src/utils/fragmentGuard.js
+++ b/src/utils/fragmentGuard.js
@@ -1,0 +1,10 @@
+// @ts-check
+/**
+ * Remove any #cfg or #svc fragment from the current URL, without triggering a reload.
+ */
+export function clearConfigFragment () {
+  if (location.hash.includes('cfg=') || location.hash.includes('svc=')) {
+    window.history.replaceState(null, '', location.pathname + location.search)
+    console.info('🔁 Cleared #cfg/#svc fragment from URL to prevent stale overwrite')
+  }
+}

--- a/src/utils/fragmentGuard.js
+++ b/src/utils/fragmentGuard.js
@@ -1,6 +1,10 @@
 // @ts-check
 /**
- * Remove any #cfg or #svc fragment from the current URL, without triggering a reload.
+ * Remove any `#cfg` or `#svc` fragment from the current URL without triggering
+ * a reload.
+ *
+ * @function clearConfigFragment
+ * @returns {void}
  */
 export function clearConfigFragment () {
   if (location.hash.includes('cfg=') || location.hash.includes('svc=')) {

--- a/src/utils/fragmentLoader.js
+++ b/src/utils/fragmentLoader.js
@@ -39,8 +39,13 @@ export async function loadFromFragment (wasExplicitLoad = false) {
   const cfgParam = params.get('cfg')
   const svcParam = params.get('svc')
 
-  if (localStorage.getItem('config') && !wasExplicitLoad) {
-    console.warn('⚠️ Skipping fragment load: config already exists in storage')
+  const hasLocalData =
+    localStorage.getItem('config') ||
+    localStorage.getItem('services') ||
+    localStorage.getItem('boards')
+
+  if (hasLocalData && !wasExplicitLoad) {
+    console.warn('⚠️ Skipping fragment load: local data already exists')
     return
   }
 

--- a/src/utils/fragmentLoader.js
+++ b/src/utils/fragmentLoader.js
@@ -19,7 +19,13 @@ const logger = new Logger('fragmentLoader.js')
  * @function loadFromFragment
  * @returns {Promise<void>}
  */
-export async function loadFromFragment () {
+/**
+ * Load config/services from URL fragment into localStorage.
+ *
+ * @param {boolean} [wasExplicitLoad=false] - Skip guard when true.
+ * @returns {Promise<void>}
+ */
+export async function loadFromFragment (wasExplicitLoad = false) {
   if (!('DecompressionStream' in window)) {
     if (location.hash.includes('cfg=') || location.hash.includes('svc=')) {
       showNotification('⚠️ DecompressionStream niet ondersteund door deze browser.', 4000, 'error')
@@ -32,6 +38,11 @@ export async function loadFromFragment () {
   const params = new URLSearchParams(hash)
   const cfgParam = params.get('cfg')
   const svcParam = params.get('svc')
+
+  if (localStorage.getItem('config') && !wasExplicitLoad) {
+    console.warn('⚠️ Skipping fragment load: config already exists in storage')
+    return
+  }
 
   const base64UrlDecode = str => {
     const pad = '===='.slice(0, (4 - str.length % 4) % 4)

--- a/src/utils/fragmentLoader.js
+++ b/src/utils/fragmentLoader.js
@@ -10,6 +10,7 @@
 import { Logger } from './Logger.js'
 import { showNotification } from '../component/dialog/notification.js'
 import { gunzipBase64urlToJson } from './compression.js'
+import { openFragmentDecisionModal } from '../component/modal/fragmentDecisionModal.js'
 
 const logger = new Logger('fragmentLoader.js')
 
@@ -45,8 +46,8 @@ export async function loadFromFragment (wasExplicitLoad = false) {
     localStorage.getItem('services') ||
     localStorage.getItem('boards')
 
-  if (hasLocalData && !wasExplicitLoad) {
-    console.warn('⚠️ Skipping fragment load: local data already exists')
+  if ((cfgParam || svcParam) && hasLocalData && !wasExplicitLoad) {
+    await openFragmentDecisionModal(cfgParam, svcParam)
     return
   }
 

--- a/src/utils/merge.js
+++ b/src/utils/merge.js
@@ -1,0 +1,51 @@
+// @ts-check
+/**
+ * Helpers to merge arrays of boards or services.
+ *
+ * @module merge
+ */
+
+/** @typedef {import('../types.js').Board} Board */
+/** @typedef {import('../types.js').Service} Service */
+
+/**
+ * Merge board arrays by id.
+ *
+ * @param {Array<Board>} existingBoards
+ * @param {Array<Board>} newBoards
+ * @function mergeBoards
+ * @returns {Array<Board>}
+ */
+export function mergeBoards (existingBoards = [], newBoards = []) {
+  const merged = [...existingBoards]
+  const seen = new Set(existingBoards.map(b => b.id))
+  for (const board of newBoards) {
+    if (!seen.has(board.id)) {
+      merged.push(board)
+      seen.add(board.id)
+    }
+  }
+  return merged
+}
+
+/**
+ * Merge service arrays by unique url or id.
+ *
+ * @param {Array<Service>} existingServices
+ * @param {Array<Service>} newServices
+ * @function mergeServices
+ * @returns {Array<Service>}
+ */
+export function mergeServices (existingServices = [], newServices = []) {
+  const merged = [...existingServices]
+  const key = s => s.id || s.url
+  const seen = new Set(existingServices.map(key))
+  for (const svc of newServices) {
+    const k = key(svc)
+    if (!seen.has(k)) {
+      merged.push(svc)
+      seen.add(k)
+    }
+  }
+  return merged
+}

--- a/symbols.json
+++ b/symbols.json
@@ -659,30 +659,6 @@
     "returns": "void"
   },
   {
-    "name": "showNotification",
-    "kind": "function",
-    "file": "src/component/dialog/notification.js",
-    "description": "Display a temporary notification message.",
-    "params": [
-      {
-        "name": "message",
-        "type": "string",
-        "desc": "- Text content of the notification."
-      },
-      {
-        "name": "duration",
-        "type": "number",
-        "desc": "- How long to display the notification."
-      },
-      {
-        "name": "type",
-        "type": "('success'|'error')",
-        "desc": "- Visual style of the message."
-      }
-    ],
-    "returns": "void"
-  },
-  {
     "name": "initializeDashboardMenu",
     "kind": "function",
     "file": "src/component/menu/dashboardMenu.js",
@@ -712,6 +688,30 @@
     "file": "src/component/menu/menu.js",
     "description": "Create the main dashboard menu and insert it into the page.",
     "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "showNotification",
+    "kind": "function",
+    "file": "src/component/dialog/notification.js",
+    "description": "Display a temporary notification message.",
+    "params": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "- Text content of the notification."
+      },
+      {
+        "name": "duration",
+        "type": "number",
+        "desc": "- How long to display the notification."
+      },
+      {
+        "name": "type",
+        "type": "('success'|'error')",
+        "desc": "- Visual style of the message."
+      }
+    ],
     "returns": "void"
   },
   {

--- a/symbols.json
+++ b/symbols.json
@@ -197,6 +197,90 @@
     "returns": "void"
   },
   {
+    "name": "base64UrlEncode",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Base64url encode a byte array.",
+    "params": [
+      {
+        "name": "bytes",
+        "type": "Uint8Array",
+        "desc": ""
+      }
+    ],
+    "returns": "string"
+  },
+  {
+    "name": "base64UrlDecode",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Decode a base64url string to bytes.",
+    "params": [
+      {
+        "name": "str",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "Uint8Array"
+  },
+  {
+    "name": "gzipJsonToBase64url",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Gzip a JavaScript object and encode it as base64url.",
+    "params": [
+      {
+        "name": "obj",
+        "type": "object",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<string>"
+  },
+  {
+    "name": "gunzipBase64urlToJson",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Decode and gunzip a base64url string to a JavaScript object.",
+    "params": [
+      {
+        "name": "str",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<object>"
+  },
+  {
+    "name": "encodeConfig",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Convenience wrapper for encoding dashboard configuration objects.",
+    "params": [
+      {
+        "name": "cfg",
+        "type": "object",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<string>"
+  },
+  {
+    "name": "decodeConfig",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Convenience wrapper for decoding dashboard configuration objects.",
+    "params": [
+      {
+        "name": "str",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<object>"
+  },
+  {
     "name": "getCurrentBoardId",
     "kind": "function",
     "file": "src/utils/elements.js",
@@ -219,6 +303,14 @@
     "description": "Fetch the service list and update the service selector on the page.",
     "params": [],
     "returns": "Promise<Array<Service>>"
+  },
+  {
+    "name": "clearConfigFragment",
+    "kind": "function",
+    "file": "src/utils/fragmentGuard.js",
+    "description": "Remove any `#cfg` or `#svc` fragment from the current URL without triggering a reload.",
+    "params": [],
+    "returns": "void"
   },
   {
     "name": "loadFromFragment",

--- a/symbols.json
+++ b/symbols.json
@@ -337,6 +337,44 @@
     "returns": "string"
   },
   {
+    "name": "mergeBoards",
+    "kind": "function",
+    "file": "src/utils/merge.js",
+    "description": "Merge board arrays by id.",
+    "params": [
+      {
+        "name": "existingBoards",
+        "type": "Array<Board>",
+        "desc": ""
+      },
+      {
+        "name": "newBoards",
+        "type": "Array<Board>",
+        "desc": ""
+      }
+    ],
+    "returns": "Array<Board>"
+  },
+  {
+    "name": "mergeServices",
+    "kind": "function",
+    "file": "src/utils/merge.js",
+    "description": "Merge service arrays by unique url or id.",
+    "params": [
+      {
+        "name": "existingServices",
+        "type": "Array<Service>",
+        "desc": ""
+      },
+      {
+        "name": "newServices",
+        "type": "Array<Service>",
+        "desc": ""
+      }
+    ],
+    "returns": "Array<Service>"
+  },
+  {
     "name": "debounce",
     "kind": "function",
     "file": "src/utils/utils.js",
@@ -683,6 +721,25 @@
     "description": "Open a modal dialog allowing the user to edit and save configuration JSON.",
     "params": [],
     "returns": "void"
+  },
+  {
+    "name": "openFragmentDecisionModal",
+    "kind": "function",
+    "file": "src/component/modal/fragmentDecisionModal.js",
+    "description": "Display modal asking user to overwrite or merge fragment data.",
+    "params": [
+      {
+        "name": "cfgParam",
+        "type": "string|null",
+        "desc": "- Encoded config fragment."
+      },
+      {
+        "name": "svcParam",
+        "type": "string|null",
+        "desc": "- Encoded service fragment."
+      }
+    ],
+    "returns": "Promise<void>"
   },
   {
     "name": "openLocalStorageModal",

--- a/symbols.json
+++ b/symbols.json
@@ -1,214 +1,75 @@
 [
   {
-    "name": "saveWidgetState",
+    "name": "addBoardToUI",
     "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Serialize widgets in the current view and store them under the given board and view identifiers in localStorage. Each widget is saved with its order, dimensions, URL and any metadata/settings.",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Insert a board option into the board selector element. Also selects the board stored in localStorage if available.",
     "params": [
       {
-        "name": "boardId",
+        "name": "board",
+        "type": "{id: string, name: string}",
+        "desc": "- Board information to display."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "addDragOverlay",
+    "kind": "function",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Insert a transparent overlay to mark a widget as a drop target.",
+    "params": [
+      {
+        "name": "widgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- Widget element to overlay."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "addWidget",
+    "kind": "function",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Insert a widget into the current view and persist the layout.",
+    "params": [
+      {
+        "name": "url",
         "type": "string",
-        "desc": "- Board identifier. Defaults to the current board element id."
+        "desc": "- URL of the service to embed."
+      },
+      {
+        "name": "columns",
+        "type": "number",
+        "desc": "- Grid columns spanned by the widget."
+      },
+      {
+        "name": "rows",
+        "type": "number",
+        "desc": "- Grid rows spanned by the widget."
+      },
+      {
+        "name": "type",
+        "type": "string",
+        "desc": "- Widget type, usually 'iframe'."
+      },
+      {
+        "name": "boardId",
+        "type": "?string",
+        "desc": "- Board id; defaults to the active board."
       },
       {
         "name": "viewId",
-        "type": "string",
-        "desc": "- View identifier. Defaults to the current view element id."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Restore widget DOM elements for the specified board and view from localStorage. Widgets are recreated using {@link createWidget} and metadata and settings are re-applied.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Board identifier."
+        "type": "?string",
+        "desc": "- View id; defaults to the active view."
       },
       {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- View identifier whose widgets should be loaded."
+        "name": "dataid",
+        "type": "?string",
+        "desc": "- Persistent widget identifier."
       }
     ],
     "returns": "Promise<void>"
-  },
-  {
-    "name": "loadInitialConfig",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Store the initial board configuration defined in {@code window.asd.config} into localStorage. This is typically called on first run to seed the persistent board data.",
-    "params": [],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "saveBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Persist the entire boards array to localStorage under the key `boards`.",
-    "params": [
-      {
-        "name": "boards",
-        "type": "Array<Board>",
-        "desc": "- Array of board objects to store."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Retrieve the array of boards from localStorage. The result is also assigned to {@code window.asd.boards} for global access.",
-    "params": [],
-    "returns": "Promise<Array<Board>>"
-  },
-  {
-    "name": "Logger",
-    "kind": "class",
-    "file": "src/utils/Logger.js",
-    "description": "Simple browser console logger with runtime enable/disable support. During Playwright test runs (via `navigator.webdriver`), structured logs are also stored in `window._appLogs` for later harvesting.",
-    "params": [],
-    "returns": ""
-  },
-  {
-    "name": "checkLogStatus",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Check whether logging is enabled for the current file. Uses localStorage key `log` which may contain `'all'` or comma-separated filenames.",
-    "params": [],
-    "returns": "boolean"
-  },
-  {
-    "name": "getCallingFunctionName",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Extracts the function name of the caller (if available) from the stack trace.",
-    "params": [],
-    "returns": "string"
-  },
-  {
-    "name": "logMessage",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Internal log writer, applies prefixes and optionally persists structured logs into window._appLogs during Playwright test runs.",
-    "params": [
-      {
-        "name": "level",
-        "type": "string",
-        "desc": "- Console method to use ('log', 'warn', 'error', etc)"
-      },
-      {
-        "name": "args",
-        "type": "...any",
-        "desc": "- Arguments to log"
-      }
-    ],
-    "returns": ""
-  },
-  {
-    "name": "log",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Output standard log.",
-    "params": [
-      {
-        "name": "args",
-        "type": "...any",
-        "desc": ""
-      }
-    ],
-    "returns": ""
-  },
-  {
-    "name": "warn",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Output warning.",
-    "params": [
-      {
-        "name": "args",
-        "type": "...any",
-        "desc": ""
-      }
-    ],
-    "returns": ""
-  },
-  {
-    "name": "error",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Output error.",
-    "params": [
-      {
-        "name": "args",
-        "type": "...any",
-        "desc": ""
-      }
-    ],
-    "returns": ""
-  },
-  {
-    "name": "info",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Output info.",
-    "params": [
-      {
-        "name": "args",
-        "type": "...any",
-        "desc": ""
-      }
-    ],
-    "returns": ""
-  },
-  {
-    "name": "enableLogs",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Persist a comma-separated list of files to log or 'all'.",
-    "params": [
-      {
-        "name": "files",
-        "type": "string",
-        "desc": "- Files to enable logging for."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "disableLogs",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Disable all logging output.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "listLoggedFiles",
-    "kind": "function",
-    "file": "src/utils/Logger.js",
-    "description": "Print the list of files currently logging to the console.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "base64UrlEncode",
-    "kind": "function",
-    "file": "src/utils/compression.js",
-    "description": "Base64url encode a byte array.",
-    "params": [
-      {
-        "name": "bytes",
-        "type": "Uint8Array",
-        "desc": ""
-      }
-    ],
-    "returns": "string"
   },
   {
     "name": "base64UrlDecode",
@@ -225,84 +86,26 @@
     "returns": "Uint8Array"
   },
   {
-    "name": "gzipJsonToBase64url",
+    "name": "base64UrlEncode",
     "kind": "function",
     "file": "src/utils/compression.js",
-    "description": "Gzip a JavaScript object and encode it as base64url.",
+    "description": "Base64url encode a byte array.",
     "params": [
       {
-        "name": "obj",
-        "type": "object",
+        "name": "bytes",
+        "type": "Uint8Array",
         "desc": ""
       }
     ],
-    "returns": "Promise<string>"
-  },
-  {
-    "name": "gunzipBase64urlToJson",
-    "kind": "function",
-    "file": "src/utils/compression.js",
-    "description": "Decode and gunzip a base64url string to a JavaScript object.",
-    "params": [
-      {
-        "name": "str",
-        "type": "string",
-        "desc": ""
-      }
-    ],
-    "returns": "Promise<object>"
-  },
-  {
-    "name": "encodeConfig",
-    "kind": "function",
-    "file": "src/utils/compression.js",
-    "description": "Convenience wrapper for encoding dashboard configuration objects.",
-    "params": [
-      {
-        "name": "cfg",
-        "type": "object",
-        "desc": ""
-      }
-    ],
-    "returns": "Promise<string>"
-  },
-  {
-    "name": "decodeConfig",
-    "kind": "function",
-    "file": "src/utils/compression.js",
-    "description": "Convenience wrapper for decoding dashboard configuration objects.",
-    "params": [
-      {
-        "name": "str",
-        "type": "string",
-        "desc": ""
-      }
-    ],
-    "returns": "Promise<object>"
-  },
-  {
-    "name": "getCurrentBoardId",
-    "kind": "function",
-    "file": "src/utils/elements.js",
-    "description": "Get the id of the currently active board element.",
-    "params": [],
     "returns": "string"
   },
   {
-    "name": "getCurrentViewId",
+    "name": "checkLogStatus",
     "kind": "function",
-    "file": "src/utils/elements.js",
-    "description": "Get the id of the currently active view element.",
+    "file": "src/utils/Logger.js",
+    "description": "Check whether logging is enabled for the current file. Uses localStorage key `log` which may contain `'all'` or comma-separated filenames.",
     "params": [],
-    "returns": "string"
-  },
-  {
-    "name": "fetchServices",
-    "kind": "function",
-    "file": "src/utils/fetchServices.js",
-    "description": "Fetch the service list and update the service selector on the page.",
-    "params": [],
-    "returns": "Promise<Array<Service>>"
+    "returns": "boolean"
   },
   {
     "name": "clearConfigFragment",
@@ -311,135 +114,6 @@
     "description": "Remove any `#cfg` or `#svc` fragment from the current URL without triggering a reload.",
     "params": [],
     "returns": "void"
-  },
-  {
-    "name": "loadFromFragment",
-    "kind": "function",
-    "file": "src/utils/fragmentLoader.js",
-    "description": "Parse the URL fragment and store config/services in localStorage. Logs info on success and alerts on failure.",
-    "params": [],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "getConfig",
-    "kind": "function",
-    "file": "src/utils/getConfig.js",
-    "description": "Load and cache the dashboard configuration from multiple sources.",
-    "params": [],
-    "returns": "Promise<Object>"
-  },
-  {
-    "name": "getCurrentUrl",
-    "kind": "function",
-    "file": "src/utils/getCurrentUrl.js",
-    "description": "Return the base URL combined with the first path segment.",
-    "params": [],
-    "returns": "string"
-  },
-  {
-    "name": "mergeBoards",
-    "kind": "function",
-    "file": "src/utils/merge.js",
-    "description": "Merge board arrays by id.",
-    "params": [
-      {
-        "name": "existingBoards",
-        "type": "Array<Board>",
-        "desc": ""
-      },
-      {
-        "name": "newBoards",
-        "type": "Array<Board>",
-        "desc": ""
-      }
-    ],
-    "returns": "Array<Board>"
-  },
-  {
-    "name": "mergeServices",
-    "kind": "function",
-    "file": "src/utils/merge.js",
-    "description": "Merge service arrays by unique url or id.",
-    "params": [
-      {
-        "name": "existingServices",
-        "type": "Array<Service>",
-        "desc": ""
-      },
-      {
-        "name": "newServices",
-        "type": "Array<Service>",
-        "desc": ""
-      }
-    ],
-    "returns": "Array<Service>"
-  },
-  {
-    "name": "debounce",
-    "kind": "function",
-    "file": "src/utils/utils.js",
-    "description": "Create a debounced version of a function.",
-    "params": [
-      {
-        "name": "func",
-        "type": "Function",
-        "desc": "- Function to debounce."
-      },
-      {
-        "name": "wait",
-        "type": "number",
-        "desc": "- Delay in milliseconds."
-      }
-    ],
-    "returns": "Function"
-  },
-  {
-    "name": "getUUID",
-    "kind": "function",
-    "file": "src/utils/utils.js",
-    "description": "Generate a UUID using the browser crypto API when available.",
-    "params": [],
-    "returns": "string"
-  },
-  {
-    "name": "initializeBoardDropdown",
-    "kind": "function",
-    "file": "src/component/board/boardDropdown.js",
-    "description": "Attach dropdown actions for board management.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "handleCreateBoard",
-    "kind": "function",
-    "file": "src/component/board/boardDropdown.js",
-    "description": "Prompt the user for a board name and create it.",
-    "params": [],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "handleRenameBoard",
-    "kind": "function",
-    "file": "src/component/board/boardDropdown.js",
-    "description": "Prompt for a new name and rename the selected board.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "handleDeleteBoard",
-    "kind": "function",
-    "file": "src/component/board/boardDropdown.js",
-    "description": "Delete the currently selected board after confirmation.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "getSelectedBoardId",
-    "kind": "function",
-    "file": "src/component/board/boardDropdown.js",
-    "description": "Get the board id currently selected in the dropdown.",
-    "params": [],
-    "returns": "string"
   },
   {
     "name": "createBoard",
@@ -490,97 +164,71 @@
     "returns": "View|undefined"
   },
   {
-    "name": "switchView",
+    "name": "createWidget",
     "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Switch the currently active view within a board. Clears and repopulates the widget container and updates localStorage.",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Build the DOM structure for a widget iframe and its controls.",
     "params": [
       {
-        "name": "boardId",
+        "name": "service",
         "type": "string",
-        "desc": "- Identifier of the board containing the view."
+        "desc": "- Service identifier derived from the URL."
       },
       {
-        "name": "viewId",
+        "name": "url",
         "type": "string",
-        "desc": "- Identifier of the view to activate."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "updateViewSelector",
-    "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Populate the view selector dropdown for a given board. Reads the last used view from localStorage to preselect it.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Identifier of the board whose views will be shown."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "switchBoard",
-    "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Switch the current board and optionally a specific view. Updates DOM identifiers and remembers the selection in localStorage.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Identifier of the board to activate."
+        "desc": "- Iframe source URL."
       },
       {
-        "name": "viewId",
+        "name": "gridColumnSpan",
+        "type": "number",
+        "desc": "- Number of grid columns to span."
+      },
+      {
+        "name": "gridRowSpan",
+        "type": "number",
+        "desc": "- Number of grid rows to span."
+      },
+      {
+        "name": "dataid",
         "type": "?string",
-        "desc": "- Specific view id to load, defaults to first view."
+        "desc": "- Optional persistent widget identifier."
       }
     ],
-    "returns": "Promise<void>"
+    "returns": "Promise<HTMLDivElement>"
   },
   {
-    "name": "initializeBoards",
+    "name": "debounce",
     "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Load boards from localStorage and populate the selectors. Creates a default board when none exist and returns the first board/view.",
-    "params": [],
-    "returns": "Promise<{boardId: string, viewId: string}|undefined>"
-  },
-  {
-    "name": "addBoardToUI",
-    "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Insert a board option into the board selector element. Also selects the board stored in localStorage if available.",
+    "file": "src/utils/utils.js",
+    "description": "Create a debounced version of a function.",
     "params": [
       {
-        "name": "board",
-        "type": "{id: string, name: string}",
-        "desc": "- Board information to display."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "renameBoard",
-    "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Rename an existing board and persist the change.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Identifier of the board to rename."
+        "name": "func",
+        "type": "Function",
+        "desc": "- Function to debounce."
       },
       {
-        "name": "newBoardName",
-        "type": "string",
-        "desc": "- New name displayed to the user."
+        "name": "wait",
+        "type": "number",
+        "desc": "- Delay in milliseconds."
       }
     ],
-    "returns": "void"
+    "returns": "Function"
+  },
+  {
+    "name": "decodeConfig",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Convenience wrapper for decoding dashboard configuration objects.",
+    "params": [
+      {
+        "name": "str",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<object>"
   },
   {
     "name": "deleteBoard",
@@ -592,30 +240,6 @@
         "name": "boardId",
         "type": "string",
         "desc": "- Identifier of the board to delete."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "renameView",
-    "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Rename a view within a board and persist the update.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Board containing the view."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- Identifier of the view to rename."
-      },
-      {
-        "name": "newViewName",
-        "type": "string",
-        "desc": "- The new display name."
       }
     ],
     "returns": "void"
@@ -640,23 +264,404 @@
     "returns": "void"
   },
   {
-    "name": "resetView",
+    "name": "disableLogs",
     "kind": "function",
-    "file": "src/component/board/boardManagement.js",
-    "description": "Clear all widgets from a view and persist the empty state.",
+    "file": "src/utils/Logger.js",
+    "description": "Disable all logging output.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "enableLogs",
+    "kind": "function",
+    "file": "src/utils/Logger.js",
+    "description": "Persist a comma-separated list of files to log or 'all'.",
     "params": [
       {
-        "name": "boardId",
+        "name": "files",
         "type": "string",
-        "desc": "- Identifier of the board containing the view."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- Identifier of the view to reset."
+        "desc": "- Files to enable logging for."
       }
     ],
     "returns": "void"
+  },
+  {
+    "name": "encodeConfig",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Convenience wrapper for encoding dashboard configuration objects.",
+    "params": [
+      {
+        "name": "cfg",
+        "type": "object",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<string>"
+  },
+  {
+    "name": "error",
+    "kind": "function",
+    "file": "src/utils/Logger.js",
+    "description": "Output error.",
+    "params": [
+      {
+        "name": "args",
+        "type": "...any",
+        "desc": ""
+      }
+    ],
+    "returns": ""
+  },
+  {
+    "name": "fetchData",
+    "kind": "function",
+    "file": "src/component/widget/utils/fetchData.js",
+    "description": "Fetch JSON data from a URL and pass it to a callback.",
+    "params": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "- Endpoint to request."
+      },
+      {
+        "name": "callback",
+        "type": "Function",
+        "desc": "- Receives the parsed JSON."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "fetchServices",
+    "kind": "function",
+    "file": "src/component/widget/utils/fetchServices.js",
+    "description": "Retrieve the list of services from query params, localStorage or a default file.",
+    "params": [],
+    "returns": "Promise<Array>"
+  },
+  {
+    "name": "fetchServices",
+    "kind": "function",
+    "file": "src/utils/fetchServices.js",
+    "description": "Fetch the service list and update the service selector on the page.",
+    "params": [],
+    "returns": "Promise<Array<Service>>"
+  },
+  {
+    "name": "getAuthToken",
+    "kind": "function",
+    "file": "src/component/widget/utils/fetchData.js",
+    "description": "Retrieve the auth token for API requests.",
+    "params": [],
+    "returns": "string"
+  },
+  {
+    "name": "getCallingFunctionName",
+    "kind": "function",
+    "file": "src/utils/Logger.js",
+    "description": "Extracts the function name of the caller (if available) from the stack trace.",
+    "params": [],
+    "returns": "string"
+  },
+  {
+    "name": "getConfig",
+    "kind": "function",
+    "file": "src/utils/getConfig.js",
+    "description": "Load and cache the dashboard configuration from multiple sources.",
+    "params": [],
+    "returns": "Promise<Object>"
+  },
+  {
+    "name": "getCurrentBoardId",
+    "kind": "function",
+    "file": "src/utils/elements.js",
+    "description": "Get the id of the currently active board element.",
+    "params": [],
+    "returns": "string"
+  },
+  {
+    "name": "getCurrentUrl",
+    "kind": "function",
+    "file": "src/utils/getCurrentUrl.js",
+    "description": "Return the base URL combined with the first path segment.",
+    "params": [],
+    "returns": "string"
+  },
+  {
+    "name": "getCurrentViewId",
+    "kind": "function",
+    "file": "src/utils/elements.js",
+    "description": "Get the id of the currently active view element.",
+    "params": [],
+    "returns": "string"
+  },
+  {
+    "name": "getSelectedBoardId",
+    "kind": "function",
+    "file": "src/component/board/boardDropdown.js",
+    "description": "Get the board id currently selected in the dropdown.",
+    "params": [],
+    "returns": "string"
+  },
+  {
+    "name": "getServiceFromUrl",
+    "kind": "function",
+    "file": "src/component/widget/utils/widgetUtils.js",
+    "description": "Determine which service definition matches the provided URL.",
+    "params": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "- Widget URL."
+      }
+    ],
+    "returns": "Promise<string>"
+  },
+  {
+    "name": "getUUID",
+    "kind": "function",
+    "file": "src/utils/utils.js",
+    "description": "Generate a UUID using the browser crypto API when available.",
+    "params": [],
+    "returns": "string"
+  },
+  {
+    "name": "gunzipBase64urlToJson",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Decode and gunzip a base64url string to a JavaScript object.",
+    "params": [
+      {
+        "name": "str",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<object>"
+  },
+  {
+    "name": "gzipJsonToBase64url",
+    "kind": "function",
+    "file": "src/utils/compression.js",
+    "description": "Gzip a JavaScript object and encode it as base64url.",
+    "params": [
+      {
+        "name": "obj",
+        "type": "object",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<string>"
+  },
+  {
+    "name": "handleCreateBoard",
+    "kind": "function",
+    "file": "src/component/board/boardDropdown.js",
+    "description": "Prompt the user for a board name and create it.",
+    "params": [],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "handleCreateView",
+    "kind": "function",
+    "file": "src/component/view/viewDropdown.js",
+    "description": "Create a new view on the active board.",
+    "params": [],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "handleDeleteBoard",
+    "kind": "function",
+    "file": "src/component/board/boardDropdown.js",
+    "description": "Delete the currently selected board after confirmation.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "handleDeleteView",
+    "kind": "function",
+    "file": "src/component/view/viewDropdown.js",
+    "description": "Delete the active view after confirmation.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "handleDragEnd",
+    "kind": "function",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Clean up after a drag operation ends.",
+    "params": [
+      {
+        "name": "e",
+        "type": "DragEvent",
+        "desc": "- The dragend event."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "handleDragLeave",
+    "kind": "function",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Remove highlighting when a dragged item leaves a widget.",
+    "params": [
+      {
+        "name": "e",
+        "type": "DragEvent",
+        "desc": "- The dragleave event."
+      },
+      {
+        "name": "widgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- Widget that lost drag focus."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "handleDragOver",
+    "kind": "function",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Highlight a widget as a potential drop target.",
+    "params": [
+      {
+        "name": "e",
+        "type": "DragEvent",
+        "desc": "- The dragover event."
+      },
+      {
+        "name": "widgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- The widget element hovered over."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "handleDragStart",
+    "kind": "function",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Begin dragging a widget by setting up transfer data and overlays.",
+    "params": [
+      {
+        "name": "e",
+        "type": "DragEvent",
+        "desc": "- The dragstart event."
+      },
+      {
+        "name": "draggedWidgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- The widget being dragged."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "handleDrop",
+    "kind": "function",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Drop handler to rearrange widgets or reposition them on the grid.",
+    "params": [
+      {
+        "name": "e",
+        "type": "DragEvent",
+        "desc": "- The drop event."
+      },
+      {
+        "name": "targetWidgetWrapper",
+        "type": "?HTMLElement",
+        "desc": "- Widget wrapper receiving the drop or null."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "handleEscapeKey",
+    "kind": "function",
+    "file": "src/component/widget/events/fullscreenToggle.js",
+    "description": "Exit fullscreen when the user presses the Escape key.",
+    "params": [
+      {
+        "name": "event",
+        "type": "KeyboardEvent",
+        "desc": "- Keydown event."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "handleRenameBoard",
+    "kind": "function",
+    "file": "src/component/board/boardDropdown.js",
+    "description": "Prompt for a new name and rename the selected board.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "handleRenameView",
+    "kind": "function",
+    "file": "src/component/view/viewDropdown.js",
+    "description": "Rename the currently selected view.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "handleResetView",
+    "kind": "function",
+    "file": "src/component/view/viewDropdown.js",
+    "description": "Remove all widgets from the current view.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "handleResizeStart",
+    "kind": "function",
+    "file": "src/component/widget/events/resizeHandler.js",
+    "description": "Start tracking mouse movement for resizing a widget.",
+    "params": [
+      {
+        "name": "event",
+        "type": "MouseEvent",
+        "desc": "- Mousedown event that initiated resize."
+      },
+      {
+        "name": "widget",
+        "type": "HTMLElement",
+        "desc": "- The widget element being resized."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "info",
+    "kind": "function",
+    "file": "src/utils/Logger.js",
+    "description": "Output info.",
+    "params": [
+      {
+        "name": "args",
+        "type": "...any",
+        "desc": ""
+      }
+    ],
+    "returns": ""
+  },
+  {
+    "name": "initializeBoardDropdown",
+    "kind": "function",
+    "file": "src/component/board/boardDropdown.js",
+    "description": "Attach dropdown actions for board management.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "initializeBoards",
+    "kind": "function",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Load boards from localStorage and populate the selectors. Creates a default board when none exist and returns the first board/view.",
+    "params": [],
+    "returns": "Promise<{boardId: string, viewId: string}|undefined>"
   },
   {
     "name": "initializeDashboardMenu",
@@ -667,10 +672,53 @@
     "returns": "void"
   },
   {
-    "name": "populateServiceDropdown",
+    "name": "initializeDragAndDrop",
     "kind": "function",
-    "file": "src/component/menu/dashboardMenu.js",
-    "description": "Populate the service drop-down with saved services.",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Enable drag-and-drop events on the widget container.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "initializeDropdown",
+    "kind": "function",
+    "file": "src/component/utils/dropDownUtils.js",
+    "description": "Attach click handlers to a dropdown based on data-action attributes.",
+    "params": [
+      {
+        "name": "dropdownElement",
+        "type": "HTMLElement",
+        "desc": "- The dropdown container element."
+      },
+      {
+        "name": "handlers",
+        "type": "Object<string,Function>",
+        "desc": "- Map of action names to callbacks."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "initializeMainMenu",
+    "kind": "function",
+    "file": "src/component/menu/menu.js",
+    "description": "Create the main dashboard menu and insert it into the page.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "initializeResizeHandles",
+    "kind": "function",
+    "file": "src/component/widget/events/resizeHandler.js",
+    "description": "Append resize handles to all widgets and register listeners.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "initializeViewDropdown",
+    "kind": "function",
+    "file": "src/component/view/viewDropdown.js",
+    "description": "Set up the dropdown used for view management actions.",
     "params": [],
     "returns": "void"
   },
@@ -683,36 +731,134 @@
     "returns": "void"
   },
   {
-    "name": "initializeMainMenu",
+    "name": "listLoggedFiles",
     "kind": "function",
-    "file": "src/component/menu/menu.js",
-    "description": "Create the main dashboard menu and insert it into the page.",
+    "file": "src/utils/Logger.js",
+    "description": "Print the list of files currently logging to the console.",
     "params": [],
     "returns": "void"
   },
   {
-    "name": "showNotification",
+    "name": "loadBoardState",
     "kind": "function",
-    "file": "src/component/dialog/notification.js",
-    "description": "Display a temporary notification message.",
+    "file": "src/storage/localStorage.js",
+    "description": "Retrieve the array of boards from localStorage. The result is also assigned to {@code window.asd.boards} for global access.",
+    "params": [],
+    "returns": "Promise<Array<Board>>"
+  },
+  {
+    "name": "loadFromFragment",
+    "kind": "function",
+    "file": "src/utils/fragmentLoader.js",
+    "description": "Parse the URL fragment and store config/services in localStorage. Logs info on success and alerts on failure.",
+    "params": [],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadInitialConfig",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Store the initial board configuration defined in {@code window.asd.config} into localStorage. This is typically called on first run to seed the persistent board data.",
+    "params": [],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "loadWidgetState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Restore widget DOM elements for the specified board and view from localStorage. Widgets are recreated using {@link createWidget} and metadata and settings are re-applied.",
     "params": [
       {
-        "name": "message",
+        "name": "boardId",
         "type": "string",
-        "desc": "- Text content of the notification."
+        "desc": "- Board identifier."
       },
       {
-        "name": "duration",
-        "type": "number",
-        "desc": "- How long to display the notification."
-      },
-      {
-        "name": "type",
-        "type": "('success'|'error')",
-        "desc": "- Visual style of the message."
+        "name": "viewId",
+        "type": "string",
+        "desc": "- View identifier whose widgets should be loaded."
       }
     ],
-    "returns": "void"
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "log",
+    "kind": "function",
+    "file": "src/utils/Logger.js",
+    "description": "Output standard log.",
+    "params": [
+      {
+        "name": "args",
+        "type": "...any",
+        "desc": ""
+      }
+    ],
+    "returns": ""
+  },
+  {
+    "name": "Logger",
+    "kind": "class",
+    "file": "src/utils/Logger.js",
+    "description": "Simple browser console logger with runtime enable/disable support. During Playwright test runs (via `navigator.webdriver`), structured logs are also stored in `window._appLogs` for later harvesting.",
+    "params": [],
+    "returns": ""
+  },
+  {
+    "name": "logMessage",
+    "kind": "function",
+    "file": "src/utils/Logger.js",
+    "description": "Internal log writer, applies prefixes and optionally persists structured logs into window._appLogs during Playwright test runs.",
+    "params": [
+      {
+        "name": "level",
+        "type": "string",
+        "desc": "- Console method to use ('log', 'warn', 'error', etc)"
+      },
+      {
+        "name": "args",
+        "type": "...any",
+        "desc": "- Arguments to log"
+      }
+    ],
+    "returns": ""
+  },
+  {
+    "name": "mergeBoards",
+    "kind": "function",
+    "file": "src/utils/merge.js",
+    "description": "Merge board arrays by id.",
+    "params": [
+      {
+        "name": "existingBoards",
+        "type": "Array<Board>",
+        "desc": ""
+      },
+      {
+        "name": "newBoards",
+        "type": "Array<Board>",
+        "desc": ""
+      }
+    ],
+    "returns": "Array<Board>"
+  },
+  {
+    "name": "mergeServices",
+    "kind": "function",
+    "file": "src/utils/merge.js",
+    "description": "Merge service arrays by unique url or id.",
+    "params": [
+      {
+        "name": "existingServices",
+        "type": "Array<Service>",
+        "desc": ""
+      },
+      {
+        "name": "newServices",
+        "type": "Array<Service>",
+        "desc": ""
+      }
+    ],
+    "returns": "Array<Service>"
   },
   {
     "name": "openConfigModal",
@@ -803,6 +949,161 @@
     "returns": "void"
   },
   {
+    "name": "populateServiceDropdown",
+    "kind": "function",
+    "file": "src/component/menu/dashboardMenu.js",
+    "description": "Populate the service drop-down with saved services.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "removeDragOverlay",
+    "kind": "function",
+    "file": "src/component/widget/events/dragDrop.js",
+    "description": "Remove the overlay from a widget wrapper if present.",
+    "params": [
+      {
+        "name": "widgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- Widget element to clean up."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "removeWidget",
+    "kind": "function",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Remove a widget from the DOM and update ordering information. Persist the resulting widget layout using {@link saveWidgetState}.",
+    "params": [
+      {
+        "name": "widgetElement",
+        "type": "HTMLElement",
+        "desc": "- Wrapper element to remove."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "renameBoard",
+    "kind": "function",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Rename an existing board and persist the change.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Identifier of the board to rename."
+      },
+      {
+        "name": "newBoardName",
+        "type": "string",
+        "desc": "- New name displayed to the user."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "renameView",
+    "kind": "function",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Rename a view within a board and persist the update.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Board containing the view."
+      },
+      {
+        "name": "viewId",
+        "type": "string",
+        "desc": "- Identifier of the view to rename."
+      },
+      {
+        "name": "newViewName",
+        "type": "string",
+        "desc": "- The new display name."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "resetView",
+    "kind": "function",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Clear all widgets from a view and persist the empty state.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Identifier of the board containing the view."
+      },
+      {
+        "name": "viewId",
+        "type": "string",
+        "desc": "- Identifier of the view to reset."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "saveBoardState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Persist the entire boards array to localStorage under the key `boards`.",
+    "params": [
+      {
+        "name": "boards",
+        "type": "Array<Board>",
+        "desc": "- Array of board objects to store."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "saveWidgetState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Serialize widgets in the current view and store them under the given board and view identifiers in localStorage. Each widget is saved with its order, dimensions, URL and any metadata/settings.",
+    "params": [
+      {
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Board identifier. Defaults to the current board element id."
+      },
+      {
+        "name": "viewId",
+        "type": "string",
+        "desc": "- View identifier. Defaults to the current view element id."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "showNotification",
+    "kind": "function",
+    "file": "src/component/dialog/notification.js",
+    "description": "Display a temporary notification message.",
+    "params": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "- Text content of the notification."
+      },
+      {
+        "name": "duration",
+        "type": "number",
+        "desc": "- How long to display the notification."
+      },
+      {
+        "name": "type",
+        "type": "('success'|'error')",
+        "desc": "- Visual style of the message."
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "showServiceModal",
     "kind": "function",
     "file": "src/component/modal/serviceLaunchModal.js",
@@ -822,289 +1123,42 @@
     "returns": "void"
   },
   {
-    "name": "initializeDropdown",
+    "name": "switchBoard",
     "kind": "function",
-    "file": "src/component/utils/dropDownUtils.js",
-    "description": "Attach click handlers to a dropdown based on data-action attributes.",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Switch the current board and optionally a specific view. Updates DOM identifiers and remembers the selection in localStorage.",
     "params": [
-      {
-        "name": "dropdownElement",
-        "type": "HTMLElement",
-        "desc": "- The dropdown container element."
-      },
-      {
-        "name": "handlers",
-        "type": "Object<string,Function>",
-        "desc": "- Map of action names to callbacks."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "initializeViewDropdown",
-    "kind": "function",
-    "file": "src/component/view/viewDropdown.js",
-    "description": "Set up the dropdown used for view management actions.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "handleCreateView",
-    "kind": "function",
-    "file": "src/component/view/viewDropdown.js",
-    "description": "Create a new view on the active board.",
-    "params": [],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "handleRenameView",
-    "kind": "function",
-    "file": "src/component/view/viewDropdown.js",
-    "description": "Rename the currently selected view.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "handleDeleteView",
-    "kind": "function",
-    "file": "src/component/view/viewDropdown.js",
-    "description": "Delete the active view after confirmation.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "handleResetView",
-    "kind": "function",
-    "file": "src/component/view/viewDropdown.js",
-    "description": "Remove all widgets from the current view.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "createWidget",
-    "kind": "function",
-    "file": "src/component/widget/widgetManagement.js",
-    "description": "Build the DOM structure for a widget iframe and its controls.",
-    "params": [
-      {
-        "name": "service",
-        "type": "string",
-        "desc": "- Service identifier derived from the URL."
-      },
-      {
-        "name": "url",
-        "type": "string",
-        "desc": "- Iframe source URL."
-      },
-      {
-        "name": "gridColumnSpan",
-        "type": "number",
-        "desc": "- Number of grid columns to span."
-      },
-      {
-        "name": "gridRowSpan",
-        "type": "number",
-        "desc": "- Number of grid rows to span."
-      },
-      {
-        "name": "dataid",
-        "type": "?string",
-        "desc": "- Optional persistent widget identifier."
-      }
-    ],
-    "returns": "Promise<HTMLDivElement>"
-  },
-  {
-    "name": "addWidget",
-    "kind": "function",
-    "file": "src/component/widget/widgetManagement.js",
-    "description": "Insert a widget into the current view and persist the layout.",
-    "params": [
-      {
-        "name": "url",
-        "type": "string",
-        "desc": "- URL of the service to embed."
-      },
-      {
-        "name": "columns",
-        "type": "number",
-        "desc": "- Grid columns spanned by the widget."
-      },
-      {
-        "name": "rows",
-        "type": "number",
-        "desc": "- Grid rows spanned by the widget."
-      },
-      {
-        "name": "type",
-        "type": "string",
-        "desc": "- Widget type, usually 'iframe'."
-      },
       {
         "name": "boardId",
-        "type": "?string",
-        "desc": "- Board id; defaults to the active board."
+        "type": "string",
+        "desc": "- Identifier of the board to activate."
       },
       {
         "name": "viewId",
         "type": "?string",
-        "desc": "- View id; defaults to the active view."
-      },
-      {
-        "name": "dataid",
-        "type": "?string",
-        "desc": "- Persistent widget identifier."
+        "desc": "- Specific view id to load, defaults to first view."
       }
     ],
     "returns": "Promise<void>"
   },
   {
-    "name": "removeWidget",
+    "name": "switchView",
     "kind": "function",
-    "file": "src/component/widget/widgetManagement.js",
-    "description": "Remove a widget from the DOM and update ordering information. Persist the resulting widget layout using {@link saveWidgetState}.",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Switch the currently active view within a board. Clears and repopulates the widget container and updates localStorage.",
     "params": [
       {
-        "name": "widgetElement",
-        "type": "HTMLElement",
-        "desc": "- Wrapper element to remove."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "updateWidgetOrders",
-    "kind": "function",
-    "file": "src/component/widget/widgetManagement.js",
-    "description": "Recompute and store the ordering of widgets in the container. Saves the updated arrangement via {@link saveWidgetState}.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "handleDragStart",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Begin dragging a widget by setting up transfer data and overlays.",
-    "params": [
-      {
-        "name": "e",
-        "type": "DragEvent",
-        "desc": "- The dragstart event."
+        "name": "boardId",
+        "type": "string",
+        "desc": "- Identifier of the board containing the view."
       },
       {
-        "name": "draggedWidgetWrapper",
-        "type": "HTMLElement",
-        "desc": "- The widget being dragged."
+        "name": "viewId",
+        "type": "string",
+        "desc": "- Identifier of the view to activate."
       }
     ],
-    "returns": "void"
-  },
-  {
-    "name": "handleDragEnd",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Clean up after a drag operation ends.",
-    "params": [
-      {
-        "name": "e",
-        "type": "DragEvent",
-        "desc": "- The dragend event."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "addDragOverlay",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Insert a transparent overlay to mark a widget as a drop target.",
-    "params": [
-      {
-        "name": "widgetWrapper",
-        "type": "HTMLElement",
-        "desc": "- Widget element to overlay."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "removeDragOverlay",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Remove the overlay from a widget wrapper if present.",
-    "params": [
-      {
-        "name": "widgetWrapper",
-        "type": "HTMLElement",
-        "desc": "- Widget element to clean up."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "handleDrop",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Drop handler to rearrange widgets or reposition them on the grid.",
-    "params": [
-      {
-        "name": "e",
-        "type": "DragEvent",
-        "desc": "- The drop event."
-      },
-      {
-        "name": "targetWidgetWrapper",
-        "type": "?HTMLElement",
-        "desc": "- Widget wrapper receiving the drop or null."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "handleDragOver",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Highlight a widget as a potential drop target.",
-    "params": [
-      {
-        "name": "e",
-        "type": "DragEvent",
-        "desc": "- The dragover event."
-      },
-      {
-        "name": "widgetWrapper",
-        "type": "HTMLElement",
-        "desc": "- The widget element hovered over."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "handleDragLeave",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Remove highlighting when a dragged item leaves a widget.",
-    "params": [
-      {
-        "name": "e",
-        "type": "DragEvent",
-        "desc": "- The dragleave event."
-      },
-      {
-        "name": "widgetWrapper",
-        "type": "HTMLElement",
-        "desc": "- Widget that lost drag focus."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "initializeDragAndDrop",
-    "kind": "function",
-    "file": "src/component/widget/events/dragDrop.js",
-    "description": "Enable drag-and-drop events on the widget container.",
-    "params": [],
-    "returns": "void"
+    "returns": "Promise<void>"
   },
   {
     "name": "toggleFullScreen",
@@ -1121,93 +1175,39 @@
     "returns": "void"
   },
   {
-    "name": "handleEscapeKey",
+    "name": "updateViewSelector",
     "kind": "function",
-    "file": "src/component/widget/events/fullscreenToggle.js",
-    "description": "Exit fullscreen when the user presses the Escape key.",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Populate the view selector dropdown for a given board. Reads the last used view from localStorage to preselect it.",
     "params": [
       {
-        "name": "event",
-        "type": "KeyboardEvent",
-        "desc": "- Keydown event."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "initializeResizeHandles",
-    "kind": "function",
-    "file": "src/component/widget/events/resizeHandler.js",
-    "description": "Append resize handles to all widgets and register listeners.",
-    "params": [],
-    "returns": "void"
-  },
-  {
-    "name": "handleResizeStart",
-    "kind": "function",
-    "file": "src/component/widget/events/resizeHandler.js",
-    "description": "Start tracking mouse movement for resizing a widget.",
-    "params": [
-      {
-        "name": "event",
-        "type": "MouseEvent",
-        "desc": "- Mousedown event that initiated resize."
-      },
-      {
-        "name": "widget",
-        "type": "HTMLElement",
-        "desc": "- The widget element being resized."
-      }
-    ],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "fetchData",
-    "kind": "function",
-    "file": "src/component/widget/utils/fetchData.js",
-    "description": "Fetch JSON data from a URL and pass it to a callback.",
-    "params": [
-      {
-        "name": "url",
+        "name": "boardId",
         "type": "string",
-        "desc": "- Endpoint to request."
-      },
-      {
-        "name": "callback",
-        "type": "Function",
-        "desc": "- Receives the parsed JSON."
+        "desc": "- Identifier of the board whose views will be shown."
       }
     ],
     "returns": "void"
   },
   {
-    "name": "getAuthToken",
+    "name": "updateWidgetOrders",
     "kind": "function",
-    "file": "src/component/widget/utils/fetchData.js",
-    "description": "Retrieve the auth token for API requests.",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Recompute and store the ordering of widgets in the container. Saves the updated arrangement via {@link saveWidgetState}.",
     "params": [],
-    "returns": "string"
+    "returns": "void"
   },
   {
-    "name": "fetchServices",
+    "name": "warn",
     "kind": "function",
-    "file": "src/component/widget/utils/fetchServices.js",
-    "description": "Retrieve the list of services from query params, localStorage or a default file.",
-    "params": [],
-    "returns": "Promise<Array>"
-  },
-  {
-    "name": "getServiceFromUrl",
-    "kind": "function",
-    "file": "src/component/widget/utils/widgetUtils.js",
-    "description": "Determine which service definition matches the provided URL.",
+    "file": "src/utils/Logger.js",
+    "description": "Output warning.",
     "params": [
       {
-        "name": "url",
-        "type": "string",
-        "desc": "- Widget URL."
+        "name": "args",
+        "type": "...any",
+        "desc": ""
       }
     ],
-    "returns": "Promise<string>"
+    "returns": ""
   }
 ]

--- a/tests/fragmentLoader.spec.ts
+++ b/tests/fragmentLoader.spec.ts
@@ -20,16 +20,49 @@ test('loads config and services from URL fragment', async ({ page }) => {
 
 test('fragment data is not reapplied if localStorage already has data', async ({ page }) => {
   const cfg = await encode(ciConfig)
-  await page.goto(`/#cfg=${cfg}`)
-  await page.waitForLoadState('domcontentloaded')
 
-  await page.evaluate(() => {
+  await page.addInitScript(() => {
     localStorage.setItem('config', JSON.stringify({ globalSettings: { theme: 'dark' } }))
     localStorage.setItem('services', JSON.stringify([]))
     localStorage.setItem('boards', JSON.stringify([]))
   })
 
   await page.goto(`/#cfg=${cfg}`)
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForSelector('#fragment-decision-modal', { timeout: 5000 })
+  const modal = page.locator('#fragment-decision-modal')
+  await expect(modal).toBeVisible()
+  await modal.locator('button:has-text("Cancel")').click()
+  await expect(modal).toBeHidden()
+
+  const theme = await page.evaluate(() => JSON.parse(localStorage.getItem('config') || '{}').globalSettings.theme)
+  expect(theme).toBe('dark')
+})
+
+test('shows merge decision modal when local data exists', async ({ page }) => {
+  const cfg = await encode(ciConfig)
+  const svc = await encode(ciServices)
+
+  await page.addInitScript(value => {
+    localStorage.setItem('config', JSON.stringify(value.config))
+    localStorage.setItem('services', JSON.stringify(value.services))
+    localStorage.setItem('boards', JSON.stringify(value.boards))
+  }, {
+    config: { globalSettings: { theme: 'dark' } },
+    services: [{ name: 'Old', url: 'http://localhost/old' }],
+    boards: [{ id: 'b1', name: 'Board 1', order: 0, views: [] }]
+  })
+
+  await page.goto(`/#cfg=${cfg}&svc=${svc}`)
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForSelector('#fragment-decision-modal', { timeout: 5000 })
+  const modal = page.locator('#fragment-decision-modal')
+  await expect(modal).toBeVisible()
+  await expect(modal).toContainText('What would you like to do?')
+
+  await modal.locator('button:has-text("Cancel")').click()
+  await expect(modal).toBeHidden()
+
   const theme = await page.evaluate(() => JSON.parse(localStorage.getItem('config') || '{}').globalSettings.theme)
   expect(theme).toBe('dark')
 })

--- a/tests/fragmentLoader.spec.ts
+++ b/tests/fragmentLoader.spec.ts
@@ -19,3 +19,19 @@ test('loads config and services from URL fragment', async ({ page }) => {
   expect(config.globalSettings.theme).toBe(ciConfig.globalSettings.theme)
   expect(services.length).toBe(ciServices.length)
 })
+
+test('fragment data is not reapplied if localStorage already has data', async ({ page }) => {
+  const cfg = encode(ciConfig)
+  await page.goto(`/#cfg=${cfg}`)
+  await page.waitForLoadState('domcontentloaded')
+
+  await page.evaluate(() => {
+    localStorage.setItem('config', JSON.stringify({ globalSettings: { theme: 'dark' } }))
+    localStorage.setItem('services', JSON.stringify([]))
+    localStorage.setItem('boards', JSON.stringify([]))
+  })
+
+  await page.goto(`/#cfg=${cfg}`)
+  const theme = await page.evaluate(() => JSON.parse(localStorage.getItem('config') || '{}').globalSettings.theme)
+  expect(theme).toBe('dark')
+})

--- a/tests/fragmentLoader.spec.ts
+++ b/tests/fragmentLoader.spec.ts
@@ -1,17 +1,15 @@
 import { test, expect } from '@playwright/test'
 import { ciConfig } from './data/ciConfig'
 import { ciServices } from './data/ciServices'
-import { gzipSync } from 'zlib'
+import { gzipJsonToBase64url } from '../src/utils/compression.js'
 
-function encode(obj: any) {
-  const json = JSON.stringify(obj)
-  const compressed = gzipSync(Buffer.from(json))
-  return compressed.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+async function encode (obj: any) {
+  return gzipJsonToBase64url(obj)
 }
 
 test('loads config and services from URL fragment', async ({ page }) => {
-  const cfg = encode(ciConfig)
-  const svc = encode(ciServices)
+  const cfg = await encode(ciConfig)
+  const svc = await encode(ciServices)
   await page.goto(`/#cfg=${cfg}&svc=${svc}`)
   await page.waitForLoadState('domcontentloaded')
   const config = await page.evaluate(() => JSON.parse(localStorage.getItem('config') || '{}'))
@@ -21,7 +19,7 @@ test('loads config and services from URL fragment', async ({ page }) => {
 })
 
 test('fragment data is not reapplied if localStorage already has data', async ({ page }) => {
-  const cfg = encode(ciConfig)
+  const cfg = await encode(ciConfig)
   await page.goto(`/#cfg=${cfg}`)
   await page.waitForLoadState('domcontentloaded')
 

--- a/tests/saveServiceModal.spec.ts
+++ b/tests/saveServiceModal.spec.ts
@@ -16,4 +16,43 @@ test.describe('Save Service Modal', () => {
     await expect(modal).toBeVisible()
     await expect(modal.locator('input#save-service-name')).toBeVisible()
   })
+
+  test('saves manual service when confirmed', async ({ page }) => {
+    const url = 'http://localhost/manual-save'
+    await page.fill('#widget-url', url)
+    await page.click('#add-widget-button')
+    const modal = page.locator('#save-service-modal')
+    await expect(modal).toBeVisible()
+    await page.fill('#save-service-name', 'Manual Service')
+    await page.click('#save-service-modal button:has-text("Save & Close")')
+    await expect(modal).toBeHidden()
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
+    expect(services.some(s => s.url === url && s.name === 'Manual Service')).toBeTruthy()
+
+    const options = await page.$$eval('#service-selector option', opts => opts.map(o => o.textContent))
+    expect(options).toContain('Manual Service')
+
+    const iframe = page.locator('.widget-wrapper iframe').first()
+    await expect(iframe).toHaveAttribute('src', url)
+  })
+
+  test('skipping manual service does not store it', async ({ page }) => {
+    const url = 'http://localhost/manual-skip'
+    await page.fill('#widget-url', url)
+    await page.click('#add-widget-button')
+    const modal = page.locator('#save-service-modal')
+    await expect(modal).toBeVisible()
+    await page.click('#save-service-modal button:has-text("Skip")')
+    await expect(modal).toBeHidden()
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
+    expect(services.some(s => s.url === url)).toBeFalsy()
+
+    const options = await page.$$eval('#service-selector option', opts => opts.map(o => o.textContent))
+    expect(options).not.toContain('Manual Service')
+
+    const iframe = page.locator('.widget-wrapper iframe').first()
+    await expect(iframe).toHaveAttribute('src', url)
+  })
 })


### PR DESCRIPTION
# Add fragment guard for config

## Overview

This PR introduces a user-facing *fragment guard* mechanism for configuration data loaded via URL fragments (`#cfg`/`#svc`), protecting against **accidental overwrites** of dashboard state in localStorage. When a config/service fragment is detected *and* local data exists, users are now prompted to **merge, overwrite, or cancel**—reducing the risk of data loss and making config imports explicit.

The PR also modularizes and hardens the underlying utilities for compression, fragment handling, and merging, and updates tests for all new behaviors.

---

## Key Changes

### 1. **Fragment Guard Modal (`fragmentDecisionModal`)**

* New modal (`src/component/modal/fragmentDecisionModal.js`) is displayed when URL contains a config/service fragment and existing local data is detected.
* User can:

  * **Overwrite**: Replace all local config/services/boards with fragment data.
  * **Merge**: Intelligently merges fragment boards/services with local data.
  * **Cancel**: Leaves everything unchanged and clears the fragment.
* **Skepticism**: Is the modal user experience optimal for all device sizes and accessibility scenarios? Should additional warnings or previews be provided before destructive overwrite?

### 2. **Compression Utilities Refactored**

* New (`src/utils/compression.js`) provides `gzipJsonToBase64url` and `gunzipBase64urlToJson`, supporting both browser and Node contexts.
* **Note**: Old compression code removed from modals.
* **Skeptical Point**: Should browser-only code (`CompressionStream`) be polyfilled for older clients, or is the Node fallback sufficient for all supported targets? Is feature detection robust enough?

### 3. **Fragment Removal Utility**

* New (`src/utils/fragmentGuard.js`) safely clears URL fragments without reload, preventing repeated accidental loads.
* **Question**: Are there edge cases where fragment removal fails, e.g., race conditions with navigation or modal closure? Should hashchange events be further guarded?

### 4. **Config/Service Merging**

* New (`src/utils/merge.js`) merges boards/services by ID or URL.
* **Skeptical Query**: Is the merge logic too simplistic for future board/service schema evolution (e.g., versioning, soft deletes, board order)? Should merge strategies be pluggable or user-extensible?

### 5. **Refactor: Fragment Loader**

* (`src/utils/fragmentLoader.js`) now calls the decision modal when a fragment is detected and local data is present, deferring to user intent.
* `loadFromFragment(force)` parameter added for bypassing the guard (for explicit loads).
* **Question**: Is explicit load (`?force=true`) documented for users/admins? Should API be further simplified, e.g., by decoupling modal logic and storage side effects?

### 6. **Test Coverage**

* Playwright tests updated to verify:

  * Guard blocks fragment overwrites when localStorage has data.
  * Merge/cancel flows leave data unchanged or as expected.
  * Encoding/decoding works consistently across test and runtime.
* **Critical Point**: Is the testing coverage sufficient for legacy/edge browser scenarios, and does it capture failures in decompression/merge logic? Should fuzz/monkey tests be added?

### 7. **UI Tweaks**

* Minor adjustments in `src/ui/controls.css` for compact controls and improved responsiveness.
