### PR TITLE
Implement session bucket migration and widget loader

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -1,0 +1,33 @@
+# Local Storage Schema
+
+Dashboard state is stored in `localStorage` buckets prefixed with `image#<session>`.
+Each session id comes from `location.hash` of the form `#local:<id>` and is
+also persisted to the `__lastSessionId` key. When the page loads without a hash,
+this stored id is reapplied to maintain continuity.
+
+## Bucket naming
+
+```
+image#<sessionId>
+```
+
+Every bucket contains a JSON object with a `boards` array. New sessions reuse the
+same structure and legacy buckets are migrated on startup.
+
+## Widget objects
+
+Widgets inside a view require these fields:
+
+- `dataid` – persistent identifier
+- `url` – iframe source
+- `columns` – grid column span
+- `rows` – grid row span
+- `order` – position order
+- `type` – optional widget type
+- `version` – defaults to `"1"` when missing
+
+## Compatibility rules
+
+Older buckets might omit the `version` property. The loader automatically sets it
+to `"1"` to keep widgets functional. When new fields are introduced they must be
+optional so earlier dashboards continue to load without modification.

--- a/src/component/widget/widgetLoader.js
+++ b/src/component/widget/widgetLoader.js
@@ -1,0 +1,55 @@
+// @ts-check
+/**
+ * Load widgets from a configuration object into the DOM.
+ *
+ * @module widgetLoader
+ */
+import { createWidget } from './widgetManagement.js'
+import { getServiceFromUrl } from './utils/widgetUtils.js'
+import { initializeResizeHandles } from './events/resizeHandler.js'
+
+/** @typedef {import('../../types.js').Widget} Widget */
+
+/**
+ * Instantiate widgets defined in a view configuration.
+ * Objects missing a `version` field are defaulted to "1" for backward compatibility.
+ *
+ * @param {Array<Widget>} widgets
+ * @function loadWidgetsFromConfig
+ * @returns {Promise<void>}
+ */
+export async function loadWidgetsFromConfig (widgets) {
+  const container = document.getElementById('widget-container')
+  if (!container) return
+  for (const data of widgets) {
+    if (!data) {
+      console.debug('loadWidgetsFromConfig: skipped falsy widget')
+      continue
+    }
+    if (container.querySelector(`[data-dataid="${data.dataid}"]`)) {
+      console.debug('loadWidgetsFromConfig: widget already exists', data.dataid)
+      continue
+    }
+    if (!data.version) {
+      console.debug('loadWidgetsFromConfig: applying default version to', data.dataid)
+      data.version = '1'
+    }
+    const service = await getServiceFromUrl(data.url)
+    const el = await createWidget(
+      service,
+      data.url,
+      Number(data.columns),
+      Number(data.rows),
+      data.dataid,
+      data.version
+    )
+    el.dataset.order = String(data.order)
+    el.style.order = String(data.order)
+    el.dataset.type = data.type
+    el.dataset.version = String(data.version)
+    el.dataset.metadata = JSON.stringify(data.metadata || {})
+    el.dataset.settings = JSON.stringify(data.settings || {})
+    container.appendChild(el)
+  }
+  initializeResizeHandles()
+}

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { initializeMainMenu } from './component/menu/menu.js'
 import { initializeBoards, switchBoard } from './component/board/boardManagement.js'
 import { initializeDashboardMenu } from './component/menu/dashboardMenu.js'
 import { loadInitialConfig, loadBoardState } from './storage/localStorage.js'
+import { getSessionId, migrateLegacyBuckets } from './storage/sessionBuckets.js'
 import { initializeDragAndDrop } from './component/widget/events/dragDrop.js'
 import { fetchServices } from './utils/fetchServices.js'
 import { getConfig } from './utils/getConfig.js'
