### PR TITLE
Fix widget parking debug info and container clearing

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -105,11 +105,14 @@ export function createView (boardId, viewName, viewId = null) {
 
 function clearWidgetContainer () {
   const widgetContainer = document.getElementById('widget-container')
-  const parking = document.getElementById('widget-parking')
   while (widgetContainer.firstChild) {
-    parking.appendChild(widgetContainer.firstChild)
+    const widgetEl = /** @type {HTMLElement} */(widgetContainer.firstChild)
+    widgetEl.remove()
+    const dataid = widgetEl.dataset.dataid
+    if (dataid) {
+      widgetParkingLot.park(dataid, widgetEl)
+    }
   }
-  parking.lastChild?.style && (parking.lastChild.style.display = 'none')
 }
 
 /**

--- a/src/component/widget/WidgetParkingLot.js
+++ b/src/component/widget/WidgetParkingLot.js
@@ -42,8 +42,13 @@ export class WidgetParkingLot {
       this.cache.delete(key)
     } else if (this.cache.size >= this.limit) {
       const oldestKey = this.cache.keys().next().value
+      const oldestEl = this.cache.get(oldestKey)
+      if (oldestEl) {
+        oldestEl.remove()
+      }
       this.cache.delete(oldestKey)
     }
+    el.remove()
     this.cache.set(key, el)
   }
 

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -24,7 +24,6 @@ const logger = new Logger('widgetManagement.js')
 export const widgetParkingLot = new WidgetParkingLot(10)
 widgetParkingLot.debugInfo = () => ({
   size: widgetParkingLot.cache.size,
-  parked: document.getElementById('widget-parking').childElementCount,
   keys: [...widgetParkingLot.cache.keys()]
 })
 

--- a/src/index.html
+++ b/src/index.html
@@ -18,8 +18,6 @@
             </div>
         </div>
     </main>
-    <!-- Keeps cached widgets alive but invisible -->
-    <div id="widget-parking" style="display:none"></div>
     <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure widgets are removed before parking when clearing the container
- simplify `widgetParkingLot.debugInfo` now that the parking div is gone

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `just test` *(fails: 4 failed, 3 interrupted, 4 did not run)*
- `node scripts/playwright-indexer.js`


------
https://chatgpt.com/codex/tasks/task_b_6863ecefae508325b1dec7bf566bc25a