### PR TITLE
Add unique ID helpers for dashboard entities

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -7,6 +7,7 @@
 import { saveBoardState, loadBoardState } from '../../storage/localStorage.js'
 import { addWidget } from '../widget/widgetManagement.js'
 import { Logger } from '../../utils/Logger.js'
+import { boardGetUUID, viewGetUUID } from '../../utils/id.js'
 
 /** @typedef {import('../../types.js').Board} Board */
 /** @typedef {import('../../types.js').View} View */
@@ -16,10 +17,6 @@ const logger = new Logger('boardManagement.js')
 
 /** @type {Array<Board>} */
 export let boards = []
-
-function generateUniqueId (prefix) {
-  return `${prefix}-${Date.now()}`
-}
 
 /**
  * Create a board with a default view.
@@ -32,7 +29,7 @@ function generateUniqueId (prefix) {
  * @returns {Board} The created board.
  */
 export function createBoard (boardName, boardId = null, viewId = null) {
-  const newBoardId = boardId || generateUniqueId('board')
+  const newBoardId = boardId || boardGetUUID()
   const newBoard = {
     id: newBoardId,
     name: boardName,
@@ -41,7 +38,7 @@ export function createBoard (boardName, boardId = null, viewId = null) {
   }
   boards.push(newBoard)
 
-  const defaultViewId = viewId || generateUniqueId('view')
+  const defaultViewId = viewId || viewGetUUID()
   createView(newBoardId, 'Default View', defaultViewId)
   logger.log(`Created default view ${defaultViewId} for new board ${newBoardId}`)
 
@@ -76,7 +73,7 @@ export function createBoard (boardName, boardId = null, viewId = null) {
 export function createView (boardId, viewName, viewId = null) {
   const board = boards.find(b => b.id === boardId)
   if (board) {
-    const newViewId = viewId || generateUniqueId('view')
+    const newViewId = viewId || viewGetUUID()
     const newView = {
       id: newViewId,
       name: viewName,

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -17,6 +17,7 @@ import { toggleFullScreen } from './events/fullscreenToggle.js'
 import { initializeResizeHandles } from './events/resizeHandler.js'
 import { Logger } from '../../utils/Logger.js'
 import { showServiceModal } from '../modal/serviceLaunchModal.js'
+import { widgetGetUUID } from '../../utils/id.js'
 
 const logger = new Logger('widgetManagement.js')
 
@@ -49,7 +50,7 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   widgetWrapper.style.position = 'relative'
   widgetWrapper.dataset.service = service
   widgetWrapper.dataset.url = url
-  widgetWrapper.dataset.dataid = dataid || crypto.randomUUID() // Use existing dataid or generate a new one
+  widgetWrapper.dataset.dataid = dataid || widgetGetUUID()
   logger.log(`Creating widget for service: ${service}`)
 
   gridColumnSpan = Math.min(Math.max(gridColumnSpan, minColumns), maxColumns)

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,0 +1,39 @@
+// @ts-check
+/**
+ * Unique identifier generators for dashboard entities.
+ *
+ * @module id
+ */
+import { getUUID } from './utils.js'
+
+/**
+ * Generate a unique widget id.
+ *
+ * @function widgetGetUUID
+ * @returns {string}
+ */
+function widgetGetUUID () {
+  return `widget-${getUUID()}`
+}
+
+/**
+ * Generate a unique board id.
+ *
+ * @function boardGetUUID
+ * @returns {string}
+ */
+function boardGetUUID () {
+  return `board-${getUUID()}`
+}
+
+/**
+ * Generate a unique view id.
+ *
+ * @function viewGetUUID
+ * @returns {string}
+ */
+function viewGetUUID () {
+  return `view-${getUUID()}`
+}
+
+export { widgetGetUUID, boardGetUUID, viewGetUUID }

--- a/symbols.json
+++ b/symbols.json
@@ -100,6 +100,14 @@
     "returns": "string"
   },
   {
+    "name": "boardGetUUID",
+    "kind": "function",
+    "file": "src/utils/id.js",
+    "description": "Generate a unique board id.",
+    "params": [],
+    "returns": "string"
+  },
+  {
     "name": "checkLogStatus",
     "kind": "function",
     "file": "src/utils/Logger.js",
@@ -1197,6 +1205,14 @@
     "returns": "void"
   },
   {
+    "name": "viewGetUUID",
+    "kind": "function",
+    "file": "src/utils/id.js",
+    "description": "Generate a unique view id.",
+    "params": [],
+    "returns": "string"
+  },
+  {
     "name": "warn",
     "kind": "function",
     "file": "src/utils/Logger.js",
@@ -1209,5 +1225,13 @@
       }
     ],
     "returns": ""
+  },
+  {
+    "name": "widgetGetUUID",
+    "kind": "function",
+    "file": "src/utils/id.js",
+    "description": "Generate a unique widget id.",
+    "params": [],
+    "returns": "string"
   }
 ]


### PR DESCRIPTION
## Summary
- implement `widgetGetUUID`, `boardGetUUID`, and `viewGetUUID`
- refactor board and widget management to use these helpers
- update symbol index

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `just test`
- `node scripts/playwright-indexer.js`

------
https://chatgpt.com/codex/tasks/task_b_6864168561b883259da2b9c417560131