### PR TITLE
Expose widgetStore singleton

### DIFF
--- a/src/component/widget/widgetStore.js
+++ b/src/component/widget/widgetStore.js
@@ -137,3 +137,5 @@ export class WidgetStore {
     }
   }
 }
+
+export const widgetStore = new WidgetStore()

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ import { initializeBoardDropdown } from './component/board/boardDropdown.js'
 import { initializeViewDropdown } from './component/view/viewDropdown.js'
 import { loadFromFragment } from './utils/fragmentLoader.js'
 import { Logger } from './utils/Logger.js'
-import { WidgetStore } from './component/widget/widgetStore.js'
+import { widgetStore } from './component/widget/widgetStore.js'
 
 const logger = new Logger('main.js')
 
@@ -29,7 +29,7 @@ window.asd = {
   boards: [],
   currentBoardId: null,
   currentViewId: null,
-  widgetStore: new WidgetStore()
+  widgetStore
 }
 
 document.addEventListener('DOMContentLoaded', async () => {


### PR DESCRIPTION
## Summary
- expose widgetStore singleton so modules can reuse it
- reference the singleton in main.js

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `just test`
- `node scripts/playwright-indexer.js`


------
https://chatgpt.com/codex/tasks/task_b_6864444daeb88325b048030183e6f333