### PR TITLE
Add JSDoc documentation

### DIFF
--- a/scripts/playwright-extract-logs.js
+++ b/scripts/playwright-extract-logs.js
@@ -1,39 +1,46 @@
 #!/usr/bin/env node
+// @ts-check
 /**
- * Decode console / network / app logs for a test matched by NAME & BROWSER.
- * Usage: node playwright-extract-logs.js "<name substring>" "<browser-regex>"
+ * Extracts and filters logs from the compressed Playwright report index.
+ * This script allows for targeted inspection of test logs based on browser and spec file patterns.
+ * @function main
+ * @returns {Promise<void>}
  */
-const [, , namePattern, browserPattern = '.*'] = process.argv
-if (!namePattern) {
-  console.error('Usage: node playwright-extract-logs.js "<name>" [browser-regex]')
-  process.exit(1)
-}
-const report = JSON.parse(require('fs').readFileSync('playwright-report.json', 'utf8'))
-const nameRe = new RegExp(namePattern, 'i')
-const brwRe = new RegExp(browserPattern, 'i')
+async function main () {
+  const [, , namePattern, browserPattern = '.*'] = process.argv
+  if (!namePattern) {
+    console.error('Usage: node playwright-extract-logs.js "<name>" [browser-regex]')
+    process.exit(1)
+  }
+  const report = JSON.parse(require('fs').readFileSync('playwright-report.json', 'utf8'))
+  const nameRe = new RegExp(namePattern, 'i')
+  const brwRe = new RegExp(browserPattern, 'i')
 
-function * tests (suite, ancestry = []) {
-  for (const s of suite.suites || []) yield * tests(s, ancestry.concat(suite.title))
-  for (const spec of suite.specs || []) {
-    for (const t of spec.tests) {
-      yield {
-        test: t,
-        title: ancestry.concat(suite.title, spec.title).filter(Boolean).join(' › ')
+  function * tests (suite, ancestry = []) {
+    for (const s of suite.suites || []) yield * tests(s, ancestry.concat(suite.title))
+    for (const spec of suite.specs || []) {
+      for (const t of spec.tests) {
+        yield {
+          test: t,
+          title: ancestry.concat(suite.title, spec.title).filter(Boolean).join(' › ')
+        }
       }
+    }
+  }
+
+  for (const s of report.suites) {
+    for (const { test, title } of tests(s)) {
+      if (!nameRe.test(title) || !brwRe.test(test.projectName)) continue
+      const r0 = test.results[0] || {}
+      console.log(`\n=== ${title} (${test.projectName}) [${r0.status}] ===`);
+      (r0.attachments || []).forEach(att => {
+        if (att.contentType === 'application/json') {
+          const body = Buffer.from(att.body, 'base64').toString('utf8')
+          console.log(`\n--- ${att.name} ---\n`, JSON.parse(body))
+        }
+      })
     }
   }
 }
 
-for (const s of report.suites) {
-  for (const { test, title } of tests(s)) {
-    if (!nameRe.test(title) || !brwRe.test(test.projectName)) continue
-    const r0 = test.results[0] || {}
-    console.log(`\n=== ${title} (${test.projectName}) [${r0.status}] ===`);
-    (r0.attachments || []).forEach(att => {
-      if (att.contentType === 'application/json') {
-        const body = Buffer.from(att.body, 'base64').toString('utf8')
-        console.log(`\n--- ${att.name} ---\n`, JSON.parse(body))
-      }
-    })
-  }
-}
+main()

--- a/serve_no_cache.js
+++ b/serve_no_cache.js
@@ -1,4 +1,5 @@
 // serve_no_cache.js
+// @ts-check
 const http = require('http')
 const fs = require('fs')
 const path = require('path')
@@ -14,7 +15,12 @@ function logRequest (req, res, statusCode) {
 }
 
 // Serve static files with no-cache headers
-http.createServer((req, res) => {
+/**
+ * A simple HTTP server that serves files with no-cache headers.
+ * This is essential for development to ensure the latest code changes are always reflected.
+ * @type {http.Server}
+ */
+const server = http.createServer((req, res) => {
   let filePath = path.join(BASEDIR, decodeURIComponent(req.url.split('?')[0]))
   if (filePath.endsWith('/')) filePath += 'index.html'
   fs.stat(filePath, (err, stats) => {
@@ -51,6 +57,8 @@ http.createServer((req, res) => {
       logRequest(req, res, 500)
     })
   })
-}).listen(PORT, () => {
+})
+
+server.listen(PORT, () => {
   console.log(`Serving ${BASEDIR} on http://localhost:${PORT}`)
 })

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -101,6 +101,12 @@ export async function createView (boardId, viewName, viewId = null) {
   }
 }
 
+/**
+ * Hides all widgets currently managed by the widgetStore.
+ * This is used to clear the view without removing elements from the DOM permanently.
+ * @function clearWidgetContainer
+ * @returns {void}
+ */
 function clearWidgetContainer () {
   // Hide all widgets in the store instead of removing from DOM
   for (const id of widgetStore.widgets.keys()) {
@@ -441,6 +447,11 @@ export async function resetView (boardId, viewId) {
   }
 }
 
+/**
+ * Rebuilds the board selector dropdown from the in-memory `boards` array.
+ * @function updateBoardSelector
+ * @returns {void}
+ */
 function updateBoardSelector () {
   const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   boardSelector.innerHTML = ''

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -21,6 +21,12 @@ function initSW () {
   const swEnabled = localStorage.getItem('swEnabled') === 'true'
   swToggle.checked = swEnabled
 
+  /**
+   * Updates the UI of the service worker toggle icon and attributes.
+   * @function updateServiceWorkerUI
+   * @param {boolean} isEnabled - True if the service worker should be shown as enabled.
+   * @returns {void}
+   */
   function updateServiceWorkerUI (isEnabled) {
     if (isEnabled) {
       swIcon.textContent = emojiList.serviceWorkerEnabled.unicode // Network On
@@ -36,6 +42,11 @@ function initSW () {
   updateServiceWorkerUI(swEnabled)
 
   if ('serviceWorker' in navigator) {
+    /**
+     * Registers the service worker script.
+     * @function registerServiceWorker
+     * @returns {void}
+     */
     function registerServiceWorker () {
       navigator.serviceWorker.register('/serviceWorker.js', { scope: '/' })
         .then(function (registration) {
@@ -46,6 +57,11 @@ function initSW () {
         })
     }
 
+    /**
+     * Unregisters all active service workers and clears their caches.
+     * @function unregisterServiceWorker
+     * @returns {void}
+     */
     function unregisterServiceWorker () {
       navigator.serviceWorker.getRegistrations()
         .then(function (registrations) {
@@ -249,6 +265,11 @@ function initializeMainMenu () {
   initSW()
 }
 
+/**
+ * Applies visibility settings to control groups based on global configuration.
+ * @function applyControlVisibility
+ * @returns {void}
+ */
 function applyControlVisibility () {
   const settings = window.asd.config?.globalSettings || {}
   const boardControl = document.getElementById('board-control')

--- a/src/component/modal/fragmentDecisionModal.js
+++ b/src/component/modal/fragmentDecisionModal.js
@@ -65,6 +65,12 @@ export function openFragmentDecisionModal (cfgParam, svcParam) {
 
         modal.append(msg1, msg2, btnGroup)
 
+        /**
+         * Applies the configuration from the URL fragment, either by overwriting or merging.
+         * @function applyFragment
+         * @param {boolean} overwrite - If true, existing data will be replaced.
+         * @returns {Promise<void>}
+         */
         async function applyFragment (overwrite) {
           try {
             if (cfgParam) {

--- a/src/component/modal/localStorageModal.js
+++ b/src/component/modal/localStorageModal.js
@@ -10,6 +10,12 @@ import { Logger } from '../../utils/Logger.js'
 
 const logger = new Logger('localStorageModal.js')
 
+/**
+ * Checks if a given string is valid JSON.
+ * @function isJSON
+ * @param {string} value - The string to check.
+ * @returns {boolean} True if the string is valid JSON, false otherwise.
+ */
 function isJSON (value) {
   try {
     JSON.parse(value)
@@ -21,6 +27,11 @@ function isJSON (value) {
   }
 }
 
+/**
+ * Retrieves and parses all JSON-formatted items from localStorage.
+ * @function getLocalStorageData
+ * @returns {Record<string, any>} An object containing the parsed localStorage data.
+ */
 function getLocalStorageData () {
   const localStorageData = {}
 
@@ -39,6 +50,12 @@ function getLocalStorageData () {
   return localStorageData
 }
 
+/**
+ * Saves a data object to localStorage, serializing each value to a JSON string.
+ * @function saveLocalStorageData
+ * @param {Record<string, any>} updatedData - The data to save.
+ * @returns {void}
+ */
 function saveLocalStorageData (updatedData) {
   for (const key in updatedData) {
     const value = updatedData[key]

--- a/src/component/modal/modalFactory.js
+++ b/src/component/modal/modalFactory.js
@@ -28,6 +28,12 @@ export function openModal ({ id, buildContent, onCloseCallback, showCloseIcon = 
 
   logger.log(`Opening modal ${id}`)
 
+  /**
+   * Handles the 'Escape' key press to close the modal.
+   * @function handleEscape
+   * @param {KeyboardEvent} e - The keyboard event.
+   * @returns {void}
+   */
   function handleEscape (e) {
     if (e.key === 'Escape') closeModal()
   }
@@ -79,6 +85,11 @@ export function openModal ({ id, buildContent, onCloseCallback, showCloseIcon = 
   backdrop.appendChild(modal)
   document.body.appendChild(backdrop)
 
+  /**
+   * Closes the modal, removes the backdrop and event listeners, and calls the close callback.
+   * @function closeModal
+   * @returns {void}
+   */
   function closeModal () {
     backdrop.remove()
     window.removeEventListener('keydown', handleEscape)

--- a/src/component/widget/events/dragDrop.js
+++ b/src/component/widget/events/dragDrop.js
@@ -13,6 +13,13 @@ const logger = new Logger('dragDrop.js')
 
 // --- Event Handlers from Your Original Code ---
 
+/**
+ * Handles the start of a drag operation.
+ * @function handleDragStart
+ * @param {DragEvent} e - The dragstart event.
+ * @param {HTMLElement} draggedWidgetWrapper - The widget element being dragged.
+ * @returns {void}
+ */
 function handleDragStart (e, draggedWidgetWrapper) {
   // FIX #1: Use the stable `data-dataid` instead of the changing `data-order`.
   const widgetId = draggedWidgetWrapper.dataset.dataid
@@ -31,6 +38,12 @@ function handleDragStart (e, draggedWidgetWrapper) {
   })
 }
 
+/**
+ * Handles the end of a drag operation, cleaning up UI elements.
+ * @function handleDragEnd
+ * @param {DragEvent} e - The dragend event.
+ * @returns {void}
+ */
 function handleDragEnd (e) {
   // Your proven cleanup logic. This removes all visual artifacts.
   logger.log('Drag End triggered. Cleaning up UI.')
@@ -42,6 +55,14 @@ function handleDragEnd (e) {
 }
 
 // FIX #2: The drop handler MUST be async to await the state saving.
+/**
+ * Handles the drop event on a target widget.
+ * @async
+ * @function handleDrop
+ * @param {DragEvent} e - The drop event.
+ * @param {HTMLElement} targetWidgetWrapper - The widget being dropped on.
+ * @returns {Promise<void>}
+ */
 async function handleDrop (e, targetWidgetWrapper) {
   e.preventDefault()
   e.stopPropagation()
@@ -68,17 +89,37 @@ async function handleDrop (e, targetWidgetWrapper) {
   updateWidgetOrders()
 }
 
+/**
+ * Handles the dragover event on a potential drop target.
+ * @function handleDragOver
+ * @param {DragEvent} e - The dragover event.
+ * @param {HTMLElement} widgetWrapper - The widget being hovered over.
+ * @returns {void}
+ */
 function handleDragOver (e, widgetWrapper) {
   e.preventDefault()
   widgetWrapper.classList.add('drag-over', 'highlight-drop-area')
 }
 
+/**
+ * Handles the dragleave event on a potential drop target.
+ * @function handleDragLeave
+ * @param {DragEvent} e - The dragleave event.
+ * @param {HTMLElement} widgetWrapper - The widget that the cursor is leaving.
+ * @returns {void}
+ */
 function handleDragLeave (e, widgetWrapper) {
   widgetWrapper.classList.remove('drag-over', 'highlight-drop-area')
 }
 
 // --- Helper Functions (Your Original Overlay Logic) ---
 
+/**
+ * Adds a transparent overlay to a widget to act as a drop target.
+ * @function addDragOverlay
+ * @param {HTMLElement} widgetWrapper - The widget to add an overlay to.
+ * @returns {void}
+ */
 function addDragOverlay (widgetWrapper) {
   const dragOverlay = document.createElement('div')
   dragOverlay.classList.add('drag-overlay')
@@ -92,6 +133,12 @@ function addDragOverlay (widgetWrapper) {
   widgetWrapper.appendChild(dragOverlay)
 }
 
+/**
+ * Removes the drag overlay from a widget.
+ * @function removeDragOverlay
+ * @param {HTMLElement} widgetWrapper - The widget to remove the overlay from.
+ * @returns {void}
+ */
 function removeDragOverlay (widgetWrapper) {
   const dragOverlay = widgetWrapper.querySelector('.drag-overlay')
   if (dragOverlay) {
@@ -100,6 +147,12 @@ function removeDragOverlay (widgetWrapper) {
 }
 
 // No container-level listeners are needed with this correct overlay model.
+/**
+ * Initializes the drag and drop functionality. In this model, it's a placeholder
+ * as event listeners are attached dynamically during the drag operation.
+ * @function initializeDragAndDrop
+ * @returns {void}
+ */
 function initializeDragAndDrop () {
   logger.log('Drag and drop handlers are ready to be attached on drag start.')
 }

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -39,6 +39,11 @@ export function initializeResizeHandles () {
   })
 }
 
+/**
+ * Creates a full-screen overlay to capture mouse events during resizing.
+ * @function createResizeOverlay
+ * @returns {HTMLDivElement} The created overlay element.
+ */
 function createResizeOverlay () {
   const overlay = document.createElement('div')
   overlay.className = 'resize-overlay'
@@ -81,6 +86,12 @@ async function handleResizeStart (event, widget) {
   // Create and append an overlay to capture all mouse events
   const overlay = createResizeOverlay()
 
+  /**
+   * Handles mouse movement during a resize operation, updating the widget's grid span.
+   * @function handleResize
+   * @param {MouseEvent} event - The mousemove event.
+   * @returns {void}
+   */
   function handleResize (event) {
     try {
       const newWidth = Math.max(1, Math.round((startWidth + event.clientX - startX) / gridColumnSize))
@@ -100,6 +111,11 @@ async function handleResizeStart (event, widget) {
     }
   }
 
+  /**
+   * Handles the end of a resize operation, cleaning up listeners and saving state.
+   * @function stopResize
+   * @returns {void}
+   */
   function stopResize () {
     try {
       document.removeEventListener('mousemove', handleResize)

--- a/src/component/widget/menu/resizeMenu.js
+++ b/src/component/widget/menu/resizeMenu.js
@@ -7,7 +7,13 @@ import { Logger } from '../../../utils/Logger.js'
 
 const logger = new Logger('resizeMenu.js')
 
-// Function to resize widget horizontally
+/**
+ * Resizes the widget horizontally by adjusting its grid column span.
+ * @function resizeHorizontally
+ * @param {HTMLElement} widget - The widget element to resize.
+ * @param {boolean} [increase=true] - Whether to increase or decrease the size.
+ * @returns {Promise<void>}
+ */
 async function resizeHorizontally (widget, increase = true) {
   try {
     const config = await getConfig()
@@ -48,7 +54,13 @@ async function resizeHorizontally (widget, increase = true) {
   }
 }
 
-// Function to resize widget vertically
+/**
+ * Resizes the widget vertically by adjusting its grid row span.
+ * @function resizeVertically
+ * @param {HTMLElement} widget - The widget element to resize.
+ * @param {boolean} [increase=true] - Whether to increase or decrease the size.
+ * @returns {Promise<void>}
+ */
 async function resizeVertically (widget, increase = true) {
   try {
     const config = await getConfig()
@@ -89,6 +101,12 @@ async function resizeVertically (widget, increase = true) {
   }
 }
 
+/**
+ * Enlarges the widget both horizontally and vertically by one unit.
+ * @function enlarge
+ * @param {HTMLElement} widget - The widget element to enlarge.
+ * @returns {Promise<void>}
+ */
 async function enlarge (widget) {
   try {
     await resizeHorizontally(widget, true)
@@ -99,6 +117,12 @@ async function enlarge (widget) {
   }
 }
 
+/**
+ * Shrinks the widget both horizontally and vertically by one unit.
+ * @function shrink
+ * @param {HTMLElement} widget - The widget element to shrink.
+ * @returns {Promise<void>}
+ */
 async function shrink (widget) {
   try {
     await resizeHorizontally(widget, false)
@@ -109,7 +133,12 @@ async function shrink (widget) {
   }
 }
 
-// Function to show resize menu
+/**
+ * Shows the resize menu with directional arrows for a widget.
+ * @function showResizeMenu
+ * @param {HTMLElement} icon - The icon element that triggered the event.
+ * @returns {Promise<void>}
+ */
 async function showResizeMenu (icon) {
   try {
     const widget = icon.closest('.widget-wrapper')
@@ -160,7 +189,12 @@ async function showResizeMenu (icon) {
   }
 }
 
-// Function to hide resize menu
+/**
+ * Hides the resize menu for a widget.
+ * @function hideResizeMenu
+ * @param {HTMLElement} icon - The icon element that triggered the event.
+ * @returns {Promise<void>}
+ */
 async function hideResizeMenu (icon) {
   try {
     const widget = icon.closest('.widget-wrapper')
@@ -174,7 +208,13 @@ async function hideResizeMenu (icon) {
   }
 }
 
-// Function to show resize menu block
+/**
+ * Shows a menu block with explicit size options (e.g., "2 columns, 3 rows").
+ * @function showResizeMenuBlock
+ * @param {HTMLElement} icon - The icon element that triggered the event.
+ * @param {HTMLElement} widgetWrapper - The widget to show the menu for.
+ * @returns {Promise<void>}
+ */
 async function showResizeMenuBlock (icon, widgetWrapper) {
   try {
     const widgetUrl = widgetWrapper.dataset.url
@@ -232,7 +272,12 @@ async function showResizeMenuBlock (icon, widgetWrapper) {
   }
 }
 
-// Function to hide resize menu block
+/**
+ * Hides the resize menu block for a widget.
+ * @function hideResizeMenuBlock
+ * @param {HTMLElement} widgetWrapper - The widget to hide the menu from.
+ * @returns {Promise<void>}
+ */
 async function hideResizeMenuBlock (widgetWrapper) {
   logger.log('Removing resize menu block')
   try {
@@ -248,7 +293,14 @@ async function hideResizeMenuBlock (widgetWrapper) {
   }
 }
 
-// Function to adjust widget size
+/**
+ * Adjusts the widget size to a specific column and row span.
+ * @function adjustWidgetSize
+ * @param {HTMLElement} widgetWrapper - The widget to resize.
+ * @param {number} columns - The target number of columns.
+ * @param {number} rows - The target number of rows.
+ * @returns {Promise<void>}
+ */
 async function adjustWidgetSize (widgetWrapper, columns, rows) {
   try {
     const config = await getConfig()

--- a/src/component/widget/utils/fetchServices.js
+++ b/src/component/widget/utils/fetchServices.js
@@ -12,6 +12,12 @@ let serviceCache = null
 let lastFetchTime = 0
 const STORAGE_KEY = 'services'
 
+/**
+ * Parses a base64 encoded JSON string.
+ * @function parseBase64
+ * @param {string} data - The base64 encoded string.
+ * @returns {object|null} The parsed object, or null on error.
+ */
 function parseBase64 (data) {
   try {
     return JSON.parse(atob(data))
@@ -21,6 +27,12 @@ function parseBase64 (data) {
   }
 }
 
+/**
+ * Fetches and parses a JSON file from a URL.
+ * @function fetchJson
+ * @param {string} url - The URL to fetch the JSON from.
+ * @returns {Promise<object|null>} The parsed object, or null on error.
+ */
 async function fetchJson (url) {
   try {
     const response = await fetch(url)

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -21,6 +21,16 @@ import { widgetGetUUID } from '../../utils/id.js'
 
 const logger = new Logger('widgetManagement.js')
 
+/**
+ * Creates the DOM structure for a new widget, including its iframe and menu.
+ * @function createWidget
+ * @param {string} service - The service identifier.
+ * @param {string} url - The URL for the widget's iframe source.
+ * @param {number} [gridColumnSpan=1] - The number of grid columns to span.
+ * @param {number} [gridRowSpan=1] - The number of grid rows to span.
+ * @param {string|null} [dataid=null] - An optional persistent identifier for the widget.
+ * @returns {Promise<HTMLDivElement>} A promise that resolves to the widget's wrapper element.
+ */
 async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, dataid = null) {
   logger.log('Creating widget with URL:', url)
   const config = await getConfig()
@@ -123,6 +133,18 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   return widgetWrapper
 }
 
+/**
+ * Adds a new widget to the current view and persists the state.
+ * @function addWidget
+ * @param {string} url - The URL of the service to embed.
+ * @param {number} [columns=1] - The number of grid columns for the widget to span.
+ * @param {number} [rows=1] - The number of grid rows for the widget to span.
+ * @param {string} [type='iframe'] - The type of the widget.
+ * @param {string} boardId - The ID of the board to add the widget to.
+ * @param {string} viewId - The ID of the view to add the widget to.
+ * @param {string|null} [dataid=null] - An optional persistent identifier for the widget.
+ * @returns {Promise<void>}
+ */
 async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, viewId, dataid = null) {
   logger.log('Adding widget with URL:', url)
   const widgetContainer = document.getElementById('widget-container')
@@ -160,12 +182,24 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId, 
   initializeResizeHandles()
 }
 
+/**
+ * Removes a widget from the view and updates the layout.
+ * @function removeWidget
+ * @param {HTMLElement} widgetElement - The widget wrapper element to remove.
+ * @returns {void}
+ */
 function removeWidget (widgetElement) {
   const dataid = widgetElement.dataset.dataid
   window.asd.widgetStore.requestRemoval(dataid)
   updateWidgetOrders()
 }
 
+/**
+ * Prompts the user to enter a new URL for a widget's iframe.
+ * @function configureWidget
+ * @param {HTMLIFrameElement} iframeElement - The iframe element of the widget to configure.
+ * @returns {Promise<void>}
+ */
 async function configureWidget (iframeElement) {
   const newUrl = prompt('Enter new URL for the widget:', iframeElement.src)
   if (newUrl) {

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -11,6 +11,12 @@ import { Logger } from '../utils/Logger.js'
 
 const logger = new Logger('localStorage.js')
 
+/**
+ * Converts a widget DOM element into a serializable state object.
+ * @function serializeWidgetState
+ * @param {HTMLElement} widget - The widget element.
+ * @returns {import('../types.js').Widget} A serializable widget state object.
+ */
 function serializeWidgetState (widget) {
   let metadata = {}
   if (widget.dataset.metadata) {
@@ -35,6 +41,13 @@ function serializeWidgetState (widget) {
   return state
 }
 
+/**
+ * Serializes the state of all visible widgets and saves it to localStorage.
+ * @function saveWidgetState
+ * @param {string} boardId - The ID of the current board.
+ * @param {string} viewId - The ID of the current view.
+ * @returns {void}
+ */
 function saveWidgetState (boardId, viewId) {
   if (!boardId || !viewId) {
     return logger.error('Board ID or View ID is missing. Cannot save widget state.')
@@ -75,6 +88,12 @@ function saveWidgetState (boardId, viewId) {
   }
 }
 
+/**
+ * Loads the initial board configuration from the global config object into localStorage.
+ * This is typically called on first run to seed the dashboard.
+ * @function loadInitialConfig
+ * @returns {Promise<void>}
+ */
 async function loadInitialConfig () {
   try {
     const boards = window.asd.config.boards
@@ -86,6 +105,12 @@ async function loadInitialConfig () {
   }
 }
 
+/**
+ * Persists the entire array of board objects to localStorage.
+ * @function saveBoardState
+ * @param {Array<import('../types.js').Board>} boards - The array of boards to save.
+ * @returns {void}
+ */
 function saveBoardState (boards) {
   try {
     localStorage.setItem('boards', JSON.stringify(boards))
@@ -96,6 +121,11 @@ function saveBoardState (boards) {
   }
 }
 
+/**
+ * Retrieves the array of boards from localStorage.
+ * @function loadBoardState
+ * @returns {Promise<Array<import('../types.js').Board>>} A promise that resolves to the array of boards.
+ */
 async function loadBoardState () {
   try {
     const boardsJSON = localStorage.getItem('boards')

--- a/src/storage/servicesStore.js
+++ b/src/storage/servicesStore.js
@@ -1,6 +1,11 @@
 // @ts-check
 const STORAGE_KEY = 'services'
 
+/**
+ * Loads the array of services from localStorage.
+ * @function load
+ * @returns {Array<import('../types.js').Service>} An array of service objects.
+ */
 export function load () {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
@@ -11,6 +16,12 @@ export function load () {
   }
 }
 
+/**
+ * Saves the array of services to localStorage.
+ * @function save
+ * @param {Array<import('../types.js').Service>} services - The array of services to save.
+ * @returns {void}
+ */
 export function save (services) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(services))
 }

--- a/src/utils/Logger.js
+++ b/src/utils/Logger.js
@@ -1,10 +1,6 @@
 // @ts-check
 /**
- * Simple browser console logger with runtime enable/disable support.
- * During Playwright test runs (via `navigator.webdriver`), structured logs are
- * also stored in `window._appLogs` for later harvesting.
- *
- * @module Logger
+ * A simple browser console logger with runtime enable/disable support.
  * @class Logger
  */
 export class Logger {

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -12,6 +12,12 @@ import { showNotification } from '../component/dialog/notification.js'
 const logger = new Logger('fetchServices.js')
 const STORAGE_KEY = 'services'
 
+/**
+ * Parses a base64 encoded JSON string.
+ * @function parseBase64
+ * @param {string} data - The base64 encoded string.
+ * @returns {object|null} The parsed object, or null on error.
+ */
 function parseBase64 (data) {
   try {
     return JSON.parse(atob(data))
@@ -22,6 +28,12 @@ function parseBase64 (data) {
   }
 }
 
+/**
+ * Fetches and parses a JSON file from a URL.
+ * @function fetchJson
+ * @param {string} url - The URL to fetch JSON from.
+ * @returns {Promise<object|null>} The parsed object, or null on error.
+ */
 async function fetchJson (url) {
   try {
     const response = await fetch(url)

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -12,6 +12,12 @@ import { openConfigModal, DEFAULT_CONFIG_TEMPLATE } from '../component/modal/con
 const logger = new Logger('getConfig.js')
 const STORAGE_KEY = 'config'
 
+/**
+ * Parses a base64 encoded JSON string.
+ * @function parseBase64
+ * @param {string} data - The base64 encoded string.
+ * @returns {object|null} The parsed object, or null on error.
+ */
 function parseBase64 (data) {
   try {
     return JSON.parse(atob(data))
@@ -23,6 +29,12 @@ function parseBase64 (data) {
   }
 }
 
+/**
+ * Fetches and parses a JSON file from a URL.
+ * @function fetchJson
+ * @param {string} url - The URL to fetch JSON from.
+ * @returns {Promise<object|null>} The parsed object, or null on error.
+ */
 async function fetchJson (url) {
   try {
     const response = await fetch(url)
@@ -48,6 +60,12 @@ async function fetchJson (url) {
   }
 }
 
+/**
+ * Loads configuration from various sources in a specific order: URL params, localStorage, then a default file.
+ * @async
+ * @function loadFromSources
+ * @returns {Promise<object|null>} A promise that resolves to the configuration object or null.
+ */
 async function loadFromSources () {
   const params = new URLSearchParams(window.location.search)
 

--- a/symbols.json
+++ b/symbols.json
@@ -53,12 +53,12 @@
     "name": "addDragOverlay",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Insert a transparent overlay to mark a widget as a drop target.",
+    "description": "Adds a transparent overlay to a widget to act as a drop target.",
     "params": [
       {
         "name": "widgetWrapper",
         "type": "HTMLElement",
-        "desc": "- Widget element to overlay."
+        "desc": "- The widget to add an overlay to."
       }
     ],
     "returns": "void"
@@ -67,42 +67,88 @@
     "name": "addWidget",
     "kind": "function",
     "file": "src/component/widget/widgetManagement.js",
-    "description": "Insert a widget into the current view and persist the layout.",
+    "description": "Adds a new widget to the current view and persists the state.",
     "params": [
       {
         "name": "url",
         "type": "string",
-        "desc": "- URL of the service to embed."
+        "desc": "- The URL of the service to embed."
       },
       {
         "name": "columns",
         "type": "number",
-        "desc": "- Grid columns spanned by the widget."
+        "desc": "- The number of grid columns for the widget to span."
       },
       {
         "name": "rows",
         "type": "number",
-        "desc": "- Grid rows spanned by the widget."
+        "desc": "- The number of grid rows for the widget to span."
       },
       {
         "name": "type",
         "type": "string",
-        "desc": "- Widget type, usually 'iframe'."
+        "desc": "- The type of the widget."
       },
       {
         "name": "boardId",
-        "type": "?string",
-        "desc": "- Board id; defaults to the active board."
+        "type": "string",
+        "desc": "- The ID of the board to add the widget to."
       },
       {
         "name": "viewId",
-        "type": "?string",
-        "desc": "- View id; defaults to the active view."
+        "type": "string",
+        "desc": "- The ID of the view to add the widget to."
       },
       {
         "name": "dataid",
-        "type": "?string",
-        "desc": "- Persistent widget identifier."
+        "type": "string|null",
+        "desc": "- An optional persistent identifier for the widget."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "adjustWidgetSize",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Adjusts the widget size to a specific column and row span.",
+    "params": [
+      {
+        "name": "widgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- The widget to resize."
+      },
+      {
+        "name": "columns",
+        "type": "number",
+        "desc": "- The target number of columns."
+      },
+      {
+        "name": "rows",
+        "type": "number",
+        "desc": "- The target number of rows."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "applyControlVisibility",
+    "kind": "function",
+    "file": "src/component/menu/menu.js",
+    "description": "Applies visibility settings to control groups based on global configuration.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "applyFragment",
+    "kind": "function",
+    "file": "src/component/modal/fragmentDecisionModal.js",
+    "description": "Applies the configuration from the URL fragment, either by overwriting or merging.",
+    "params": [
+      {
+        "name": "overwrite",
+        "type": "boolean",
+        "desc": "- If true, existing data will be replaced."
       }
     ],
     "returns": "Promise<void>"
@@ -160,6 +206,36 @@
     "returns": "void"
   },
   {
+    "name": "clearWidgetContainer",
+    "kind": "function",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Hides all widgets currently managed by the widgetStore. This is used to clear the view without removing elements from the DOM permanently.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "closeModal",
+    "kind": "function",
+    "file": "src/component/modal/modalFactory.js",
+    "description": "Closes the modal, removes the backdrop and event listeners, and calls the close callback.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "configureWidget",
+    "kind": "function",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Prompts the user to enter a new URL for a widget's iframe.",
+    "params": [
+      {
+        "name": "iframeElement",
+        "type": "HTMLIFrameElement",
+        "desc": "- The iframe element of the widget to configure."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
     "name": "createBoard",
     "kind": "function",
     "file": "src/component/board/boardManagement.js",
@@ -182,6 +258,14 @@
       }
     ],
     "returns": "Promise<Board>"
+  },
+  {
+    "name": "createResizeOverlay",
+    "kind": "function",
+    "file": "src/component/widget/events/resizeHandler.js",
+    "description": "Creates a full-screen overlay to capture mouse events during resizing.",
+    "params": [],
+    "returns": "HTMLDivElement"
   },
   {
     "name": "createView",
@@ -211,32 +295,32 @@
     "name": "createWidget",
     "kind": "function",
     "file": "src/component/widget/widgetManagement.js",
-    "description": "Build the DOM structure for a widget iframe and its controls.",
+    "description": "Creates the DOM structure for a new widget, including its iframe and menu.",
     "params": [
       {
         "name": "service",
         "type": "string",
-        "desc": "- Service identifier derived from the URL."
+        "desc": "- The service identifier."
       },
       {
         "name": "url",
         "type": "string",
-        "desc": "- Iframe source URL."
+        "desc": "- The URL for the widget's iframe source."
       },
       {
         "name": "gridColumnSpan",
         "type": "number",
-        "desc": "- Number of grid columns to span."
+        "desc": "- The number of grid columns to span."
       },
       {
         "name": "gridRowSpan",
         "type": "number",
-        "desc": "- Number of grid rows to span."
+        "desc": "- The number of grid rows to span."
       },
       {
         "name": "dataid",
-        "type": "?string",
-        "desc": "- Optional persistent widget identifier."
+        "type": "string|null",
+        "desc": "- An optional persistent identifier for the widget."
       }
     ],
     "returns": "Promise<HTMLDivElement>"
@@ -344,6 +428,20 @@
     "returns": "Promise<string>"
   },
   {
+    "name": "enlarge",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Enlarges the widget both horizontally and vertically by one unit.",
+    "params": [
+      {
+        "name": "widget",
+        "type": "HTMLElement",
+        "desc": "- The widget element to enlarge."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
     "name": "error",
     "kind": "function",
     "file": "src/utils/Logger.js",
@@ -375,6 +473,48 @@
       }
     ],
     "returns": "void"
+  },
+  {
+    "name": "fetchJson",
+    "kind": "function",
+    "file": "src/component/widget/utils/fetchServices.js",
+    "description": "Fetches and parses a JSON file from a URL.",
+    "params": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "- The URL to fetch the JSON from."
+      }
+    ],
+    "returns": "Promise<object|null>"
+  },
+  {
+    "name": "fetchJson",
+    "kind": "function",
+    "file": "src/utils/fetchServices.js",
+    "description": "Fetches and parses a JSON file from a URL.",
+    "params": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "- The URL to fetch JSON from."
+      }
+    ],
+    "returns": "Promise<object|null>"
+  },
+  {
+    "name": "fetchJson",
+    "kind": "function",
+    "file": "src/utils/getConfig.js",
+    "description": "Fetches and parses a JSON file from a URL.",
+    "params": [
+      {
+        "name": "url",
+        "type": "string",
+        "desc": "- The URL to fetch JSON from."
+      }
+    ],
+    "returns": "Promise<object|null>"
   },
   {
     "name": "fetchServices",
@@ -453,6 +593,14 @@
     "description": "Get the id of the currently active view element.",
     "params": [],
     "returns": "string"
+  },
+  {
+    "name": "getLocalStorageData",
+    "kind": "function",
+    "file": "src/component/modal/localStorageModal.js",
+    "description": "Retrieves and parses all JSON-formatted items from localStorage.",
+    "params": [],
+    "returns": "Record<string, any>"
   },
   {
     "name": "getSelectedBoardId",
@@ -548,7 +696,7 @@
     "name": "handleDragEnd",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Clean up after a drag operation ends.",
+    "description": "Handles the end of a drag operation, cleaning up UI elements.",
     "params": [
       {
         "name": "e",
@@ -562,7 +710,7 @@
     "name": "handleDragLeave",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Remove highlighting when a dragged item leaves a widget.",
+    "description": "Handles the dragleave event on a potential drop target.",
     "params": [
       {
         "name": "e",
@@ -572,7 +720,7 @@
       {
         "name": "widgetWrapper",
         "type": "HTMLElement",
-        "desc": "- Widget that lost drag focus."
+        "desc": "- The widget that the cursor is leaving."
       }
     ],
     "returns": "void"
@@ -581,7 +729,7 @@
     "name": "handleDragOver",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Highlight a widget as a potential drop target.",
+    "description": "Handles the dragover event on a potential drop target.",
     "params": [
       {
         "name": "e",
@@ -591,7 +739,7 @@
       {
         "name": "widgetWrapper",
         "type": "HTMLElement",
-        "desc": "- The widget element hovered over."
+        "desc": "- The widget being hovered over."
       }
     ],
     "returns": "void"
@@ -600,7 +748,7 @@
     "name": "handleDragStart",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Begin dragging a widget by setting up transfer data and overlays.",
+    "description": "Handles the start of a drag operation.",
     "params": [
       {
         "name": "e",
@@ -610,7 +758,7 @@
       {
         "name": "draggedWidgetWrapper",
         "type": "HTMLElement",
-        "desc": "- The widget being dragged."
+        "desc": "- The widget element being dragged."
       }
     ],
     "returns": "void"
@@ -619,7 +767,7 @@
     "name": "handleDrop",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Drop handler to rearrange widgets or reposition them on the grid.",
+    "description": "Handles the drop event on a target widget.",
     "params": [
       {
         "name": "e",
@@ -628,8 +776,22 @@
       },
       {
         "name": "targetWidgetWrapper",
-        "type": "?HTMLElement",
-        "desc": "- Widget wrapper receiving the drop or null."
+        "type": "HTMLElement",
+        "desc": "- The widget being dropped on."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "handleEscape",
+    "kind": "function",
+    "file": "src/component/modal/modalFactory.js",
+    "description": "Handles the 'Escape' key press to close the modal.",
+    "params": [
+      {
+        "name": "e",
+        "type": "KeyboardEvent",
+        "desc": "- The keyboard event."
       }
     ],
     "returns": "void"
@@ -671,6 +833,20 @@
     "description": "Remove all widgets from the current view.",
     "params": [],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "handleResize",
+    "kind": "function",
+    "file": "src/component/widget/events/resizeHandler.js",
+    "description": "Handles mouse movement during a resize operation, updating the widget's grid span.",
+    "params": [
+      {
+        "name": "event",
+        "type": "MouseEvent",
+        "desc": "- The mousemove event."
+      }
+    ],
+    "returns": "void"
   },
   {
     "name": "handleResizeStart",
@@ -720,6 +896,34 @@
     "returns": "void"
   },
   {
+    "name": "hideResizeMenu",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Hides the resize menu for a widget.",
+    "params": [
+      {
+        "name": "icon",
+        "type": "HTMLElement",
+        "desc": "- The icon element that triggered the event."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "hideResizeMenuBlock",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Hides the resize menu block for a widget.",
+    "params": [
+      {
+        "name": "widgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- The widget to hide the menu from."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
     "name": "info",
     "kind": "function",
     "file": "src/utils/Logger.js",
@@ -755,13 +959,13 @@
     "file": "src/component/menu/dashboardMenu.js",
     "description": "Set up event handlers for the dashboard menu and populate service options.",
     "params": [],
-    "returns": "Promise<void>"
+    "returns": "void"
   },
   {
     "name": "initializeDragAndDrop",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Enable drag-and-drop events on the widget container.",
+    "description": "Initializes the drag and drop functionality. In this model, it's a placeholder as event listeners are attached dynamically during the drag operation.",
     "params": [],
     "returns": "void"
   },
@@ -817,6 +1021,20 @@
     "returns": "void"
   },
   {
+    "name": "isJSON",
+    "kind": "function",
+    "file": "src/component/modal/localStorageModal.js",
+    "description": "Checks if a given string is valid JSON.",
+    "params": [
+      {
+        "name": "value",
+        "type": "string",
+        "desc": "- The string to check."
+      }
+    ],
+    "returns": "boolean"
+  },
+  {
     "name": "listLoggedFiles",
     "kind": "function",
     "file": "src/utils/Logger.js",
@@ -825,12 +1043,20 @@
     "returns": "void"
   },
   {
+    "name": "load",
+    "kind": "function",
+    "file": "src/storage/servicesStore.js",
+    "description": "Loads the array of services from localStorage.",
+    "params": [],
+    "returns": "Array<import('../types.js').Service>"
+  },
+  {
     "name": "loadBoardState",
     "kind": "function",
     "file": "src/storage/localStorage.js",
-    "description": "Retrieve the array of boards from localStorage. The result is also assigned to {@code window.asd.boards} for global access.",
+    "description": "Retrieves the array of boards from localStorage.",
     "params": [],
-    "returns": "Promise<Array<Board>>"
+    "returns": "Promise<Array<import('../types.js').Board>>"
   },
   {
     "name": "loadFromFragment",
@@ -841,30 +1067,19 @@
     "returns": "Promise<void>"
   },
   {
+    "name": "loadFromSources",
+    "kind": "function",
+    "file": "src/utils/getConfig.js",
+    "description": "Loads configuration from various sources in a specific order: URL params, localStorage, then a default file.",
+    "params": [],
+    "returns": "Promise<object|null>"
+  },
+  {
     "name": "loadInitialConfig",
     "kind": "function",
     "file": "src/storage/localStorage.js",
-    "description": "Store the initial board configuration defined in {@code window.asd.config} into localStorage. This is typically called on first run to seed the persistent board data.",
+    "description": "Loads the initial board configuration from the global config object into localStorage. This is typically called on first run to seed the dashboard.",
     "params": [],
-    "returns": "Promise<void>"
-  },
-  {
-    "name": "loadWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Restore widget DOM elements for the specified board and view from localStorage. Widgets are recreated using {@link createWidget} and metadata and settings are re-applied.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- Board identifier."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- View identifier whose widgets should be loaded."
-      }
-    ],
     "returns": "Promise<void>"
   },
   {
@@ -885,7 +1100,7 @@
     "name": "Logger",
     "kind": "class",
     "file": "src/utils/Logger.js",
-    "description": "Simple browser console logger with runtime enable/disable support. During Playwright test runs (via `navigator.webdriver`), structured logs are also stored in `window._appLogs` for later harvesting.",
+    "description": "A simple browser console logger with runtime enable/disable support.",
     "params": [],
     "returns": ""
   },
@@ -1035,6 +1250,48 @@
     "returns": "void"
   },
   {
+    "name": "parseBase64",
+    "kind": "function",
+    "file": "src/component/widget/utils/fetchServices.js",
+    "description": "Parses a base64 encoded JSON string.",
+    "params": [
+      {
+        "name": "data",
+        "type": "string",
+        "desc": "- The base64 encoded string."
+      }
+    ],
+    "returns": "object|null"
+  },
+  {
+    "name": "parseBase64",
+    "kind": "function",
+    "file": "src/utils/fetchServices.js",
+    "description": "Parses a base64 encoded JSON string.",
+    "params": [
+      {
+        "name": "data",
+        "type": "string",
+        "desc": "- The base64 encoded string."
+      }
+    ],
+    "returns": "object|null"
+  },
+  {
+    "name": "parseBase64",
+    "kind": "function",
+    "file": "src/utils/getConfig.js",
+    "description": "Parses a base64 encoded JSON string.",
+    "params": [
+      {
+        "name": "data",
+        "type": "string",
+        "desc": "- The base64 encoded string."
+      }
+    ],
+    "returns": "object|null"
+  },
+  {
     "name": "populateServiceDropdown",
     "kind": "function",
     "file": "src/component/menu/dashboardMenu.js",
@@ -1043,15 +1300,23 @@
     "returns": "void"
   },
   {
+    "name": "registerServiceWorker",
+    "kind": "function",
+    "file": "src/component/menu/menu.js",
+    "description": "Registers the service worker script.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "removeDragOverlay",
     "kind": "function",
     "file": "src/component/widget/events/dragDrop.js",
-    "description": "Remove the overlay from a widget wrapper if present.",
+    "description": "Removes the drag overlay from a widget.",
     "params": [
       {
         "name": "widgetWrapper",
         "type": "HTMLElement",
-        "desc": "- Widget element to clean up."
+        "desc": "- The widget to remove the overlay from."
       }
     ],
     "returns": "void"
@@ -1060,12 +1325,12 @@
     "name": "removeWidget",
     "kind": "function",
     "file": "src/component/widget/widgetManagement.js",
-    "description": "Remove a widget from the DOM and update ordering information. Persist the resulting widget layout using {@link saveWidgetState}.",
+    "description": "Removes a widget from the view and updates the layout.",
     "params": [
       {
         "name": "widgetElement",
         "type": "HTMLElement",
-        "desc": "- Wrapper element to remove."
+        "desc": "- The widget wrapper element to remove."
       }
     ],
     "returns": "void"
@@ -1147,37 +1412,117 @@
     "returns": "Promise<void>"
   },
   {
-    "name": "saveBoardState",
+    "name": "resizeHorizontally",
     "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Persist the entire boards array to localStorage under the key `boards`.",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Resizes the widget horizontally by adjusting its grid column span.",
     "params": [
       {
-        "name": "boards",
-        "type": "Array<Board>",
-        "desc": "- Array of board objects to store."
+        "name": "widget",
+        "type": "HTMLElement",
+        "desc": "- The widget element to resize."
+      },
+      {
+        "name": "increase",
+        "type": "boolean",
+        "desc": "- Whether to increase or decrease the size."
       }
     ],
     "returns": "Promise<void>"
   },
   {
+    "name": "resizeVertically",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Resizes the widget vertically by adjusting its grid row span.",
+    "params": [
+      {
+        "name": "widget",
+        "type": "HTMLElement",
+        "desc": "- The widget element to resize."
+      },
+      {
+        "name": "increase",
+        "type": "boolean",
+        "desc": "- Whether to increase or decrease the size."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "save",
+    "kind": "function",
+    "file": "src/storage/servicesStore.js",
+    "description": "Saves the array of services to localStorage.",
+    "params": [
+      {
+        "name": "services",
+        "type": "Array<import('../types.js').Service>",
+        "desc": "- The array of services to save."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "saveBoardState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Persists the entire array of board objects to localStorage.",
+    "params": [
+      {
+        "name": "boards",
+        "type": "Array<import('../types.js').Board>",
+        "desc": "- The array of boards to save."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "saveLocalStorageData",
+    "kind": "function",
+    "file": "src/component/modal/localStorageModal.js",
+    "description": "Saves a data object to localStorage, serializing each value to a JSON string.",
+    "params": [
+      {
+        "name": "updatedData",
+        "type": "Record<string, any>",
+        "desc": "- The data to save."
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "saveWidgetState",
     "kind": "function",
     "file": "src/storage/localStorage.js",
-    "description": "Serialize widgets in the current view and store them under the given board and view identifiers in localStorage. This function now reads the visible widgets directly from the DOM to ensure the saved state matches the UI.",
+    "description": "Serializes the state of all visible widgets and saves it to localStorage.",
     "params": [
       {
         "name": "boardId",
         "type": "string",
-        "desc": "- Board identifier."
+        "desc": "- The ID of the current board."
       },
       {
         "name": "viewId",
         "type": "string",
-        "desc": "- View identifier."
+        "desc": "- The ID of the current view."
       }
     ],
-    "returns": "Promise<void>"
+    "returns": "void"
+  },
+  {
+    "name": "serializeWidgetState",
+    "kind": "function",
+    "file": "src/storage/localStorage.js",
+    "description": "Converts a widget DOM element into a serializable state object.",
+    "params": [
+      {
+        "name": "widget",
+        "type": "HTMLElement",
+        "desc": "- The widget element."
+      }
+    ],
+    "returns": "import('../types.js').Widget"
   },
   {
     "name": "show",
@@ -1218,6 +1563,39 @@
     "returns": "void"
   },
   {
+    "name": "showResizeMenu",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Shows the resize menu with directional arrows for a widget.",
+    "params": [
+      {
+        "name": "icon",
+        "type": "HTMLElement",
+        "desc": "- The icon element that triggered the event."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "showResizeMenuBlock",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Shows a menu block with explicit size options (e.g., \"2 columns, 3 rows\").",
+    "params": [
+      {
+        "name": "icon",
+        "type": "HTMLElement",
+        "desc": "- The icon element that triggered the event."
+      },
+      {
+        "name": "widgetWrapper",
+        "type": "HTMLElement",
+        "desc": "- The widget to show the menu for."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
     "name": "showServiceModal",
     "kind": "function",
     "file": "src/component/modal/serviceLaunchModal.js",
@@ -1234,6 +1612,28 @@
         "desc": "- Widget element to refresh."
       }
     ],
+    "returns": "void"
+  },
+  {
+    "name": "shrink",
+    "kind": "function",
+    "file": "src/component/widget/menu/resizeMenu.js",
+    "description": "Shrinks the widget both horizontally and vertically by one unit.",
+    "params": [
+      {
+        "name": "widget",
+        "type": "HTMLElement",
+        "desc": "- The widget element to shrink."
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
+    "name": "stopResize",
+    "kind": "function",
+    "file": "src/component/widget/events/resizeHandler.js",
+    "description": "Handles the end of a resize operation, cleaning up listeners and saving state.",
+    "params": [],
     "returns": "void"
   },
   {
@@ -1289,6 +1689,36 @@
     "returns": "void"
   },
   {
+    "name": "unregisterServiceWorker",
+    "kind": "function",
+    "file": "src/component/menu/menu.js",
+    "description": "Unregisters all active service workers and clears their caches.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "updateBoardSelector",
+    "kind": "function",
+    "file": "src/component/board/boardManagement.js",
+    "description": "Rebuilds the board selector dropdown from the in-memory `boards` array.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "updateServiceWorkerUI",
+    "kind": "function",
+    "file": "src/component/menu/menu.js",
+    "description": "Updates the UI of the service worker toggle icon and attributes.",
+    "params": [
+      {
+        "name": "isEnabled",
+        "type": "boolean",
+        "desc": "- True if the service worker should be shown as enabled."
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "updateViewSelector",
     "kind": "function",
     "file": "src/component/board/boardManagement.js",
@@ -1300,14 +1730,6 @@
         "desc": "- Identifier of the board whose views will be shown."
       }
     ],
-    "returns": "void"
-  },
-  {
-    "name": "updateWidgetOrders",
-    "kind": "function",
-    "file": "src/component/widget/widgetManagement.js",
-    "description": "Recompute and store the ordering of widgets in the container. Saves the updated arrangement via {@link saveWidgetState}.",
-    "params": [],
     "returns": "void"
   },
   {


### PR DESCRIPTION
## Summary
- document `main` in playwright logs extraction utility
- add server JSDoc in `serve_no_cache.js`
- document board and widget management helpers
- add JSDoc blocks for UI menu and modal utilities
- document widget drag, resize and size menu helpers
- document storage and config helpers
- update symbol index

## Testing
- `npm run lint-fix`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686536dd65f08325bf5d77cd89204fcc