### PR TITLE
Fix widget cache race and typings

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 import { defineConfig, devices } from '@playwright/test';
+import './tests/helper/augment';
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -59,6 +59,7 @@ function handleDragEnd (e) {
  * @returns {void}
  */
 function addDragOverlay (widgetWrapper) {
+  if (widgetWrapper.querySelector('.drag-overlay')) return
   const dragOverlay = document.createElement('div')
   dragOverlay.classList.add('drag-overlay')
 

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -24,10 +24,11 @@ export function initializeResizeHandles () {
   logger.info(`Found ${widgets.length} widgets to initialize resize handles.`)
 
   widgets.forEach((widget, index) => {
+    const el = /** @type {HTMLElement} */(widget)
+    if (!el.isConnected) return
     logger.info(`Initializing resize handle for widget index: ${index}`)
     const resizeHandle = document.createElement('div')
     resizeHandle.className = 'resize-handle'
-    const el = /** @type {HTMLElement} */(widget)
     el.appendChild(resizeHandle)
 
     logger.info('Appended resize handle:', resizeHandle)

--- a/src/component/widget/utils/deferredMount.js
+++ b/src/component/widget/utils/deferredMount.js
@@ -5,6 +5,8 @@
  * @module deferredMount
  */
 
+import { initializeResizeHandles } from '../events/resizeHandler.js'
+
 const pending = new Set()
 
 /**
@@ -16,6 +18,7 @@ const pending = new Set()
 export function deferredMount (parent, child) {
   const cb = () => {
     parent.appendChild(child)
+    initializeResizeHandles()
     pending.delete(cancel)
   }
   let handle

--- a/src/component/widget/widgetCache.js
+++ b/src/component/widget/widgetCache.js
@@ -95,7 +95,6 @@ export class WidgetLRUCache {
     // explicit null to avoid leaks
     // @ts-ignore
     el = null
-    this.cache.delete(id)
   }
 }
 

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -29,9 +29,7 @@ function getCache () {
   if (!cacheInstance) {
     const limit = Number(window.asd?.config?.globalSettings?.widget_cache_count) || 10
     cacheInstance = new WidgetLRUCache(limit)
-    const dev = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.DEV) ||
-      (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production') ||
-      window.location.hostname === 'localhost'
+    const dev = import.meta.env?.MODE !== 'production'
     if (dev) {
       window.widgetCacheDebug = {
         getStats: () => cacheInstance.stats(),
@@ -281,9 +279,7 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   widgetWrapper.setAttribute('data-order', String(widgetContainer.children.length))
   widgetWrapper.dataset.cache = cacheHit ? 'hit' : 'miss'
 
-  const devOverlay = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.DEV) ||
-    (typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production') ||
-    window.location.hostname === 'localhost'
+  const devOverlay = import.meta.env?.MODE !== 'production'
   if (devOverlay) {
     let overlay = widgetWrapper.querySelector('.widget-debug-overlay')
     if (!overlay) {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,15 @@
+export {}
+
+declare global {
+  interface Window {
+    widgetCacheDebug?: {
+      getStats(): { size: number; keys: string[] }
+      clear(): void
+      getKeys(): string[]
+    }
+  }
+
+  interface ImportMeta {
+    readonly env?: Record<string, string>
+  }
+}

--- a/tests/data/ciConfig.ts
+++ b/tests/data/ciConfig.ts
@@ -35,6 +35,7 @@ export const ciBoards = [
             {
               "order": "0",
               "url": "http://localhost:8000/asd/toolbox",
+              "version": "1",
               "minColumns": "4",
               "maxColumns": "4",
               "minRows": "4",
@@ -64,6 +65,7 @@ export const ciBoards = [
             {
               "order": "0",
               "url": "http://localhost:8000/asd/toolbox",
+              "version": "1",
               "type": "web",
               "settings": {
                 "autoRefresh": false,

--- a/tests/helper/augment.ts
+++ b/tests/helper/augment.ts
@@ -1,0 +1,11 @@
+export {}
+
+declare global {
+  interface Window {
+    widgetCacheDebug?: {
+      getStats(): { size: number; keys: string[] }
+      clear(): void
+      getKeys(): string[]
+    }
+  }
+}

--- a/tests/shared/common.ts
+++ b/tests/shared/common.ts
@@ -36,5 +36,6 @@ export async function getBoardsFromLocalStorage(page) {
 export async function addServicesByName(page: Page, serviceName: string, count: number) {
     for (let i = 0; i < count; i++) {
         await selectServiceByName(page, serviceName);
+        await page.waitForTimeout(100);
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "checkJs": true,
     "noEmit": true
   },
-  "include": ["src", "tests", "src/global.d.ts"]
+  "include": ["src", "tests", "src/global.d.ts", "src/types/global.d.ts"]
 }


### PR DESCRIPTION
## Summary
- add ambient declarations for ImportMeta.env and window.widgetCacheDebug
- skip disconnected widgets when setting up resize handles
- avoid overlay duplicates during drag operations
- use Vite `import.meta.env.MODE` check
- update cache eviction helper
- sync CI board fixtures with version field
- expose ambient widgetCacheDebug type to Playwright
- wait after each test widget addition
- initialize resize handles after deferred mounts

## Testing
- `npm run check`
- `just test` *(fails: 4 failing tests)*
- `node scripts/playwright-indexer.js`


------
https://chatgpt.com/codex/tasks/task_b_686342a5487883258ac466f641e56af5