### PR TITLE
Add regression test for view state isolation

### DIFF
--- a/symbols.json
+++ b/symbols.json
@@ -899,7 +899,7 @@
     "name": "hideResizeMenu",
     "kind": "function",
     "file": "src/component/widget/menu/resizeMenu.js",
-    "description": "Hides the resize menu for a widget.",
+    "description": "",
     "params": [
       {
         "name": "icon",

--- a/tests/viewStateIsolation.spec.ts
+++ b/tests/viewStateIsolation.spec.ts
@@ -1,0 +1,104 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { routeServicesConfig } from './shared/mocking.js';
+import { selectServiceByName } from './shared/common.js';
+
+// Define a deterministic initial state with a clean board and two empty views.
+const initialBoards = [
+  {
+    id: 'board-iso-test-1',
+    name: 'State Isolation Test Board',
+    order: 0,
+    views: [
+      {
+        id: 'view-A',
+        name: 'View A',
+        widgetState: []
+      },
+      {
+        id: 'view-B',
+        name: 'View B',
+        widgetState: []
+      }
+    ]
+  }
+];
+
+test.describe('Widget State Isolation Between Views', () => {
+
+  // Before each test, set up the clean environment with our predefined board structure.
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page);
+
+    // Use addInitScript to set localStorage *before* the page loads.
+    // This ensures the application initializes with our test state.
+    await page.addInitScript(({ boards, services }) => {
+      localStorage.clear();
+      localStorage.setItem('boards', JSON.stringify(boards));
+      localStorage.setItem('services', JSON.stringify(services));
+      localStorage.setItem('lastUsedBoardId', 'board-iso-test-1');
+      localStorage.setItem('lastUsedViewId', 'view-A');
+    }, {
+      boards: initialBoards,
+      services: [
+        { name: 'ASD-toolbox', url: 'http://localhost:8000/asd/toolbox' },
+        { name: 'ASD-terminal', url: 'http://localhost:8000/asd/terminal' }
+      ]
+    });
+
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  /**
+   * This test specifically targets the "widget copying" bug by verifying that
+   * widget state is correctly isolated when switching between views.
+   */
+  test('widgets added to one view should not appear in another view after switching', async ({ page }) => {
+    // Define locators for the widgets we'll be adding.
+    const widgetToolbox = page.locator('.widget-wrapper[data-service="ASD-toolbox"]');
+    const widgetTerminal = page.locator('.widget-wrapper[data-service="ASD-terminal"]');
+    const viewSelector = page.locator('#view-selector');
+
+    // --- STEP 1: Add a widget to View A ---
+    await viewSelector.selectOption({ label: 'View A' });
+    await selectServiceByName(page, 'ASD-toolbox');
+
+    // VERIFY (View A): Toolbox widget is visible, and it's the only one.
+    await expect(widgetToolbox).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+
+    // --- STEP 2: Switch to View B ---
+    await viewSelector.selectOption({ label: 'View B' });
+
+    // VERIFY (View B): The container is now empty. The Toolbox widget should be hidden.
+    await expect(widgetToolbox).toBeHidden();
+    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(0);
+
+    // --- STEP 3: Add a different widget to View B ---
+    await selectServiceByName(page, 'ASD-terminal');
+
+    // VERIFY (View B): Terminal widget is visible, Toolbox is still hidden.
+    await expect(widgetTerminal).toBeVisible();
+    await expect(widgetToolbox).toBeHidden();
+    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+
+    // --- STEP 4: Switch back to View A ---
+    await viewSelector.selectOption({ label: 'View A' });
+
+    // CRITICAL VERIFICATION:
+    // Ensure View A shows ONLY the Toolbox widget. The Terminal widget must now be hidden.
+    // This is the step that would have failed with the previous faulty logic.
+    await expect(widgetToolbox).toBeVisible();
+    await expect(widgetTerminal).toBeHidden();
+    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+
+    // --- FINAL CHECK: Switch back to View B one last time ---
+    await viewSelector.selectOption({ label: 'View B' });
+
+    // VERIFY (View B): Correctly shows only the Terminal widget.
+    await expect(widgetToolbox).toBeHidden();
+    await expect(widgetTerminal).toBeVisible();
+    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure widget state doesn't leak between views
- keep symbol index up to date

## Testing
- `just format`
- `just check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_b_6865c21db2c08325a7e9bd0ed47a9a1f