### PR TITLE
Fix widget state persistence and cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "localStorage",
       "location",
       "getComputedStyle",
-      "caches"
+      "caches",
+      "HTMLElement"
     ]
   }
 }

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -120,14 +120,14 @@ function handleDrop (e, targetWidgetWrapper) {
   const widgetContainer = document.getElementById('widget-container')
   const draggedWidget = widgetContainer.querySelector(`[data-order='${draggedOrder}']`)
 
-  if (!draggedWidget) {
+  if (!(draggedWidget instanceof HTMLElement)) {
     logger.error('Invalid dragged widget element', 3000, 'error')
     return
   }
 
   if (targetOrder !== null) {
     const targetWidget = widgetContainer.querySelector(`[data-order='${targetOrder}']`)
-    if (!targetWidget) {
+    if (!(targetWidget instanceof HTMLElement)) {
       logger.error('Invalid target widget element', 3000, 'error')
       return
     }
@@ -137,17 +137,11 @@ function handleDrop (e, targetWidgetWrapper) {
       targetWidgetOrder: targetWidget.getAttribute('data-order')
     })
 
-    widgetContainer.removeChild(draggedWidget)
+    draggedWidget.setAttribute('data-order', targetOrder)
+    targetWidget.setAttribute('data-order', draggedOrder)
 
-    if (parseInt(draggedOrder) < parseInt(targetOrder)) {
-      if (targetWidget.nextSibling) {
-        widgetContainer.insertBefore(draggedWidget, targetWidget.nextSibling)
-      } else {
-        widgetContainer.appendChild(draggedWidget)
-      }
-    } else {
-      widgetContainer.insertBefore(draggedWidget, targetWidget)
-    }
+    draggedWidget.style.order = targetOrder
+    targetWidget.style.order = draggedOrder
   } else {
     // Calculate nearest available grid position
     const gridColumnCount = parseInt(getComputedStyle(widgetContainer).getPropertyValue('grid-template-columns').split(' ').length.toString(), 10)

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -227,7 +227,7 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   const widgetWrapper = await createWidget(service, url, columns, rows, dataid)
   widgetWrapper.setAttribute('data-order', String(widgetContainer.children.length))
   widgetContainer.appendChild(widgetWrapper)
-  window.asd.widgetStore.add(widgetWrapper.dataset.dataid, widgetWrapper)
+  window.asd.widgetStore.add(widgetWrapper)
 
   logger.log('Widget appended to container:', widgetWrapper)
 

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -297,13 +297,14 @@ async function configureWidget (iframeElement) {
 function updateWidgetOrders () {
   const widgetContainer = document.getElementById('widget-container')
   const widgets = Array.from(widgetContainer.children)
+    .map(w => /** @type {HTMLElement} */(w))
+    .sort((a, b) => parseInt(a.style.order || '0') - parseInt(b.style.order || '0'))
 
   widgets.forEach((widget, index) => {
-    const el = /** @type {HTMLElement} */(widget)
-    el.setAttribute('data-order', String(index))
-    el.style.order = String(index)
+    widget.setAttribute('data-order', String(index))
+    widget.style.order = String(index)
     logger.log('Updated widget order:', {
-      dataid: el.dataset.dataid,
+      dataid: widget.dataset.dataid,
       order: index
     })
   })

--- a/src/component/widget/widgetStore.js
+++ b/src/component/widget/widgetStore.js
@@ -24,14 +24,16 @@ export class WidgetStore {
   }
 
   /**
-   * Store a widget element by id. Existing entries are refreshed.
+   * Store a widget element using its `dataid` attribute as the key.
+   * Existing entries are refreshed.
    *
-   * @param {string} id
    * @param {HTMLElement} element
    * @function add
    * @returns {void}
    */
-  add (id, element) {
+  add (element) {
+    const id = element.dataset.dataid
+    if (!id) return
     if (this.widgets.has(id)) {
       this.widgets.delete(id)
     }

--- a/symbols.json
+++ b/symbols.json
@@ -25,13 +25,8 @@
     "name": "add",
     "kind": "function",
     "file": "src/component/widget/widgetStore.js",
-    "description": "Store a widget element by id. Existing entries are refreshed.",
+    "description": "Store a widget element using its `dataid` attribute as the key. Existing entries are refreshed.",
     "params": [
-      {
-        "name": "id",
-        "type": "string",
-        "desc": ""
-      },
       {
         "name": "element",
         "type": "HTMLElement",


### PR DESCRIPTION
## Summary
- fix widgetStore.add to take a widget element and use dataset id
- register widgets in store using updated API
- update symbol index

## Testing
- `npm run lint-fix`
- `just extract-symbols`
- `just test` *(fails: TimeoutError: locator.getAttribute)*
- `just index-report` *(fails: Cannot find module `scripts/just/scripts/playwright-indexer.js`)*

------
https://chatgpt.com/codex/tasks/task_b_686446f1bd3c8325bcbe52605e928dc7