### PR TITLE
Refactor drag and drop ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "localStorage",
       "location",
       "getComputedStyle",
-      "caches"
+      "caches",
+      "HTMLElement"
     ]
   }
 }

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -120,14 +120,14 @@ function handleDrop (e, targetWidgetWrapper) {
   const widgetContainer = document.getElementById('widget-container')
   const draggedWidget = widgetContainer.querySelector(`[data-order='${draggedOrder}']`)
 
-  if (!draggedWidget) {
+  if (!(draggedWidget instanceof HTMLElement)) {
     logger.error('Invalid dragged widget element', 3000, 'error')
     return
   }
 
   if (targetOrder !== null) {
     const targetWidget = widgetContainer.querySelector(`[data-order='${targetOrder}']`)
-    if (!targetWidget) {
+    if (!(targetWidget instanceof HTMLElement)) {
       logger.error('Invalid target widget element', 3000, 'error')
       return
     }

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -137,17 +137,11 @@ function handleDrop (e, targetWidgetWrapper) {
       targetWidgetOrder: targetWidget.getAttribute('data-order')
     })
 
-    widgetContainer.removeChild(draggedWidget)
+    draggedWidget.setAttribute('data-order', targetOrder)
+    targetWidget.setAttribute('data-order', draggedOrder)
 
-    if (parseInt(draggedOrder) < parseInt(targetOrder)) {
-      if (targetWidget.nextSibling) {
-        widgetContainer.insertBefore(draggedWidget, targetWidget.nextSibling)
-      } else {
-        widgetContainer.appendChild(draggedWidget)
-      }
-    } else {
-      widgetContainer.insertBefore(draggedWidget, targetWidget)
-    }
+    draggedWidget.style.order = targetOrder
+    targetWidget.style.order = draggedOrder
   } else {
     // Calculate nearest available grid position
     const gridColumnCount = parseInt(getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length.toString(), 10)

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -297,13 +297,14 @@ async function configureWidget (iframeElement) {
 function updateWidgetOrders () {
   const widgetContainer = document.getElementById('widget-container')
   const widgets = Array.from(widgetContainer.children)
+    .map(w => /** @type {HTMLElement} */(w))
+    .sort((a, b) => parseInt(a.style.order || '0') - parseInt(b.style.order || '0'))
 
   widgets.forEach((widget, index) => {
-    const el = /** @type {HTMLElement} */(widget)
-    el.setAttribute('data-order', String(index))
-    el.style.order = String(index)
+    widget.setAttribute('data-order', String(index))
+    widget.style.order = String(index)
     logger.log('Updated widget order:', {
-      dataid: el.dataset.dataid,
+      dataid: widget.dataset.dataid,
       order: index
     })
   })


### PR DESCRIPTION
## Summary
- swap widgets using data-order and CSS order properties
- compute new order based on style ordering

## Testing
- `just extract-symbols`
- `just test` *(fails: Widgets › should be able to add 4 services and drag and drop 🤏)*

------
https://chatgpt.com/codex/tasks/task_b_68643a2af6088325aa38e6a42e36792a