@@ -32,6 +33,9 @@ window.asd = {
 
 document.addEventListener('DOMContentLoaded', async () => {
   logger.log('DOMContentLoaded event fired')
+  const sessionId = getSessionId()
+  window.sessionId = sessionId
+  migrateLegacyBuckets(sessionId)
   const params = new URLSearchParams(location.search)
   const force = params.get('force') === 'true'
   await loadFromFragment(force)

--- a/src/storage/sessionBuckets.js
+++ b/src/storage/sessionBuckets.js
@@ -1,0 +1,88 @@
+// @ts-check
+/**
+ * Manage per-session localStorage buckets.
+ *
+ * @module sessionBuckets
+ */
+import { Logger } from '../utils/Logger.js'
+
+const logger = new Logger('sessionBuckets.js')
+
+export const LAST_ID_KEY = '__lastSessionId'
+
+/**
+ * Get or generate the current session id from the URL hash.
+ * The hash format should be `#local:<id>`. If missing, a new id is
+ * generated and persisted to localStorage. When no hash is provided
+ * on first load but `__lastSessionId` exists, that id is reused.
+ *
+ * @function getSessionId
+ * @returns {string}
+ */
+export function getSessionId () {
+  const match = location.hash.match(/^#local:([\w-]+)$/)
+  let id = null
+  if (match) {
+    id = match[1]
+  } else {
+    const stored = localStorage.getItem(LAST_ID_KEY)
+    if (stored) {
+      id = stored
+      if (!location.hash) {
+        location.hash = `#local:${id}`
+      }
+    } else {
+      id = crypto.randomUUID()
+      location.hash = `#local:${id}`
+    }
+  }
+  localStorage.setItem(LAST_ID_KEY, id)
+  logger.log('Using session id:', id)
+  return id
+}
+
+/**
+ * Migrate data from legacy image buckets into the current session bucket.
+ * Any widget objects missing a version field will receive "1".
+ *
+ * @function migrateLegacyBuckets
+ * @param {string} sessionId - Current session identifier.
+ * @returns {void}
+ */
+export function migrateLegacyBuckets (sessionId) {
+  const keys = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key && key.startsWith('image#') && !key.includes(sessionId)) {
+      keys.push(key)
+    }
+  }
+  for (const key of keys) {
+    try {
+      const raw = localStorage.getItem(key)
+      if (!raw) continue
+      const data = JSON.parse(raw)
+      if (Array.isArray(data.boards)) {
+        for (const board of data.boards) {
+          for (const view of board.views || []) {
+            for (const widget of view.widgetState || []) {
+              if (!('version' in widget)) {
+                widget.version = '1'
+              }
+            }
+          }
+        }
+      }
+      const bucketKey = `image#${sessionId}`
+      const existingRaw = localStorage.getItem(bucketKey)
+      const existing = existingRaw ? JSON.parse(existingRaw) : { boards: [] }
+      if (Array.isArray(data.boards)) {
+        existing.boards = existing.boards.concat(data.boards)
+      }
+      localStorage.setItem(bucketKey, JSON.stringify(existing))
+      localStorage.removeItem(key)
+    } catch (e) {
+      console.debug('migrateLegacyBuckets: skipped malformed bucket', key)
+    }
+  }
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,6 +7,7 @@ declare global {
       clear(): void
       getKeys(): string[]
     }
+    sessionId?: string
   }
 
   interface ImportMeta {

--- a/symbols.json
+++ b/symbols.json
@@ -434,6 +434,14 @@
     "returns": "Promise<string>"
   },
   {
+    "name": "getSessionId",
+    "kind": "function",
+    "file": "src/storage/sessionBuckets.js",
+    "description": "Get or generate the current session id from the URL hash. The hash format should be `#local:<id>`. If missing, a new id is generated and persisted to localStorage. When no hash is provided on first load but `__lastSessionId` exists, that id is reused.",
+    "params": [],
+    "returns": "string"
+  },
+  {
     "name": "getUUID",
     "kind": "function",
     "file": "src/utils/utils.js",
@@ -778,6 +786,20 @@
     "returns": "Promise<void>"
   },
   {
+    "name": "loadWidgetsFromConfig",
+    "kind": "function",
+    "file": "src/component/widget/widgetLoader.js",
+    "description": "Instantiate widgets defined in a view configuration. Objects missing a `version` field are defaulted to \"1\" for backward compatibility.",
+    "params": [
+      {
+        "name": "widgets",
+        "type": "Array<Widget>",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
     "name": "loadWidgetState",
     "kind": "function",
     "file": "src/storage/localStorage.js",
@@ -874,6 +896,20 @@
       }
     ],
     "returns": "Array<Service>"
+  },
+  {
+    "name": "migrateLegacyBuckets",
+    "kind": "function",
+    "file": "src/storage/sessionBuckets.js",
+    "description": "Migrate data from legacy image buckets into the current session bucket. Any widget objects missing a version field will receive \"1\".",
+    "params": [
+      {
+        "name": "sessionId",
+        "type": "string",
+        "desc": "- Current session identifier."
+      }
+    ],
+    "returns": "void"
   },
   {
     "name": "openConfigModal",

--- a/tests/widgetCache.spec.ts
+++ b/tests/widgetCache.spec.ts
@@ -36,4 +36,13 @@ test.describe('Widget LRU Cache', () => {
     expect(stats.keys).not.toContain(idsBefore[0])
     expect(stats.keys).not.toContain(idsBefore[1])
   })
+
+  test('widgets persist across reloads and clear correctly', async ({ page }) => {
+    await addServicesByName(page, 'ASD-terminal', 2)
+    await page.reload()
+    await expect(page.locator('.widget-wrapper')).toHaveCount(2)
+    await page.evaluate(() => localStorage.clear())
+    await page.reload()
+    await expect(page.locator('.widget-wrapper')).toHaveCount(0)
+  })
 })


### PR DESCRIPTION
## Summary
- persist local session IDs and migrate old buckets
- add widget loader with version back-compat
- document local storage schema
- update global types and bootstrap logic
- extend widget cache regression test

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `just test` *(fails: missing network access)*
- `node scripts/playwright-indexer.js`

------
https://chatgpt.com/codex/tasks/task_b_6863b2192dfc83259f40fe7d10757476