### PR TITLE
Add menu widget visibility control

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ASD Dashboard is architected with a focus on simplicity and adaptability:
 - **Widget Management**: Add, resize, reorder, and remove widgets dynamically. Widgets can be customized with properties such as size, metadata, and settings. Resizing is facilitated via mouse cursor dragging, adhering to grid standards.
 - **Board and View Structure**: Manage multiple boards and views, akin to tabs, allowing users to switch, rename, delete, or reset configurations. State is persistently stored.
 - **Global Configuration**: Centralized configuration through `config.json` for global settings like themes and widget store URLs.
+- **Widget Menu Toggle**: `showMenuWidget` controls whether widget menus are visible by default.
 - **LocalStorage Integration**: Persistent storage of dashboard preferences, with a modal for editing localStorage, enabling import/export and modification of JSON data.
 - **Responsive Grid Layout**: Widgets are arranged in a grid that adapts to screen size, with default configurations and options for customization.
 - **Service Selection**: Widgets can be added from a predefined JSON file, custom URL, or remote services, with support for merging multiple sources.

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,6 +36,7 @@ function initializeDashboardMenu () {
   logger.log('Dashboard menu initialized')
   populateServiceDropdown()
   document.addEventListener('services-updated', populateServiceDropdown)
+  applyWidgetMenuVisibility()
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
     const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
@@ -67,6 +68,11 @@ function initializeDashboardMenu () {
     const message = toggled
       ? `${emojiList.cross.unicode} Widget menu hidden`
       : `${emojiList.edit.unicode} Widget menu shown`
+
+    if (window.asd && window.asd.config && window.asd.config.globalSettings) {
+      window.asd.config.globalSettings.showMenuWidget = !toggled
+      localStorage.setItem('config', JSON.stringify(window.asd.config))
+    }
 
     showNotification(message, 500)
   })
@@ -122,4 +128,21 @@ function populateServiceDropdown () {
   })
 }
 
-export { initializeDashboardMenu }
+/**
+ * Apply visibility of the widget menu based on configuration.
+ *
+ * @function applyWidgetMenuVisibility
+ * @returns {void}
+ */
+function applyWidgetMenuVisibility () {
+  const widgetContainer = document.getElementById('widget-container')
+  if (!widgetContainer) return
+  const show = window.asd?.config?.globalSettings?.showMenuWidget
+  if (show === false || show === 'false') {
+    widgetContainer.classList.add('hide-widget-menu')
+  } else {
+    widgetContainer.classList.remove('hide-widget-menu')
+  }
+}
+
+export { initializeDashboardMenu, applyWidgetMenuVisibility }

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -20,6 +20,7 @@ export const DEFAULT_CONFIG_TEMPLATE = {
     hideBoardControl: false,
     hideViewControl: false,
     hideServiceControl: false,
+    showMenuWidget: true,
     localStorage: {
       enabled: 'true',
       loadDashboardFromConfig: 'true'

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@
  */
 import { initializeMainMenu, applyControlVisibility } from './component/menu/menu.js'
 import { initializeBoards, switchBoard } from './component/board/boardManagement.js'
-import { initializeDashboardMenu } from './component/menu/dashboardMenu.js'
+import { initializeDashboardMenu, applyWidgetMenuVisibility } from './component/menu/dashboardMenu.js'
 import { loadInitialConfig, loadBoardState } from './storage/localStorage.js'
 import { initializeDragAndDrop } from './component/widget/events/dragDrop.js'
 import { fetchServices } from './utils/fetchServices.js'
@@ -64,6 +64,7 @@ async function main () {
 
   // 4. Apply settings that depend on the loaded config
   applyControlVisibility()
+  applyWidgetMenuVisibility()
 
   // 5. Load board state from localStorage or initial config
   let boards = await loadBoardState()

--- a/src/setup/example-config.json
+++ b/src/setup/example-config.json
@@ -6,6 +6,7 @@
         "hideBoardControl": false,
         "hideViewControl": false,
         "hideServiceControl": false,
+        "showMenuWidget": true,
         "localStorage": {
             "enabled": "true",
             "loadDashboardFromConfig": "false",

--- a/src/types.js
+++ b/src/types.js
@@ -52,6 +52,14 @@
  * Dashboard configuration loaded from storage or URL.
  * @typedef {Object} DashboardConfig
  * @property {object} [globalSettings]
+ * @property {string} [globalSettings.theme]
+ * @property {Array<string>} [globalSettings.widgetStoreUrl]
+ * @property {string} [globalSettings.database]
+ * @property {boolean|string} [globalSettings.hideBoardControl]
+ * @property {boolean|string} [globalSettings.hideViewControl]
+ * @property {boolean|string} [globalSettings.hideServiceControl]
+ * @property {boolean|string} [globalSettings.showMenuWidget]
+ * @property {{enabled:string, loadDashboardFromConfig:string, defaultBoard?:string, defaultView?:string}} [globalSettings.localStorage]
  * @property {Array<Board>} [boards]
  * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} [styling]
 */

--- a/symbols.json
+++ b/symbols.json
@@ -154,6 +154,14 @@
     "returns": "Promise<void>"
   },
   {
+    "name": "applyWidgetMenuVisibility",
+    "kind": "function",
+    "file": "src/component/menu/dashboardMenu.js",
+    "description": "Apply visibility of the widget menu based on configuration.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "base64UrlDecode",
     "kind": "function",
     "file": "src/utils/compression.js",


### PR DESCRIPTION
## Summary
- allow toggling widget menu visibility via `showMenuWidget`
- persist toggle state in configuration
- apply widget menu visibility during init
- document new setting

## Testing
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_68669ac810b483258fce728eaf175bc5