### PR TITLE
Implement widget iframe caching with LRU and debug tools

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -5,7 +5,7 @@
  * @module boardManagement
  */
 import { saveBoardState, loadBoardState } from '../../storage/localStorage.js'
-import { addWidget } from '../widget/widgetManagement.js'
+import { addWidget, clearPendingMounts } from '../widget/widgetManagement.js'
 import { Logger } from '../../utils/Logger.js'
 
 /** @typedef {import('../../types.js').Board} Board */
@@ -104,6 +104,7 @@ export function createView (boardId, viewName, viewId = null) {
 }
 
 function clearWidgetContainer () {
+  clearPendingMounts()
   const widgetContainer = document.getElementById('widget-container')
   while (widgetContainer.firstChild) {
     widgetContainer.removeChild(widgetContainer.firstChild)
@@ -143,7 +144,9 @@ export async function switchView (boardId, viewId) {
           widget.type,
           boardId,
           viewId,
-          widget.dataid
+          widget.dataid,
+          widget.version,
+          true
         )
       }
       window.asd.currentViewId = viewId

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,7 +36,7 @@ function initializeDashboardMenu () {
   populateServiceDropdown()
   document.addEventListener('services-updated', populateServiceDropdown)
 
-  document.getElementById('add-widget-button').addEventListener('click', () => {
+  document.getElementById('add-widget-button').addEventListener('click', async () => {
     const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
     const widgetUrlInput = /** @type {HTMLInputElement} */(document.getElementById('widget-url'))
     const boardElement = document.querySelector('.board')
@@ -45,8 +45,8 @@ function initializeDashboardMenu () {
     const manualUrl = widgetUrlInput.value
     const url = selectedServiceUrl || manualUrl
 
-    const finalize = () => {
-      addWidget(url, 1, 1, 'iframe', boardElement.id, viewElement.id)
+    const finalize = async () => {
+      await addWidget(url, 1, 1, 'iframe', boardElement.id, viewElement.id)
       widgetUrlInput.value = ''
     }
 
@@ -75,21 +75,21 @@ function initializeDashboardMenu () {
     }
   })
 
-  document.getElementById('board-selector').addEventListener('change', (event) => {
+  document.getElementById('board-selector').addEventListener('change', async (event) => {
     const target = /** @type {HTMLSelectElement} */(event.target)
     const selectedBoardId = target.value
     const currentBoardId = getCurrentBoardId()
     saveWidgetState(currentBoardId, getCurrentViewId()) // Save current view state
-    switchBoard(selectedBoardId)
+    await switchBoard(selectedBoardId)
     updateViewSelector(selectedBoardId)
   })
 
-  document.getElementById('view-selector').addEventListener('change', (event) => {
+  document.getElementById('view-selector').addEventListener('change', async (event) => {
     const selectedBoardId = getCurrentBoardId()
     const target = /** @type {HTMLSelectElement} */(event.target)
     const selectedViewId = target.value
     logger.log(`Switching to selected view ${selectedViewId} in board ${selectedBoardId}`)
-    switchView(selectedBoardId, selectedViewId)
+    await switchView(selectedBoardId, selectedViewId)
   })
 }
 

--- a/src/component/widget/utils/deferredMount.js
+++ b/src/component/widget/utils/deferredMount.js
@@ -1,0 +1,51 @@
+// @ts-check
+/**
+ * Utilities for deferred DOM insertion of widgets.
+ *
+ * @module deferredMount
+ */
+
+const pending = new Set()
+
+/**
+ * Schedule mounting of an element on the next idle frame.
+ * @param {HTMLElement} parent
+ * @param {HTMLElement} child
+ * @returns {() => void} Cancel function
+ */
+export function deferredMount (parent, child) {
+  const cb = () => {
+    parent.appendChild(child)
+    pending.delete(cancel)
+  }
+  let handle
+  if ('requestIdleCallback' in window) {
+    handle = window.requestIdleCallback(cb)
+  } else {
+    handle = setTimeout(cb, 0)
+  }
+  function cancel () {
+    if (handle !== undefined) {
+      if ('cancelIdleCallback' in window && typeof handle === 'number') {
+        // @ts-ignore
+        window.cancelIdleCallback(handle)
+      } else {
+        clearTimeout(handle)
+      }
+    }
+    pending.delete(cancel)
+  }
+  pending.add(cancel)
+  return cancel
+}
+
+/**
+ * Cancel all pending mount operations.
+ * @returns {void}
+ */
+export function cancelAllMounts () {
+  for (const cancel of Array.from(pending)) {
+    cancel()
+  }
+  pending.clear()
+}

--- a/src/component/widget/widgetCache.js
+++ b/src/component/widget/widgetCache.js
@@ -1,0 +1,111 @@
+// @ts-check
+/**
+ * LRU cache for widget DOM elements.
+ *
+ * @module widgetCache
+ */
+
+export class WidgetLRUCache {
+  /**
+   * @param {number} max
+   */
+  constructor (max) {
+    this.max = max
+    /** @type {Map<string, HTMLElement>} */
+    this.cache = new Map()
+  }
+
+  /**
+   * Retrieve an element and mark as recently used.
+   * @param {string} id
+   * @returns {HTMLElement|undefined}
+   */
+  get (id) {
+    const el = this.cache.get(id)
+    if (!el) return undefined
+    this.cache.delete(id)
+    this.cache.set(id, el)
+    return el
+  }
+
+  /**
+   * Add an element to the cache, evicting old entries if needed.
+   * @param {string} id
+   * @param {HTMLElement} el
+   * @returns {void}
+   */
+  set (id, el) {
+    const existing = this.cache.get(id)
+    if (existing && existing !== el) {
+      this._removeElement(id, existing)
+    }
+    this.cache.delete(id)
+    this.cache.set(id, el)
+    if (this.cache.size > this.max) {
+      this.evict()
+    }
+  }
+
+  /**
+   * Remove the least recently used element from the cache.
+   * @returns {void}
+   */
+  evict () {
+    const firstKey = this.cache.keys().next().value
+    if (firstKey) {
+      const el = this.cache.get(firstKey)
+      if (el) this._removeElement(firstKey, el)
+      this.cache.delete(firstKey)
+    }
+  }
+
+  /**
+   * Clear all cached elements.
+   * @returns {void}
+   */
+  clear () {
+    for (const [key, el] of this.cache.entries()) {
+      this._removeElement(key, el)
+      this.cache.delete(key)
+    }
+  }
+
+  /**
+   * Get cache statistics.
+   * @returns {{size:number, keys:string[]}}
+   */
+  stats () {
+    return { size: this.cache.size, keys: Array.from(this.cache.keys()) }
+  }
+
+  /**
+   * Internal helper to remove a widget element safely.
+   * @private
+   * @param {string} id
+   * @param {HTMLElement} el
+   */
+  _removeElement (id, el) {
+    const iframe = el.querySelector('iframe')
+    try {
+      if (iframe && iframe.contentWindow && iframe.contentWindow.origin === window.origin) {
+        iframe.contentWindow.postMessage({ type: 'WIDGET_UNLOAD' }, '*')
+      }
+    } catch { /* ignore cross origin */ }
+    el.remove()
+    // explicit null to avoid leaks
+    // @ts-ignore
+    el = null
+    this.cache.delete(id)
+  }
+}
+
+/**
+ * Determine if widget cache usage is disabled.
+ * @returns {boolean}
+ */
+export function isCacheDisabled () {
+  const params = new URLSearchParams(window.location.search)
+  const param = params.get('noWidgetCache') === '1'
+  const cfg = window.asd?.config?.globalSettings?.noWidgetCache === 'true'
+  return param || cfg
+}

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -47,6 +47,7 @@ function serializeWidgetState (widget) {
     columns: widget.dataset.columns || 1,
     rows: widget.dataset.rows || 1,
     type: widget.dataset.type || 'iframe',
+    version: widget.dataset.version || '1',
     metadata,
     settings
   }
@@ -141,11 +142,13 @@ async function loadWidgetState (boardId, viewId) {
               widgetData.url,
               Number(widgetData.columns),
               Number(widgetData.rows),
-              widgetData.dataid // Ensure dataid is passed to maintain widget identity
+              widgetData.dataid,
+              widgetData.version || '1'
             )
             widgetWrapper.dataset.order = String(widgetData.order)
             widgetWrapper.style.order = String(widgetData.order)
             widgetWrapper.dataset.type = widgetData.type
+            widgetWrapper.dataset.version = String(widgetData.version || '1')
             widgetWrapper.dataset.metadata = JSON.stringify(widgetData.metadata)
             widgetWrapper.dataset.settings = JSON.stringify(widgetData.settings)
             widgetContainer.appendChild(widgetWrapper)

--- a/src/types.js
+++ b/src/types.js
@@ -11,6 +11,7 @@
  * @property {string} [order]
  * @property {Record<string, any>} [metadata]
  * @property {Record<string, any>} [settings]
+ * @property {string|number} [version]
  */
 
 /**

--- a/src/ui/widget.css
+++ b/src/ui/widget.css
@@ -171,3 +171,15 @@
 .resizing {
     border: 2px dotted green;
 }
+
+.widget-debug-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: rgba(0,0,0,0.6);
+    color: #fff;
+    font-size: 10px;
+    padding: 2px 4px;
+    z-index: 100;
+    pointer-events: none;
+}

--- a/symbols.json
+++ b/symbols.json
@@ -67,6 +67,16 @@
         "name": "dataid",
         "type": "?string",
         "desc": "- Persistent widget identifier."
+      },
+      {
+        "name": "version",
+        "type": "string|number",
+        "desc": "- Widget version for cache validation."
+      },
+      {
+        "name": "deferMount",
+        "type": "boolean",
+        "desc": "- Defer DOM insertion with cancellation support."
       }
     ],
     "returns": "Promise<void>"
@@ -193,6 +203,11 @@
         "name": "dataid",
         "type": "?string",
         "desc": "- Optional persistent widget identifier."
+      },
+      {
+        "name": "version",
+        "type": "string|number",
+        "desc": "- Widget version for cache validation."
       }
     ],
     "returns": "Promise<HTMLDivElement>"

--- a/tests/data/ciConfig.ts
+++ b/tests/data/ciConfig.ts
@@ -8,7 +8,8 @@ export const ciConfig = {
           "loadDashboardFromConfig": "true",
           "defaultBoard": "board-1728763634657",
           "defaultView": "view-1728763634657"
-      }
+      },
+      "widget_cache_count": 10
     },
     "boards": [],
     "styling": {

--- a/tests/widgetCache.spec.ts
+++ b/tests/widgetCache.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+import { routeServicesConfig } from './shared/mocking'
+import { addServicesByName, handleDialog } from './shared/common'
+
+async function createEmptyView(page) {
+  await handleDialog(page, 'prompt', 'CacheTest')
+  await page.click('#view-dropdown .dropbtn')
+  await page.click('#view-control a[data-action="create"]')
+}
+
+test.describe('Widget LRU Cache', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+  })
+
+  test('evicts oldest widgets and reuses cached ones', async ({ page }) => {
+    await addServicesByName(page, 'ASD-terminal', 12)
+    const idsBefore = await page.$$eval('.widget-wrapper', els => els.map(el => el.dataset.dataid))
+
+    await createEmptyView(page)
+    await page.selectOption('#view-selector', { label: 'CacheTest' })
+
+    const stats = await page.evaluate(() => window.widgetCacheDebug.getStats())
+    expect(stats.size).toBe(10)
+
+    await page.selectOption('#view-selector', { label: 'Default View' })
+
+    const cacheStatuses = await page.$$eval('.widget-wrapper', els => els.map(el => ({ id: el.dataset.dataid, cache: el.dataset.cache })))
+    const lastTen = idsBefore.slice(-10)
+    for (const info of cacheStatuses) {
+      if (lastTen.includes(info.id)) {
+        expect(info.cache).toBe('hit')
+      }
+    }
+    expect(stats.keys).not.toContain(idsBefore[0])
+    expect(stats.keys).not.toContain(idsBefore[1])
+  })
+})


### PR DESCRIPTION
## Summary
- extract `WidgetLRUCache` with eviction and stats helpers
- add deferred DOM mounting utilities
- version widgets and expose cache debug API
- display debug overlay when running in dev mode
- persist widget version in saved board state
- wire caching into widget management and board switching
- add example cache setting in test config
- create integration test for LRU behaviour
- fix widget caching and interaction bugs

## Testing
- `npm run lint-fix`
- `npx -y node scripts/extract-symbol-index.mjs`
- `npx playwright test` *(fails: widgetCache, resizeHandler, localStorageEditor)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6863384c03388325b112f9709ee99386