### PR TITLE
Add modal interaction tests

### DIFF
--- a/symbols.json
+++ b/symbols.json
@@ -659,30 +659,6 @@
     "returns": "void"
   },
   {
-    "name": "showNotification",
-    "kind": "function",
-    "file": "src/component/dialog/notification.js",
-    "description": "Display a temporary notification message.",
-    "params": [
-      {
-        "name": "message",
-        "type": "string",
-        "desc": "- Text content of the notification."
-      },
-      {
-        "name": "duration",
-        "type": "number",
-        "desc": "- How long to display the notification."
-      },
-      {
-        "name": "type",
-        "type": "('success'|'error')",
-        "desc": "- Visual style of the message."
-      }
-    ],
-    "returns": "void"
-  },
-  {
     "name": "initializeDashboardMenu",
     "kind": "function",
     "file": "src/component/menu/dashboardMenu.js",
@@ -712,6 +688,30 @@
     "file": "src/component/menu/menu.js",
     "description": "Create the main dashboard menu and insert it into the page.",
     "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "showNotification",
+    "kind": "function",
+    "file": "src/component/dialog/notification.js",
+    "description": "Display a temporary notification message.",
+    "params": [
+      {
+        "name": "message",
+        "type": "string",
+        "desc": "- Text content of the notification."
+      },
+      {
+        "name": "duration",
+        "type": "number",
+        "desc": "- How long to display the notification."
+      },
+      {
+        "name": "type",
+        "type": "('success'|'error')",
+        "desc": "- Visual style of the message."
+      }
+    ],
     "returns": "void"
   },
   {

--- a/tests/fragmentLoader.spec.ts
+++ b/tests/fragmentLoader.spec.ts
@@ -20,16 +20,49 @@ test('loads config and services from URL fragment', async ({ page }) => {
 
 test('fragment data is not reapplied if localStorage already has data', async ({ page }) => {
   const cfg = await encode(ciConfig)
-  await page.goto(`/#cfg=${cfg}`)
-  await page.waitForLoadState('domcontentloaded')
 
-  await page.evaluate(() => {
+  await page.addInitScript(() => {
     localStorage.setItem('config', JSON.stringify({ globalSettings: { theme: 'dark' } }))
     localStorage.setItem('services', JSON.stringify([]))
     localStorage.setItem('boards', JSON.stringify([]))
   })
 
   await page.goto(`/#cfg=${cfg}`)
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForSelector('#fragment-decision-modal', { timeout: 5000 })
+  const modal = page.locator('#fragment-decision-modal')
+  await expect(modal).toBeVisible()
+  await modal.locator('button:has-text("Cancel")').click()
+  await expect(modal).toBeHidden()
+
+  const theme = await page.evaluate(() => JSON.parse(localStorage.getItem('config') || '{}').globalSettings.theme)
+  expect(theme).toBe('dark')
+})
+
+test('shows merge decision modal when local data exists', async ({ page }) => {
+  const cfg = await encode(ciConfig)
+  const svc = await encode(ciServices)
+
+  await page.addInitScript(value => {
+    localStorage.setItem('config', JSON.stringify(value.config))
+    localStorage.setItem('services', JSON.stringify(value.services))
+    localStorage.setItem('boards', JSON.stringify(value.boards))
+  }, {
+    config: { globalSettings: { theme: 'dark' } },
+    services: [{ name: 'Old', url: 'http://localhost/old' }],
+    boards: [{ id: 'b1', name: 'Board 1', order: 0, views: [] }]
+  })
+
+  await page.goto(`/#cfg=${cfg}&svc=${svc}`)
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForSelector('#fragment-decision-modal', { timeout: 5000 })
+  const modal = page.locator('#fragment-decision-modal')
+  await expect(modal).toBeVisible()
+  await expect(modal).toContainText('What would you like to do?')
+
+  await modal.locator('button:has-text("Cancel")').click()
+  await expect(modal).toBeHidden()
+
   const theme = await page.evaluate(() => JSON.parse(localStorage.getItem('config') || '{}').globalSettings.theme)
   expect(theme).toBe('dark')
 })

--- a/tests/saveServiceModal.spec.ts
+++ b/tests/saveServiceModal.spec.ts
@@ -16,4 +16,43 @@ test.describe('Save Service Modal', () => {
     await expect(modal).toBeVisible()
     await expect(modal.locator('input#save-service-name')).toBeVisible()
   })
+
+  test('saves manual service when confirmed', async ({ page }) => {
+    const url = 'http://localhost/manual-save'
+    await page.fill('#widget-url', url)
+    await page.click('#add-widget-button')
+    const modal = page.locator('#save-service-modal')
+    await expect(modal).toBeVisible()
+    await page.fill('#save-service-name', 'Manual Service')
+    await page.click('#save-service-modal button:has-text("Save & Close")')
+    await expect(modal).toBeHidden()
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
+    expect(services.some(s => s.url === url && s.name === 'Manual Service')).toBeTruthy()
+
+    const options = await page.$$eval('#service-selector option', opts => opts.map(o => o.textContent))
+    expect(options).toContain('Manual Service')
+
+    const iframe = page.locator('.widget-wrapper iframe').first()
+    await expect(iframe).toHaveAttribute('src', url)
+  })
+
+  test('skipping manual service does not store it', async ({ page }) => {
+    const url = 'http://localhost/manual-skip'
+    await page.fill('#widget-url', url)
+    await page.click('#add-widget-button')
+    const modal = page.locator('#save-service-modal')
+    await expect(modal).toBeVisible()
+    await page.click('#save-service-modal button:has-text("Skip")')
+    await expect(modal).toBeHidden()
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
+    expect(services.some(s => s.url === url)).toBeFalsy()
+
+    const options = await page.$$eval('#service-selector option', opts => opts.map(o => o.textContent))
+    expect(options).not.toContain('Manual Service')
+
+    const iframe = page.locator('.widget-wrapper iframe').first()
+    await expect(iframe).toHaveAttribute('src', url)
+  })
 })


### PR DESCRIPTION
## Summary
- extend `saveServiceModal.spec.ts` to test saving and skipping

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `just test`
- `node scripts/playwright-indexer.js`


------
https://chatgpt.com/codex/tasks/task_b_68631563e7a88325b5ae8e69b393c025