### PR TITLE
Implement widget store and view switching improvements

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -130,18 +130,40 @@ export async function switchView (boardId, viewId) {
         logger.error('board-view element not found in DOM')
       }
 
-      clearWidgetContainer()
       logger.log(`Rendering widgets for view ${viewId}:`, view.widgetState)
-      for (const widget of view.widgetState) {
-        await addWidget(
-          widget.url,
-          Number(widget.columns),
-          Number(widget.rows),
-          widget.type,
-          boardId,
-          viewId,
-          widget.dataid
-        )
+      const widgetContainer = document.getElementById('widget-container')
+      const store = window.asd.widgetStore
+
+      const activeIds = new Set(view.widgetState.map(w => w.dataid))
+
+      for (const [id] of store.widgets.entries()) {
+        if (!activeIds.has(id)) {
+          store.hide(id)
+        }
+      }
+
+      for (const [index, widget] of view.widgetState.entries()) {
+        if (store.has(widget.dataid)) {
+          const el = store.get(widget.dataid)
+          store.show(widget.dataid)
+          el.setAttribute('data-order', String(index))
+          el.style.order = String(index)
+          if (!widgetContainer.contains(el)) {
+            widgetContainer.appendChild(el)
+          } else {
+            widgetContainer.appendChild(el)
+          }
+        } else {
+          await addWidget(
+            widget.url,
+            Number(widget.columns),
+            Number(widget.rows),
+            widget.type,
+            boardId,
+            viewId,
+            widget.dataid
+          )
+        }
       }
       window.asd.currentViewId = viewId
       localStorage.setItem('lastUsedViewId', viewId)

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -216,12 +216,18 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   boardId = boardId || window.asd.currentBoardId
   viewId = viewId || window.asd.currentViewId
 
+  if (dataid && window.asd.widgetStore.has(dataid)) {
+    window.asd.widgetStore.show(dataid)
+    return
+  }
+
   const service = await getServiceFromUrl(url)
   logger.log('Extracted service:', service)
 
   const widgetWrapper = await createWidget(service, url, columns, rows, dataid)
   widgetWrapper.setAttribute('data-order', String(widgetContainer.children.length))
   widgetContainer.appendChild(widgetWrapper)
+  window.asd.widgetStore.add(widgetWrapper.dataset.dataid, widgetWrapper)
 
   logger.log('Widget appended to container:', widgetWrapper)
 
@@ -252,7 +258,7 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
  */
 function removeWidget (widgetElement) {
   const dataid = widgetElement.dataset.dataid
-  widgetElement.remove()
+  window.asd.widgetStore.requestRemoval(dataid)
   logger.log('Widget removed with dataid:', dataid)
   updateWidgetOrders()
   const boardId = window.asd.currentBoardId

--- a/src/component/widget/widgetStore.js
+++ b/src/component/widget/widgetStore.js
@@ -1,0 +1,139 @@
+// @ts-check
+/**
+ * In-memory LRU store for widget DOM elements.
+ *
+ * @module widgetStore
+ */
+import { Logger } from '../../utils/Logger.js'
+
+/**
+ * Lightweight LRU cache storing widget elements by id.
+ * Evicts least recently used widgets when capacity is exceeded.
+ * @class WidgetStore
+ */
+export class WidgetStore {
+  /**
+   * @constructor
+   * @param {number} [maxSize=50] - Maximum number of widgets to retain.
+   */
+  constructor (maxSize = 50) {
+    this.maxSize = maxSize
+    /** @type {Map<string, HTMLElement>} */
+    this.widgets = new Map()
+    this.logger = new Logger('widgetStore.js')
+  }
+
+  /**
+   * Store a widget element by id. Existing entries are refreshed.
+   *
+   * @param {string} id
+   * @param {HTMLElement} element
+   * @function add
+   * @returns {void}
+   */
+  add (id, element) {
+    if (this.widgets.has(id)) {
+      this.widgets.delete(id)
+    }
+    this.widgets.set(id, element)
+    this._ensureLimit()
+  }
+
+  /**
+   * Retrieve a widget element and mark it as recently used.
+   *
+   * @param {string} id
+   * @function get
+   * @returns {HTMLElement|undefined}
+   */
+  get (id) {
+    if (!this.widgets.has(id)) return undefined
+    const el = this.widgets.get(id)
+    this.widgets.delete(id)
+    this.widgets.set(id, el)
+    return el
+  }
+
+  /**
+   * Check if a widget exists in the store.
+   *
+   * @param {string} id
+   * @function has
+   * @returns {boolean}
+   */
+  has (id) {
+    return this.widgets.has(id)
+  }
+
+  /**
+   * Show a stored widget by id.
+   *
+   * @param {string} id
+   * @function show
+   * @returns {void}
+   */
+  show (id) {
+    const el = this.get(id)
+    if (el) {
+      el.style.display = ''
+    }
+  }
+
+  /**
+   * Hide a stored widget by id.
+   *
+   * @param {string} id
+   * @function hide
+   * @returns {void}
+   */
+  hide (id) {
+    const el = this.widgets.get(id)
+    if (el) {
+      el.style.display = 'none'
+    }
+  }
+
+  /**
+   * Request removal of a widget from the DOM and store.
+   *
+   * @param {string} id
+   * @function requestRemoval
+   * @returns {void}
+   */
+  requestRemoval (id) {
+    this._evict(id)
+  }
+
+  /**
+   * Remove a widget from the DOM and store if it exists.
+   * This is the sole method performing element.remove().
+   *
+   * @private
+   * @param {string} id
+   * @function _evict
+   * @returns {void}
+   */
+  _evict (id) {
+    const el = this.widgets.get(id)
+    if (el) {
+      el.remove()
+      this.widgets.delete(id)
+      this.logger.log('Evicted widget:', id)
+    }
+  }
+
+  /**
+   * Ensure the store does not exceed its capacity.
+   * Older entries are evicted first.
+   *
+   * @private
+   * @function _ensureLimit
+   * @returns {void}
+   */
+  _ensureLimit () {
+    while (this.widgets.size > this.maxSize) {
+      const oldestId = this.widgets.keys().next().value
+      this._evict(oldestId)
+    }
+  }
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,7 @@ declare global {
       boards: import('./types.js').Board[];
       currentBoardId: string | null;
       currentViewId: string | null;
+      widgetStore: import('./component/widget/widgetStore.js').WidgetStore;
     };
     _appLogs?: import('./types.js').LoggerEntry[];
   }

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ import { initializeBoardDropdown } from './component/board/boardDropdown.js'
 import { initializeViewDropdown } from './component/view/viewDropdown.js'
 import { loadFromFragment } from './utils/fragmentLoader.js'
 import { Logger } from './utils/Logger.js'
+import { WidgetStore } from './component/widget/widgetStore.js'
 
 const logger = new Logger('main.js')
 
@@ -27,7 +28,8 @@ window.asd = {
   config: {},
   boards: [],
   currentBoardId: null,
-  currentViewId: null
+  currentViewId: null,
+  widgetStore: new WidgetStore()
 }
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/symbols.json
+++ b/symbols.json
@@ -1,5 +1,46 @@
 [
   {
+    "name": "_ensureLimit",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Ensure the store does not exceed its capacity. Older entries are evicted first.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "_evict",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Remove a widget from the DOM and store if it exists. This is the sole method performing element.remove().",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "add",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Store a widget element by id. Existing entries are refreshed.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "element",
+        "type": "HTMLElement",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "addBoardToUI",
     "kind": "function",
     "file": "src/component/board/boardManagement.js",
@@ -357,6 +398,20 @@
     "returns": "Promise<Array<Service>>"
   },
   {
+    "name": "get",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Retrieve a widget element and mark it as recently used.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "HTMLElement|undefined"
+  },
+  {
     "name": "getAuthToken",
     "kind": "function",
     "file": "src/component/widget/utils/fetchData.js",
@@ -640,6 +695,34 @@
       }
     ],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "has",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Check if a widget exists in the store.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "boolean"
+  },
+  {
+    "name": "hide",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Hide a stored widget by id.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
   },
   {
     "name": "info",
@@ -1036,6 +1119,20 @@
     "returns": "void"
   },
   {
+    "name": "requestRemoval",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Request removal of a widget from the DOM and store.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "resetView",
     "kind": "function",
     "file": "src/component/board/boardManagement.js",
@@ -1086,6 +1183,20 @@
       }
     ],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "show",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Show a stored widget by id.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
   },
   {
     "name": "showNotification",
@@ -1233,5 +1344,13 @@
     "description": "Generate a unique widget id.",
     "params": [],
     "returns": "string"
+  },
+  {
+    "name": "WidgetStore",
+    "kind": "class",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Lightweight LRU cache storing widget elements by id. Evicts least recently used widgets when capacity is exceeded.",
+    "params": [],
+    "returns": ""
   }
 ]


### PR DESCRIPTION
## Summary
- add a new `WidgetStore` for LRU widget management
- expose the store via `window.asd`
- make `addWidget` idempotent and use the store for removals
- switch views by showing/hiding widgets from the store
- update symbol index

## Testing
- `npm run lint-fix`
- `npm run test`
- `node scripts/extract-symbol-index.mjs`
- `node scripts/playwright-indexer.js`


------
https://chatgpt.com/codex/tasks/task_b_686430da967c8325846b85835c526f56