### PR TITLE
ASD Compliant User Interface for ephemeral views used by ASD customers (phase 1/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ASD Dashboard is architected with a focus on simplicity and adaptability:
 - **Widget Management**: Add, resize, reorder, and remove widgets dynamically. Widgets can be customized with properties such as size, metadata, and settings. Resizing is facilitated via mouse cursor dragging, adhering to grid standards.
 - **Board and View Structure**: Manage multiple boards and views, akin to tabs, allowing users to switch, rename, delete, or reset configurations. State is persistently stored.
 - **Global Configuration**: Centralized configuration through `config.json` for global settings like themes and widget store URLs.
+- **Widget Menu Toggle**: `showMenuWidget` controls whether widget menus are visible by default.
 - **LocalStorage Integration**: Persistent storage of dashboard preferences, with a modal for editing localStorage, enabling import/export and modification of JSON data.
 - **Responsive Grid Layout**: Widgets are arranged in a grid that adapts to screen size, with default configurations and options for customization.
 - **Service Selection**: Widgets can be added from a predefined JSON file, custom URL, or remote services, with support for merging multiple sources.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -169,3 +169,186 @@ This flow gives you:
 * A directly **actionable plan** for agent evolution
 
 It closes the loop between **execution logs** and **agent spec design**, improving Codex quality incrementally without relying on post-hoc intuition alone.
+
+## Multi-Version UI Diff Extraction (Automated Scraping)
+
+This section documents the recommended approach for **extracting all file diffs across Codex browser versions** (as shown in the web UI) using an automated, event-driven script. This enables rapid AI analysis or bulk review of code changes across multiple "Version N" states.
+
+### **Rationale**
+
+* **Why automate?**
+  Manual copying is error-prone and slow. The UI exposes all data but only one version at a time.
+* **Why browser scripting, not API?**
+  Diffs are often embedded in complex, client-side rendered UIs. A robust browser console script is universally portable, requires no backend hooks, and works regardless of framework churn—as long as DOM structure and class names are stable.
+* **Why not just static waits?**
+  Reliable extraction must synchronize with UI state—not guess with hardcoded delays.
+
+---
+
+### **Process Summary**
+
+1. **Identify all visible "Version N" buttons** in the UI (matching text: `Version 1`, `Version 2`, etc.).
+2. **For each version, in DOM order:**
+
+   * If the version is not already active, click it and wait until it becomes active (CSS class check).
+   * If the "Diff" tab is not active, click it and wait until it becomes active.
+   * Once both are confirmed active, extract all visible diff data for that version.
+3. **Accumulate all extracted data** in a single JSON object keyed by version label.
+4. **Trigger a JSON download** once all versions are processed.
+
+---
+
+### **Key Implementation Notes**
+
+* **No Unnecessary Waits:**
+  The script checks active state for both version and diff tab. Only clicks and waits if not already selected, making the crawl as fast as the UI allows.
+* **Self-Validation:**
+  Throws errors (with clear messages) if expected UI changes do not occur, e.g., class changes or diff DOM mutation. Never silently skips failures.
+* **Portable:**
+  Requires only the browser console, no browser extensions or dev environment setup.
+* **Output:**
+  One JSON file, root is an object:
+
+  ```json
+  {
+    "_meta": { ... },
+    "Version 1": { ...diffs... },
+    "Version 2": { ...diffs... },
+    ...
+  }
+  ```
+
+---
+
+### **Usage**
+
+1. **Open the Codex diff UI** in your browser.
+2. **Open DevTools > Console.**
+3. **Paste the script** from `docs/scripts/codex-multiversion-diff-scraper.js` (or see below).
+4. **Press Enter.**
+5. When the script completes, a download prompt for `git-diff-multiversion.json` will appear.
+
+---
+
+#### **Current Script Reference**
+
+```js
+(function () {
+  function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+  async function waitForActive(el, className, timeout = 4000, interval = 60) {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      if (el.classList.contains(className)) return;
+      await sleep(interval);
+    }
+    throw new Error(`Element "${el.textContent.trim()}" did not activate (${className})`);
+  }
+  async function waitForDiffContentChange(refHtml, timeout = 7000, interval = 60) {
+    const area = 'div[data-diff-header]';
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      let html = Array.from(document.querySelectorAll(area)).map(x => x.innerHTML).join('');
+      if (html && html !== refHtml) return;
+      await sleep(interval);
+    }
+    throw new Error(`Diff content did not update in time`);
+  }
+  function downloadJSON(obj, filename) {
+    const blob = new Blob([JSON.stringify(obj, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = filename;
+    document.body.appendChild(a); a.click();
+    document.body.removeChild(a); URL.revokeObjectURL(url);
+  }
+  function scrapeGitDiffs() {
+    const activeBtn = document.querySelector('div.flex > span > button.text-token-text-primary');
+    const result = {
+      timestamp: new Date().toISOString(),
+      sourceUrl: window.location.href,
+      version: activeBtn ? activeBtn.textContent.trim() : null,
+      diffs: [],
+    };
+    document.querySelectorAll('div[data-diff-header]').forEach(container => {
+      const fileDiff = {
+        filePath: container.dataset.diffHeader,
+        additions: container.querySelector('.text-green-500')?.textContent.trim() || null,
+        deletions: container.querySelector('.text-red-500')?.textContent.trim() || null,
+        changes: [],
+      };
+      container.querySelectorAll('.diff-table-body tr.diff-line').forEach(row => {
+        fileDiff.changes.push({
+          old: {
+            lineNumber: row.querySelector('.diff-line-old-num')?.textContent.trim() || null,
+            content: row.querySelector('.diff-line-old-content .diff-line-syntax-raw')?.textContent ?? null,
+          },
+          new: {
+            lineNumber: row.querySelector('.diff-line-new-num')?.textContent.trim() || null,
+            content: row.querySelector('.diff-line-new-content .diff-line-syntax-raw')?.textContent ?? null,
+          }
+        });
+      });
+      result.diffs.push(fileDiff);
+    });
+    return result;
+  }
+
+  (async function () {
+    const versionBtns = Array.from(document.querySelectorAll('div.flex > span > button'))
+      .filter(btn => /^Version \d+$/.test(btn.textContent.trim()));
+    if (!versionBtns.length) throw new Error('No version buttons found.');
+    const allVersionDiffs = {
+      _meta: {
+        extractedAt: new Date().toISOString(),
+        sourceUrl: window.location.href,
+        versionCount: versionBtns.length
+      }
+    };
+
+    for (const btn of versionBtns) {
+      const label = btn.textContent.trim();
+      const wasActive = btn.classList.contains('text-token-text-primary');
+      if (!wasActive) {
+        const beforeHtml = Array.from(document.querySelectorAll('div[data-diff-header]')).map(x => x.innerHTML).join('');
+        btn.click();
+        await waitForActive(btn, 'text-token-text-primary', 5000);
+        await waitForDiffContentChange(beforeHtml, 7000);
+      }
+
+      // Always select Diff tab if not already
+      const diffNav = document.querySelector('div.flex.gap-4.text-sm.font-medium.border-b');
+      const diffBtn = Array.from(diffNav.querySelectorAll('span > button')).find(b => b.textContent.trim().toLowerCase() === 'diff');
+      if (!diffBtn) { console.warn(`No 'Diff' tab for ${label}. Skipping.`); continue; }
+      if (!diffBtn.classList.contains('text-token-text-primary')) {
+        const beforeDiffHtml = Array.from(document.querySelectorAll('div[data-diff-header]')).map(x => x.innerHTML).join('');
+        diffBtn.click();
+        await waitForActive(diffBtn, 'text-token-text-primary', 3000);
+        await waitForDiffContentChange(beforeDiffHtml, 7000);
+      }
+
+      // Scrape instantly
+      const scraped = scrapeGitDiffs();
+      allVersionDiffs[label] = scraped;
+      console.log(`[GitDiffScraper] ${label} scraped (${scraped.diffs.length} file diffs).`);
+    }
+
+    const nonEmpty = Object.values(allVersionDiffs).some(obj =>
+      obj && typeof obj === 'object' && Array.isArray(obj.diffs) && obj.diffs.length > 0
+    );
+    if (nonEmpty) {
+      downloadJSON(allVersionDiffs, 'git-diff-multiversion.json');
+      console.log('[GitDiffScraper] All versions processed. Data:', allVersionDiffs);
+    } else {
+      console.warn('[GitDiffScraper] No diffs extracted from any version. No file downloaded.');
+      console.log('Extracted data:', allVersionDiffs);
+    }
+  })();
+})();
+```
+
+---
+
+### **Best Practices**
+
+* **Always inspect DOM selectors** in your running Codex UI before updating or rerunning this script; selectors may shift if the UI changes.
+* **Do not over-automate**: This script will only extract what is loaded in the current UI session.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@types/node": "^22.7.4",
         "comment-parser": "^1.4.0",
         "eslint-plugin-jsdoc": "^51.3.1",
+        "fluent-ffmpeg": "^2.1.3",
+        "fs-extra": "^11.3.0",
         "globby": "^13.2.2",
         "husky": "^9.1.6",
         "playwright": "^1.47.2",
@@ -454,6 +456,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -1593,6 +1601,34 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
+      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fluent-ffmpeg/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -1600,6 +1636,21 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -2421,6 +2472,19 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -3675,6 +3739,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@types/node": "^22.7.4",
     "comment-parser": "^1.4.0",
     "eslint-plugin-jsdoc": "^51.3.1",
+    "fluent-ffmpeg": "^2.1.3",
+    "fs-extra": "^11.3.0",
     "globby": "^13.2.2",
     "husky": "^9.1.6",
     "playwright": "^1.47.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "location",
       "getComputedStyle",
       "caches",
-      "HTMLElement"
+      "HTMLElement",
+      "requestAnimationFrame"
     ]
   }
 }

--- a/scripts/just/repo.just
+++ b/scripts/just/repo.just
@@ -6,3 +6,6 @@ src-list dir="src":
 
 src-exports dir="src":
   bash scripts/just/list-and-export.sh {{dir}} export
+
+src-tests dir="tests":
+  bash scripts/just/list-and-export.sh {{dir}} export

--- a/setup/example-config.json
+++ b/setup/example-config.json
@@ -6,6 +6,10 @@
         "hideBoardControl": false,
         "hideViewControl": false,
         "hideServiceControl": false,
+        "views": {
+            "showViewOptionsAsButtons": false,
+            "viewToShow": ""
+        },
         "localStorage": {
             "enabled": "true",
             "loadDashboardFromConfig": "false",

--- a/setup/example-services.json
+++ b/setup/example-services.json
@@ -3,6 +3,7 @@
         "name": "ASD-toolbox",
         "url": "http://localhost:8000/asd/toolbox",
         "type": "api",
+        "maxInstances": 1,
         "config": {
           "minColumns": 1,
           "maxColumns": 4,
@@ -19,6 +20,7 @@
       {
         "name": "ASD-terminal",
         "url": "http://localhost:8000/asd/terminal",
+        "maxInstances": 10,
         "type": "web",
         "config": {
           "minColumns": 2,
@@ -36,6 +38,7 @@
       {
         "name": "ASD-tunnel",
         "url": "http://localhost:8000/asd/tunnel",
+        "maxInstances": 4,
         "type": "web",
         "config": {
           "minColumns": 1,
@@ -48,6 +51,7 @@
         "name": "ASD-containers",
         "url": "http://localhost:8000/asd/containers",
         "type": "web",
+        "maxInstances": 1,
         "config": {
           "minColumns": 2,
           "maxColumns": 4,

--- a/src/component/board/boardDropdown.js
+++ b/src/component/board/boardDropdown.js
@@ -4,7 +4,7 @@
  *
  * @module boardDropdown
  */
-import { createBoard, renameBoard, deleteBoard, updateViewSelector, addBoardToUI, boards } from './boardManagement.js'
+import { createBoard, renameBoard, deleteBoard, updateViewSelector, boards } from './boardManagement.js'
 import { initializeDropdown } from '../utils/dropDownUtils.js'
 import { Logger } from '../../utils/Logger.js'
 
@@ -39,7 +39,6 @@ async function handleCreateBoard () {
     try {
       const newBoard = await createBoard(boardName)
       logger.log('Board created:', newBoard)
-      addBoardToUI(newBoard)
     } catch (error) {
       logger.error('Error creating board:', error)
     }

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -406,11 +406,11 @@ export async function deleteView (boardId, viewId) {
       const viewToDelete = board.views[viewIndex]
 
       if (viewToDelete.widgetState) {
-        viewToDelete.widgetState.forEach(widget => {
+        for (const widget of viewToDelete.widgetState) {
           if (widget.dataid) {
-            widgetStore.requestRemoval(widget.dataid)
+            await widgetStore.requestRemoval(widget.dataid)
           }
-        })
+        }
       }
 
       board.views.splice(viewIndex, 1)
@@ -453,11 +453,11 @@ export async function resetView (boardId, viewId) {
   if (board) {
     const view = board.views.find(v => v.id === viewId)
     if (view) {
-      view.widgetState.forEach(widget => {
+      for (const widget of view.widgetState) {
         if (widget.dataid) {
-          widgetStore.requestRemoval(widget.dataid)
+          await widgetStore.requestRemoval(widget.dataid)
         }
-      })
+      }
 
       view.widgetState = []
       await saveBoardState(boards)

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -176,6 +176,11 @@ export function updateViewSelector (boardId) {
 
   viewSelector.innerHTML = '' // Clear existing options
   const board = boards.find(b => b.id === boardId)
+  const viewButtonMenu = document.getElementById('view-button-menu')
+  const settings = window.asd.config?.globalSettings || {}
+  if (viewButtonMenu && settings.views?.showViewOptionsAsButtons) {
+    viewButtonMenu.innerHTML = ''
+  }
 
   if (board) {
     logger.log(`Found board with ID: ${boardId}, adding its views to the selector`)
@@ -185,6 +190,16 @@ export function updateViewSelector (boardId) {
       option.value = view.id
       option.textContent = view.name
       viewSelector.appendChild(option)
+      if (viewButtonMenu && settings.views?.showViewOptionsAsButtons) {
+        const btn = document.createElement('button')
+        btn.textContent = view.name
+        btn.dataset.viewId = view.id
+        if (view.id === window.asd.currentViewId) btn.classList.add('active')
+        btn.addEventListener('click', () => {
+          switchView(boardId, view.id)
+        })
+        viewButtonMenu.appendChild(btn)
+      }
     })
 
     // Select the newly created or switched view
@@ -214,7 +229,9 @@ export async function switchBoard (boardId, viewId = null) {
   const board = boards.find(b => b.id === boardId)
   if (board) {
     document.querySelector('.board').id = boardId
-    const targetViewId = viewId || (board.views.length > 0 ? board.views[0].id : null)
+    const settings = window.asd.config?.globalSettings || {}
+    const preferred = settings.views?.viewToShow
+    const targetViewId = viewId || (preferred && board.views.some(v => v.id === preferred) ? preferred : (board.views.length > 0 ? board.views[0].id : null))
 
     if (targetViewId) {
       await switchView(boardId, targetViewId)
@@ -261,7 +278,13 @@ export function initializeBoards () {
 
     if (boards.length > 0) {
       const firstBoard = boards[0]
-      const firstView = firstBoard.views.length > 0 ? firstBoard.views[0] : { id: '' }
+      let firstView = firstBoard.views.length > 0 ? firstBoard.views[0] : { id: '' }
+      const settings = window.asd.config?.globalSettings || {}
+      const preferred = settings.views?.viewToShow
+      if (preferred) {
+        const candidate = firstBoard.views.find(v => v.id === preferred)
+        if (candidate) firstView = candidate
+      }
       return { boardId: firstBoard.id, viewId: firstView.id }
     }
     return { boardId: '', viewId: '' }

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -46,9 +46,6 @@ export async function createBoard (boardName, boardId = null, viewId = null) {
   // Save the board state after creating the default view
   await saveBoardState(boards)
 
-  // Update the board selector
-  updateBoardSelector()
-
   // Switch to the new board
   await switchBoard(newBoardId, defaultViewId)
   logger.log(`Switched to new board ${newBoardId}`)
@@ -57,6 +54,9 @@ export async function createBoard (boardName, boardId = null, viewId = null) {
   localStorage.setItem('lastUsedBoardId', newBoardId)
   localStorage.setItem('lastUsedViewId', defaultViewId)
   logger.log(`Saved last used boardId: ${newBoardId} and viewId: ${defaultViewId} to localStorage`)
+
+  // Update the board selector
+  updateBoardSelector()
 
   return newBoard
 }

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -18,6 +18,7 @@ import { showNotification } from '../dialog/notification.js'
 import emojiList from '../../ui/unicodeEmoji.js'
 import { Logger } from '../../utils/Logger.js'
 import { clearConfigFragment } from '../../utils/fragmentGuard.js'
+import { debounceLeading } from '../../utils/utils.js'
 
 const logger = new Logger('dashboardMenu.js')
 
@@ -37,6 +38,8 @@ function initializeDashboardMenu () {
   populateServiceDropdown()
   document.addEventListener('services-updated', populateServiceDropdown)
   applyWidgetMenuVisibility()
+
+  const buttonDebounce = 200
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
     const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
@@ -61,7 +64,7 @@ function initializeDashboardMenu () {
     }
   })
 
-  document.getElementById('toggle-widget-menu').addEventListener('click', () => {
+  const handleToggleWidgetMenu = debounceLeading(() => {
     const widgetContainer = document.getElementById('widget-container')
     const toggled = widgetContainer.classList.toggle('hide-widget-menu') // true if now hidden
 
@@ -75,9 +78,10 @@ function initializeDashboardMenu () {
     }
 
     showNotification(message, 500)
-  })
+  }, buttonDebounce)
+  document.getElementById('toggle-widget-menu').addEventListener('click', /** @type {EventListener} */(handleToggleWidgetMenu))
 
-  document.getElementById('reset-button').addEventListener('click', () => {
+  const handleReset = debounceLeading(() => {
     // Show confirmation dialog
     const confirmed = confirm('Confirm environment reset: all configurations and services will be permanently deleted.')
 
@@ -86,7 +90,8 @@ function initializeDashboardMenu () {
       clearConfigFragment()
       location.reload()
     }
-  })
+  }, buttonDebounce)
+  document.getElementById('reset-button').addEventListener('click', /** @type {EventListener} */(handleReset))
 
   document.getElementById('board-selector').addEventListener('change', (event) => {
     const target = /** @type {HTMLSelectElement} */(event.target)

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,6 +36,7 @@ function initializeDashboardMenu () {
   logger.log('Dashboard menu initialized')
   populateServiceDropdown()
   document.addEventListener('services-updated', populateServiceDropdown)
+  applyWidgetMenuVisibility()
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
     const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
@@ -67,6 +68,11 @@ function initializeDashboardMenu () {
     const message = toggled
       ? `${emojiList.cross.unicode} Widget menu hidden`
       : `${emojiList.edit.unicode} Widget menu shown`
+
+    if (window.asd && window.asd.config && window.asd.config.globalSettings) {
+      window.asd.config.globalSettings.showMenuWidget = !toggled
+      localStorage.setItem('config', JSON.stringify(window.asd.config))
+    }
 
     showNotification(message, 500)
   })
@@ -122,4 +128,21 @@ function populateServiceDropdown () {
   })
 }
 
-export { initializeDashboardMenu }
+/**
+ * Apply visibility of the widget menu based on configuration.
+ *
+ * @function applyWidgetMenuVisibility
+ * @returns {void}
+ */
+function applyWidgetMenuVisibility () {
+  const widgetContainer = document.getElementById('widget-container')
+  if (!widgetContainer) return
+  const show = window.asd?.config?.globalSettings?.showMenuWidget
+  if (show === false || show === 'false') {
+    widgetContainer.classList.add('hide-widget-menu')
+  } else {
+    widgetContainer.classList.remove('hide-widget-menu')
+  }
+}
+
+export { initializeDashboardMenu, applyWidgetMenuVisibility }

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -6,6 +6,7 @@
  */
 import emojiList from '../../ui/unicodeEmoji.js'
 import { showNotification } from '../dialog/notification.js'
+import { debounceLeading } from '../../utils/utils.js'
 
 /**
  * Initialize service worker controls in the menu.
@@ -20,6 +21,8 @@ function initSW () {
   const swCheckbox = document.querySelector('.icon-checkbox')
   const swEnabled = localStorage.getItem('swEnabled') === 'true'
   swToggle.checked = swEnabled
+
+  const buttonDebounce = 200
 
   /**
    * Updates the UI of the service worker toggle icon and attributes.
@@ -92,7 +95,7 @@ function initSW () {
       unregisterServiceWorker()
     }
 
-    swToggle.addEventListener('change', function () {
+    const handleSwChange = debounceLeading(() => {
       const isEnabled = swToggle.checked
       localStorage.setItem('swEnabled', String(isEnabled))
       updateServiceWorkerUI(isEnabled)
@@ -103,7 +106,8 @@ function initSW () {
       } else {
         unregisterServiceWorker()
       }
-    })
+    }, buttonDebounce)
+    swToggle.addEventListener('change', /** @type {EventListener} */(handleSwChange))
   }
 }
 

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -183,6 +183,11 @@ function initializeMainMenu () {
   viewControl.appendChild(viewDropdown)
   menu.appendChild(viewControl)
 
+  const viewButtonMenu = document.createElement('div')
+  viewButtonMenu.className = 'control-group'
+  viewButtonMenu.id = 'view-button-menu'
+  menu.appendChild(viewButtonMenu)
+
   // Service control group
   const serviceControl = document.createElement('div')
   serviceControl.className = 'control-group'
@@ -283,6 +288,10 @@ function applyControlVisibility () {
   const serviceControl = document.getElementById('service-control')
   if (serviceControl) {
     serviceControl.style.display = settings.hideServiceControl === true || settings.hideServiceControl === 'true' ? 'none' : ''
+  }
+  const viewButtonMenu = document.getElementById('view-button-menu')
+  if (viewButtonMenu) {
+    viewButtonMenu.style.display = settings.views?.showViewOptionsAsButtons === true || settings.views?.showViewOptionsAsButtons === 'true' ? '' : 'none'
   }
 }
 

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -20,6 +20,7 @@ export const DEFAULT_CONFIG_TEMPLATE = {
     hideBoardControl: false,
     hideViewControl: false,
     hideServiceControl: false,
+    showMenuWidget: true,
     localStorage: {
       enabled: 'true',
       loadDashboardFromConfig: 'true'

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -21,6 +21,10 @@ export const DEFAULT_CONFIG_TEMPLATE = {
     hideViewControl: false,
     hideServiceControl: false,
     showMenuWidget: true,
+    views: {
+      showViewOptionsAsButtons: false,
+      viewToShow: ''
+    },
     localStorage: {
       enabled: 'true',
       loadDashboardFromConfig: 'true'

--- a/src/component/modal/evictionModal.js
+++ b/src/component/modal/evictionModal.js
@@ -1,0 +1,76 @@
+// @ts-check
+/**
+ * Modal dialog prompting which widget to evict when the widgetStore is full.
+ *
+ * @module evictionModal
+ */
+import { openModal } from './modalFactory.js'
+import emojiList from '../../ui/unicodeEmoji.js'
+
+/**
+ * Display a modal to choose a widget for removal.
+ *
+ * @param {Map<string, HTMLElement>} widgets - Current widget map.
+ * @function openEvictionModal
+ * @returns {Promise<{id:string, title:string}|null>} Resolves with selected widget info or null.
+ */
+export function openEvictionModal (widgets) {
+  return new Promise((resolve) => {
+    let settled = false
+    const finalize = (result) => {
+      if (settled) return
+      settled = true
+      resolve(result)
+    }
+    openModal({
+      id: 'eviction-modal',
+      showCloseIcon: false,
+      onCloseCallback: () => finalize(null),
+      buildContent: (modal, closeModal) => {
+        const msg = document.createElement('p')
+        msg.textContent = 'Select a widget to remove:'
+
+        const select = document.createElement('select')
+        select.id = 'eviction-select'
+        for (const [id, el] of widgets.entries()) {
+          let title = id
+          if (el.dataset.metadata) {
+            try {
+              title = JSON.parse(el.dataset.metadata).title || id
+            } catch {}
+          }
+          const service = el.dataset.service || ''
+          const key = service.toLowerCase().split('asd-')[1] || service.toLowerCase()
+          const emoji = emojiList[key]?.unicode || '🧱'
+          const label = `${emoji} ${service} – ${title}`
+          const opt = document.createElement('option')
+          opt.value = id
+          opt.textContent = label
+          select.appendChild(opt)
+        }
+
+        const removeBtn = document.createElement('button')
+        removeBtn.textContent = 'Remove'
+        removeBtn.classList.add('modal__btn', 'modal__btn--save')
+        removeBtn.addEventListener('click', () => {
+          finalize({ id: select.value, title: select.selectedOptions[0].textContent || '' })
+          closeModal()
+        })
+
+        const cancelBtn = document.createElement('button')
+        cancelBtn.textContent = 'Cancel'
+        cancelBtn.classList.add('modal__btn', 'modal__btn--cancel')
+        cancelBtn.addEventListener('click', () => {
+          finalize(null)
+          closeModal()
+        })
+
+        const btnGroup = document.createElement('div')
+        btnGroup.classList.add('modal__btn-group')
+        btnGroup.append(removeBtn, cancelBtn)
+
+        modal.append(msg, select, btnGroup)
+      }
+    })
+  })
+}

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -6,9 +6,7 @@
  */
 import { saveWidgetState } from '../../../storage/localStorage.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../../utils/elements.js'
-// import { debounce } from '../../../utils/utils.js'
-// The logger and debounce function makes resizeHandler.spec.ts flaky. Need to research why.
-// Does the test not wait for the correct size of the widget?
+import { debounce } from '../../../utils/utils.js'
 import { Logger } from '../../../utils/Logger.js'
 
 const logger = new Logger('resizeHandler.js')
@@ -86,6 +84,13 @@ async function handleResizeStart (event, widget) {
   // Create and append an overlay to capture all mouse events
   const overlay = createResizeOverlay()
 
+  const debouncedSave = debounce(() => {
+    const boardId = getCurrentBoardId()
+    const viewId = getCurrentViewId()
+    saveWidgetState(boardId, viewId)
+    logger.info('Resize stopped and widget state saved.')
+  }, 300)
+
   /**
    * Handles mouse movement during a resize operation, updating the widget's grid span.
    * @function handleResize
@@ -127,10 +132,7 @@ async function handleResizeStart (event, widget) {
       // Remove the overlay
       document.body.removeChild(overlay)
 
-      const boardId = getCurrentBoardId()
-      const viewId = getCurrentViewId()
-      saveWidgetState(boardId, viewId)
-      logger.info('Resize stopped and widget state saved.')
+      debouncedSave()
     } catch (error) {
       logger.error('Error stopping resize:', error)
     }

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@
  */
 import { initializeMainMenu, applyControlVisibility } from './component/menu/menu.js'
 import { initializeBoards, switchBoard } from './component/board/boardManagement.js'
-import { initializeDashboardMenu } from './component/menu/dashboardMenu.js'
+import { initializeDashboardMenu, applyWidgetMenuVisibility } from './component/menu/dashboardMenu.js'
 import { loadInitialConfig, loadBoardState } from './storage/localStorage.js'
 import { initializeDragAndDrop } from './component/widget/events/dragDrop.js'
 import { fetchServices } from './utils/fetchServices.js'
@@ -64,6 +64,7 @@ async function main () {
 
   // 4. Apply settings that depend on the loaded config
   applyControlVisibility()
+  applyWidgetMenuVisibility()
 
   // 5. Load board state from localStorage or initial config
   let boards = await loadBoardState()

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import { initializeViewDropdown } from './component/view/viewDropdown.js'
 import { loadFromFragment } from './utils/fragmentLoader.js'
 import { Logger } from './utils/Logger.js'
 import { widgetStore } from './component/widget/widgetStore.js'
+import { debounceLeading } from './utils/utils.js'
 
 const logger = new Logger('main.js')
 
@@ -100,8 +101,11 @@ async function main () {
   }
 
   // 7. Initialize modal triggers
-  document.getElementById('localStorage-edit-button').addEventListener('click', openLocalStorageModal)
-  document.getElementById('open-config-modal').addEventListener('click', openConfigModal)
+  const buttonDebounce = 200
+  const handleLocalStorageModal = debounceLeading(openLocalStorageModal, buttonDebounce)
+  const handleConfigModal = debounceLeading(openConfigModal, buttonDebounce)
+  document.getElementById('localStorage-edit-button').addEventListener('click', /** @type {EventListener} */(handleLocalStorageModal))
+  document.getElementById('open-config-modal').addEventListener('click', /** @type {EventListener} */(handleConfigModal))
 
   logger.log('Application initialization finished')
   // Signal to Playwright that the initial load and render is complete.

--- a/src/setup/example-config.json
+++ b/src/setup/example-config.json
@@ -6,6 +6,7 @@
         "hideBoardControl": false,
         "hideViewControl": false,
         "hideServiceControl": false,
+        "showMenuWidget": true,
         "localStorage": {
             "enabled": "true",
             "loadDashboardFromConfig": "false",

--- a/src/setup/example-config.json
+++ b/src/setup/example-config.json
@@ -7,6 +7,10 @@
         "hideViewControl": false,
         "hideServiceControl": false,
         "showMenuWidget": true,
+        "views": {
+            "showViewOptionsAsButtons": false,
+            "viewToShow": ""
+        },
         "localStorage": {
             "enabled": "true",
             "loadDashboardFromConfig": "false",

--- a/src/setup/example-services.json
+++ b/src/setup/example-services.json
@@ -1,46 +1,50 @@
 [
-    {
-        "name": "ASD-toolbox",
-        "url": "http://localhost:8000/asd/toolbox",
-        "type": "api",
-        "config": {
-          "minColumns": 1,
-          "maxColumns": 4,
-          "minRows": 1,
-          "maxRows": 4
-        }
-      },
-      {
-        "name": "ASD-terminal",
-        "url": "http://localhost:8000/asd/terminal",
-        "type": "web",
-        "config": {
-          "minColumns": 2,
-          "maxColumns": 6,
-          "minRows": 2,
-          "maxRows": 6
-        }
-      },
-      {
-        "name": "ASD-tunnel",
-        "url": "http://localhost:8000/asd/tunnel",
-        "type": "web",
-        "config": {
-          "minColumns": 1,
-          "maxColumns": 6,
-          "minRows": 1,
-          "maxRows": 6
-        }
-      },
-      {
-        "name": "ASD-containers",
-        "url": "http://localhost:8000/asd/containers",
-        "type": "web",
-        "config": {
-          "minColumns": 2,
-          "maxColumns": 4,
-          "minRows": 2,
-          "maxRows": 6
-        }
-      },
+  {
+    "name": "ASD-toolbox",
+    "url": "http://localhost:8000/asd/toolbox",
+    "type": "api",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 1,
+      "maxColumns": 4,
+      "minRows": 1,
+      "maxRows": 4
+    }
+  },
+  {
+    "name": "ASD-terminal",
+    "url": "http://localhost:8000/asd/terminal",
+    "type": "web",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 2,
+      "maxColumns": 6,
+      "minRows": 2,
+      "maxRows": 6
+    }
+  },
+  {
+    "name": "ASD-tunnel",
+    "url": "http://localhost:8000/asd/tunnel",
+    "type": "web",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 1,
+      "maxColumns": 6,
+      "minRows": 1,
+      "maxRows": 6
+    }
+  },
+  {
+    "name": "ASD-containers",
+    "url": "http://localhost:8000/asd/containers",
+    "type": "web",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 2,
+      "maxColumns": 4,
+      "minRows": 2,
+      "maxRows": 6
+    }
+  }
 ]

--- a/src/types.js
+++ b/src/types.js
@@ -59,6 +59,7 @@
  * @property {boolean|string} [globalSettings.hideViewControl]
  * @property {boolean|string} [globalSettings.hideServiceControl]
  * @property {boolean|string} [globalSettings.showMenuWidget]
+ * @property {{showViewOptionsAsButtons:boolean|string, viewToShow:string}} [globalSettings.views]
  * @property {{enabled:string, loadDashboardFromConfig:string, defaultBoard?:string, defaultView?:string}} [globalSettings.localStorage]
  * @property {Array<Board>} [boards]
  * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} [styling]

--- a/src/types.js
+++ b/src/types.js
@@ -52,6 +52,14 @@
  * Dashboard configuration loaded from storage or URL.
  * @typedef {Object} DashboardConfig
  * @property {object} [globalSettings]
+ * @property {string} [globalSettings.theme]
+ * @property {Array<string>} [globalSettings.widgetStoreUrl]
+ * @property {string} [globalSettings.database]
+ * @property {boolean|string} [globalSettings.hideBoardControl]
+ * @property {boolean|string} [globalSettings.hideViewControl]
+ * @property {boolean|string} [globalSettings.hideServiceControl]
+ * @property {boolean|string} [globalSettings.showMenuWidget]
+ * @property {{enabled:string, loadDashboardFromConfig:string, defaultBoard?:string, defaultView?:string}} [globalSettings.localStorage]
  * @property {Array<Board>} [boards]
  * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} [styling]
 */

--- a/src/types.js
+++ b/src/types.js
@@ -46,6 +46,7 @@
  * @property {string} url
  * @property {string} [type]
  * @property {ServiceConfig} [config]
+ * @property {number} [maxInstances] Maximum allowed widget instances
  */
 
 /**
@@ -61,9 +62,10 @@
  * @property {boolean|string} [globalSettings.showMenuWidget]
  * @property {{showViewOptionsAsButtons:boolean|string, viewToShow:string}} [globalSettings.views]
  * @property {{enabled:string, loadDashboardFromConfig:string, defaultBoard?:string, defaultView?:string}} [globalSettings.localStorage]
+ * @property {number} [globalSettings.maxTotalInstances]
  * @property {Array<Board>} [boards]
  * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} [styling]
-*/
+ */
 
 /**
  * Structured entry written by {@link Logger} during tests.

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -67,6 +67,23 @@ menu {
     background-color: #45a049;
 }
 
+#view-button-menu button {
+    background: #fff;
+    color: #333;
+    border: 2px solid #31a840;
+    border-radius: 8px;
+    padding: 8px 18px;
+    margin: 2px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+#view-button-menu button.active {
+    background: #31a840;
+    color: #fff;
+}
+
 .dropdown-content a {
     font-size: 0.8rem;
     padding: 6px 10px;

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -105,3 +105,26 @@ menu {
     display: inline-block;
     user-select: none;
 }
+
+#admin-control label {
+    position: relative;
+}
+
+#admin-control label:hover {
+    font-size: 1.4rem;
+}
+
+#admin-control label:hover::after {
+    content: attr(aria-label);
+    position: absolute;
+    top: 2.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    white-space: nowrap;
+    z-index: 10;
+}

--- a/src/ui/widget.css
+++ b/src/ui/widget.css
@@ -24,6 +24,7 @@
     #widget-container {
         grid-template-columns: repeat(8, 2fr);
         grid-template-rows: repeat(6, 200px);
+        overflow: visible;
     }
 }
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -14,6 +14,7 @@
  * @returns {Function}
  */
 function debounce (func, wait) {
+  if (typeof window !== 'undefined' && '__disableDebounce__' in window) return func
   let timeout
   return function executedFunction (...args) {
     const later = () => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -26,6 +26,23 @@ function debounce (func, wait) {
 }
 
 /**
+ * Debounce function that executes immediately and ignores subsequent calls until the wait time has elapsed.
+ *
+ * @function debounceLeading
+ * @param {Function} func - Function to debounce.
+ * @param {number} wait - Delay in milliseconds.
+ * @returns {Function}
+ */
+function debounceLeading (func, wait) {
+  let timeout
+  return function executedFunction (...args) {
+    if (!timeout) func(...args)
+    clearTimeout(timeout)
+    timeout = setTimeout(() => { timeout = null }, wait)
+  }
+}
+
+/**
  * Generate a UUID using the browser crypto API when available.
  *
  * @function getUUID
@@ -43,4 +60,4 @@ function getUUID () {
   })
 }
 
-export { debounce, getUUID }
+export { debounce, debounceLeading, getUUID }

--- a/symbols.json
+++ b/symbols.json
@@ -154,6 +154,14 @@
     "returns": "Promise<void>"
   },
   {
+    "name": "applyWidgetMenuVisibility",
+    "kind": "function",
+    "file": "src/component/menu/dashboardMenu.js",
+    "description": "Apply visibility of the widget menu based on configuration.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "base64UrlDecode",
     "kind": "function",
     "file": "src/utils/compression.js",

--- a/symbols.json
+++ b/symbols.json
@@ -244,6 +244,14 @@
     "returns": "Promise<void>"
   },
   {
+    "name": "confirmCapacity",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Ensure capacity before adding a widget. Prompts for eviction when full.",
+    "params": [],
+    "returns": "Promise<boolean>"
+  },
+  {
     "name": "createBoard",
     "kind": "function",
     "file": "src/component/board/boardManagement.js",
@@ -558,6 +566,20 @@
     "description": "Fetch the service list and update the service selector on the page.",
     "params": [],
     "returns": "Promise<Array<Service>>"
+  },
+  {
+    "name": "findFirstWidgetByService",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Find the first widget instance for a given service name.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "HTMLElement|undefined"
   },
   {
     "name": "get",
@@ -1048,6 +1070,20 @@
     "returns": "void"
   },
   {
+    "name": "isAdding",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Check if a service is currently being added.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "boolean"
+  },
+  {
     "name": "isJSON",
     "kind": "function",
     "file": "src/component/modal/localStorageModal.js",
@@ -1108,6 +1144,20 @@
     "description": "Loads the initial board configuration from the global config object into localStorage. This is typically called on first run to seed the dashboard.",
     "params": [],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "lock",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Acquire the lock for a service name.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
   },
   {
     "name": "log",
@@ -1195,6 +1245,20 @@
     "description": "Open a modal dialog allowing the user to edit and save configuration JSON.",
     "params": [],
     "returns": "void"
+  },
+  {
+    "name": "openEvictionModal",
+    "kind": "function",
+    "file": "src/component/modal/evictionModal.js",
+    "description": "Display a modal to choose a widget for removal.",
+    "params": [
+      {
+        "name": "widgets",
+        "type": "Map<string, HTMLElement>",
+        "desc": "- Current widget map."
+      }
+    ],
+    "returns": "Promise<{id:string, title:string}|null>"
   },
   {
     "name": "openFragmentDecisionModal",
@@ -1360,7 +1424,7 @@
         "desc": "- The widget wrapper element to remove."
       }
     ],
-    "returns": "void"
+    "returns": "Promise<void>"
   },
   {
     "name": "renameBoard",
@@ -1417,7 +1481,7 @@
         "desc": ""
       }
     ],
-    "returns": "void"
+    "returns": "Promise<void>"
   },
   {
     "name": "resetView",
@@ -1711,6 +1775,20 @@
         "name": "widget",
         "type": "HTMLElement",
         "desc": "- The widget wrapper to modify."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "unlock",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Release the lock for a service name.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
       }
     ],
     "returns": "void"

--- a/symbols.json
+++ b/symbols.json
@@ -353,6 +353,25 @@
     "returns": "Function"
   },
   {
+    "name": "debounceLeading",
+    "kind": "function",
+    "file": "src/utils/utils.js",
+    "description": "Debounce function that executes immediately and ignores subsequent calls until the wait time has elapsed.",
+    "params": [
+      {
+        "name": "func",
+        "type": "Function",
+        "desc": "- Function to debounce."
+      },
+      {
+        "name": "wait",
+        "type": "number",
+        "desc": "- Delay in milliseconds."
+      }
+    ],
+    "returns": "Function"
+  },
+  {
     "name": "decodeConfig",
     "kind": "function",
     "file": "src/utils/compression.js",

--- a/tests/addManageWidgets.spec.ts
+++ b/tests/addManageWidgets.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures';
 import emojiList from '../src/ui/unicodeEmoji.js';
 import { routeServicesConfig } from './shared/mocking.js';
 import { addServices, selectServiceByName, addServicesByName } from './shared/common.js';

--- a/tests/boardDropdown.spec.ts
+++ b/tests/boardDropdown.spec.ts
@@ -5,7 +5,7 @@ import { addServices } from './shared/common';
 
 
 const defaultBoardName = "Default Board"
-const newBoardName = "New Board"
+const newBoardName = "New Test Board"
 
 test.describe('Board Dropdown Functionality', () => {
   test.beforeEach(async ({ page }) => {
@@ -19,20 +19,22 @@ test.describe('Board Dropdown Functionality', () => {
     await expect(boardDropdown).toBeVisible();
   });
 
-  test('should create a new board', async ({ page }) => {
+  test('should create a new board and set it as active', async ({ page }) => {
     // Handle the prompt dialog for board name input
     await handleDialog(page, 'prompt', newBoardName);
 
     await page.click('#board-dropdown .dropbtn');
     await page.click('#board-control a[data-action="create"]');
 
-    // Assert that the new board appears in the dropdown
-    const boardSelector = await page.locator('#board-selector');
-    await expect(boardSelector).toContainText(newBoardName);
+    const selectedBoardName = await page.locator('#board-selector option:checked').textContent();
+    await expect(selectedBoardName).toBe(newBoardName);
 
-    // Verify localStorage is updated
     const boards = await getBoardsFromLocalStorage(page);
-    expect(boards.some(board => board.name === newBoardName)).toBeTruthy();
+    const newBoard = boards.find(board => board.name === newBoardName);
+    expect(newBoard).toBeDefined();
+
+    const lastUsedBoardId = await page.evaluate(() => localStorage.getItem('lastUsedBoardId'));
+    expect(lastUsedBoardId).toBe(newBoard.id);
   });
 
   test('should rename an existing board', async ({ page }) => {

--- a/tests/boardDropdown.spec.ts
+++ b/tests/boardDropdown.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { handleDialog, getBoardsFromLocalStorage} from './shared/common';
 import { routeServicesConfig } from './shared/mocking';
 import { addServices } from './shared/common';

--- a/tests/configConsistency.spec.ts
+++ b/tests/configConsistency.spec.ts
@@ -1,5 +1,5 @@
 // @ts-check
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking'
 import { handleDialog } from './shared/common'
 

--- a/tests/data/ciConfig.ts
+++ b/tests/data/ciConfig.ts
@@ -3,6 +3,10 @@ export const ciConfig = {
       "theme": "light",
       "widgetStoreUrl": ["*/services.json"],
       "database": "localStorage",
+      "views": {
+          "showViewOptionsAsButtons": false,
+          "viewToShow": ""
+      },
       "localStorage": {
           "enabled": "true",
           "loadDashboardFromConfig": "true",

--- a/tests/data/ciServices.ts
+++ b/tests/data/ciServices.ts
@@ -1,46 +1,50 @@
 export const ciServices = [
-    {
-        "name": "ASD-toolbox",
-        "url": "http://localhost:8000/asd/toolbox",
-        "type": "api",
-        "config": {
-            "minColumns": 1,
-            "maxColumns": 4,
-            "minRows": 1,
-            "maxRows": 4
-    }
+  {
+    name: "ASD-toolbox",
+    url: "http://localhost:8000/asd/toolbox",
+    type: "api",
+    maxInstances: 20,
+    config: {
+      minColumns: 1,
+      maxColumns: 4,
+      minRows: 1,
+      maxRows: 4,
     },
-    {
-        "name": "ASD-terminal",
-        "url": "http://localhost:8000/asd/terminal",
-        "type": "web",
-        "config": {
-            "minColumns": 2,
-            "maxColumns": 6,
-            "minRows": 2,
-            "maxRows": 6
-    }
+  },
+  {
+    name: "ASD-terminal",
+    url: "http://localhost:8000/asd/terminal",
+    type: "web",
+    maxInstances: 20,
+    config: {
+      minColumns: 2,
+      maxColumns: 6,
+      minRows: 2,
+      maxRows: 6,
     },
-    {
-        "name": "ASD-tunnel",
-        "url": "http://localhost:8000/asd/tunnel",
-        "type": "web",
-        "config": {
-            "minColumns": 1,
-            "maxColumns": 6,
-            "minRows": 1,
-            "maxRows": 6
-    }
+  },
+  {
+    name: "ASD-tunnel",
+    url: "http://localhost:8000/asd/tunnel",
+    type: "web",
+    maxInstances: 20,
+    config: {
+      minColumns: 1,
+      maxColumns: 6,
+      minRows: 1,
+      maxRows: 6,
     },
-    {
-        "name": "ASD-containers",
-        "url": "http://localhost:8000/asd/containers",
-        "type": "web",
-        "config": {
-            "minColumns": 2,
-            "maxColumns": 4,
-            "minRows": 2,
-            "maxRows": 6
-    }
+  },
+  {
+    name: "ASD-containers",
+    url: "http://localhost:8000/asd/containers",
+    type: "web",
+    maxInstances: 20,
+    config: {
+      minColumns: 2,
+      maxColumns: 4,
+      minRows: 2,
+      maxRows: 6,
     },
+  },
 ];

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { ciConfig, ciBoards } from './data/ciConfig';
 import { ciServices } from './data/ciServices';
 import { gunzipSync } from 'zlib';

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,11 @@
+import { test as base, expect, type Page } from '@playwright/test';
+
+export const test = base.extend<{ page: Page }>({
+  page: async ({ page }, use) => {
+    await page.addInitScript(() => { (window as any).__disableDebounce__ = true; });
+    await use(page);
+  },
+});
+
+export { expect };
+export type { Page } from '@playwright/test';

--- a/tests/fragmentLoader.spec.ts
+++ b/tests/fragmentLoader.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { ciConfig } from './data/ciConfig'
 import { ciServices } from './data/ciServices'
 import { gzipJsonToBase64url } from '../src/utils/compression.js'

--- a/tests/localStorageEditor.spec.ts
+++ b/tests/localStorageEditor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { routeServicesConfig } from './shared/mocking';
 import { ciBoards } from './data/ciConfig.js';
 

--- a/tests/menuVisibility.spec.ts
+++ b/tests/menuVisibility.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import emojiList from '../src/ui/unicodeEmoji.js'
 import { routeServicesConfig } from './shared/mocking.js'
 import { ciConfig } from './data/ciConfig'

--- a/tests/resizeHandler.spec.ts
+++ b/tests/resizeHandler.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { routeServicesConfig } from './shared/mocking';
 import { addServicesByName } from './shared/common';
 import { ciServices } from './data/ciServices';
+
 
 test.describe('Resize Handler Functionality', () => {
   test.beforeEach(async ({ page }) => {
@@ -35,6 +36,7 @@ test.describe('Resize Handler Functionality', () => {
     } else {
       await resizeWidgetWithMouse(page, resizeHandle, 1200, 900);
     }
+    await page.evaluate(() => window.asd.widgetStore.idle())
 
     // Bug: It can resize beyond maxium with corner based resize; needs fixing
     // await expect(widget).toHaveAttribute('data-columns', `${maxColumns}`);
@@ -51,6 +53,7 @@ test.describe('Resize Handler Functionality', () => {
     } else {
       await resizeWidgetWithMouse(page, resizeHandle, -1200, -900);
     }
+    await page.evaluate(() => window.asd.widgetStore.idle())
   
     // Reload and verify persistence of the minimum size
     await page.reload({ waitUntil: 'domcontentloaded' });

--- a/tests/saveAndUseService.spec.ts
+++ b/tests/saveAndUseService.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking.js'
 
 const saved = [{ name: 'Saved Service', url: 'http://localhost/saved' }]

--- a/tests/saveServiceModal.spec.ts
+++ b/tests/saveServiceModal.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking.js'
 
 

--- a/tests/shared/common.ts
+++ b/tests/shared/common.ts
@@ -27,9 +27,12 @@ export async function handleDialog(page, type, inputText = '') {
   
   // Helper function to get boards from localStorage
 export async function getBoardsFromLocalStorage(page) {
-    return await page.evaluate(() => {
-        const item = localStorage.getItem('boards');
-        return item ? JSON.parse(item) : [];
+    return await page.evaluate(async () => {
+      const result = window.asd.widgetStore.idle();
+      if (result && typeof result.then === "function") await result;
+
+      const item = localStorage.getItem('boards');
+      return item ? JSON.parse(item) : [];
     });
 }
 

--- a/tests/ui/widgetStore.spec.js
+++ b/tests/ui/widgetStore.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures'
 import { ciConfig, ciBoards } from '../data/ciConfig'
 import { ciServices } from '../data/ciServices'
 
@@ -18,12 +18,36 @@ function clone (obj) {
  * @returns {Promise<void>}
  */
 async function routeBase (page, boards) {
-  await page.route('**/services.json', route => route.fulfill({ json: ciServices }))
-  await page.route('**/config.json', route => route.fulfill({ json: { ...ciConfig, boards } }))
-  await page.route('**/asd/toolbox', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-toolbox' }) }))
-  await page.route('**/asd/terminal', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-terminal' }) }))
-  await page.route('**/asd/tunnel', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-tunnel' }) }))
-  await page.route('**/asd/containers', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-containers' }) }))
+  await page.route('**/services.json', (route) =>
+    route.fulfill({ json: ciServices })
+  )
+  await page.route('**/config.json', (route) =>
+    route.fulfill({ json: { ...ciConfig, boards } })
+  )
+  await page.route('**/asd/toolbox', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-toolbox' })
+    })
+  )
+  await page.route('**/asd/terminal', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-terminal' })
+    })
+  )
+  await page.route('**/asd/tunnel', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-tunnel' })
+    })
+  )
+  await page.route('**/asd/containers', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-containers' })
+    })
+  )
 }
 
 /**
@@ -34,12 +58,14 @@ async function routeBase (page, boards) {
  * @returns {Promise<void>}
  */
 async function routeWithLRUConfig (page, widgetState, maxSize = 2) {
-  const boards = [{
-    id: 'board-lru',
-    name: 'LRU Board',
-    order: 0,
-    views: [{ id: 'view-lru', name: 'LRU View', widgetState }]
-  }]
+  const boards = [
+    {
+      id: 'board-lru',
+      name: 'LRU Board',
+      order: 0,
+      views: [{ id: 'view-lru', name: 'LRU View', widgetState }]
+    }
+  ]
 
   await page.unroute('**/config.json').catch(() => {})
   await routeBase(page, boards)
@@ -55,10 +81,12 @@ async function routeWithLRUConfig (page, widgetState, maxSize = 2) {
   }, maxSize)
 }
 
-const defaultBoards = () => [{
-  ...clone(ciBoards[0]),
-  views: [clone(ciBoards[0].views[0]), clone(ciBoards[1].views[0])]
-}]
+const defaultBoards = () => [
+  {
+    ...clone(ciBoards[0]),
+    views: [clone(ciBoards[0].views[0]), clone(ciBoards[1].views[0])]
+  }
+]
 
 test.describe('WidgetStore UI Tests', () => {
   test.beforeEach(async ({ page }) => {
@@ -71,58 +99,115 @@ test.describe('WidgetStore UI Tests', () => {
     const viewSelector = page.locator('#view-selector')
     const view1Widget = page.locator('.widget-wrapper').first()
 
-    const initialSize = await page.evaluate(() => window.asd.widgetStore.widgets.size)
+    const initialSize = await page.evaluate(
+      () => window.asd.widgetStore.widgets.size
+    )
     expect(initialSize).toBe(1)
     await expect(view1Widget).toBeVisible()
 
-    await viewSelector.selectOption({ label: 'Modified View 2' }).catch(() =>
-      viewSelector.selectOption('view-12345678')
-    )
-    await expect(view1Widget).toHaveCSS('display', 'none')
+    await viewSelector
+      .selectOption({ label: 'Modified View 2' })
+      .catch(() => viewSelector.selectOption('view-12345678'))
+    await expect(view1Widget).toBeHidden()
 
-    const afterSwitchSize = await page.evaluate(() => window.asd.widgetStore.widgets.size)
+    const afterSwitchSize = await page.evaluate(
+      () => window.asd.widgetStore.widgets.size
+    )
     expect(afterSwitchSize).toBe(2)
 
-    await viewSelector.selectOption({ label: 'Modified View 1' }).catch(() =>
-      viewSelector.selectOption('view-1234567')
-    )
-    await expect(view1Widget).not.toHaveCSS('display', 'none')
+    await viewSelector
+      .selectOption({ label: 'Modified View 1' })
+      .catch(() => viewSelector.selectOption('view-1234567'))
+    await expect(view1Widget).not.toBeVisible
 
-    const finalSize = await page.evaluate(() => window.asd.widgetStore.widgets.size)
+    const finalSize = await page.evaluate(
+      () => window.asd.widgetStore.widgets.size
+    )
     expect(finalSize).toBe(2)
   })
 
   test('LRU Eviction Policy', async ({ page }) => {
     const widgetState = [
-      { order: '0', url: 'http://localhost:8000/asd/toolbox', columns: '1', rows: '1', type: 'web', dataid: 'W1', metadata: { title: 'w1' } },
-      { order: '1', url: 'http://localhost:8000/asd/toolbox', columns: '1', rows: '1', type: 'web', dataid: 'W2', metadata: { title: 'w2' } },
-      { order: '2', url: 'http://localhost:8000/asd/toolbox', columns: '1', rows: '1', type: 'web', dataid: 'W3', metadata: { title: 'w3' } }
+      {
+        order: '0',
+        url: 'http://localhost:8000/asd/toolbox',
+        columns: '1',
+        rows: '1',
+        type: 'web',
+        dataid: 'W1',
+        metadata: { title: 'w1' }
+      },
+      {
+        order: '1',
+        url: 'http://localhost:8000/asd/toolbox',
+        columns: '1',
+        rows: '1',
+        type: 'web',
+        dataid: 'W2',
+        metadata: { title: 'w2' }
+      },
+      {
+        order: '2',
+        url: 'http://localhost:8000/asd/toolbox',
+        columns: '1',
+        rows: '1',
+        type: 'web',
+        dataid: 'W3',
+        metadata: { title: 'w3' }
+      }
     ]
+
+    const beforeHydration = await page.$$eval('.widget-wrapper', (els) => els.length)
+    console.log('Widget count before hydration:', beforeHydration)
 
     await routeWithLRUConfig(page, widgetState, 2)
     await page.evaluate(() => localStorage.clear())
     await page.reload()
-    await expect(page.locator('.widget-wrapper')).toHaveCount(2)
 
-    const size = await page.evaluate(() => window.asd.widgetStore.widgets.size)
-    expect(size).toBe(2)
+    const afterHydration = await page.$$eval('.widget-wrapper', (els) => els.length)
+    console.log('Widget count after hydration:', afterHydration)
 
-    await expect(page.locator('[data-dataid="W1"]')).toHaveCount(0)
-    await expect(page.locator('[data-dataid="W2"]')).toBeVisible()
-    await expect(page.locator('[data-dataid="W3"]')).toBeVisible()
+    await page.waitForFunction(() =>
+      document.querySelectorAll('.widget-wrapper').length === 2
+    )
+
+    const modal = page.locator('#eviction-modal')
+    await modal.waitFor({ state: 'visible' })
+    await modal.locator('button:has-text("Remove")').click()
+    await page.evaluate(() => window.asd.widgetStore.idle())
+    await expect(modal).toBeHidden()
+
+    await page.reload()
+    await page.waitForFunction(() =>
+      document.querySelectorAll('.widget-wrapper').length === 2
+    )
+
+    const ids = await page.$$eval('.widget-wrapper', (els) =>
+      els.map((e) => e.getAttribute('data-dataid'))
+    )
+    expect(ids).not.toContain('W1')
   })
 
-  test('Removes widget via UI and updates widgetStore state', async ({ page }) => {
+  test('Removes widget via UI and updates widgetStore state', async ({
+    page
+  }) => {
     const widget = page.locator('.widget-wrapper').first()
     const widgetId = await widget.getAttribute('data-dataid')
     expect(widgetId).not.toBeNull()
-    const exists = await page.evaluate(id => window.asd.widgetStore.has(id), widgetId)
+    const exists = await page.evaluate(
+      (id) => window.asd.widgetStore.has(id),
+      widgetId
+    )
     expect(exists).toBe(true)
 
     await widget.locator('.widget-icon-remove').click()
+    await page.evaluate(() => window.asd.widgetStore.idle())
     await expect(page.locator(`[data-dataid="${widgetId}"]`)).toHaveCount(0)
 
-    const removed = await page.evaluate(id => window.asd.widgetStore.has(id), widgetId)
+    const removed = await page.evaluate(
+      (id) => window.asd.widgetStore.has(id),
+      widgetId
+    )
     expect(removed).toBe(false)
   })
 })

--- a/tests/viewDropdown.spec.ts
+++ b/tests/viewDropdown.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { handleDialog, getBoardsFromLocalStorage } from './shared/common';
 import { routeServicesConfig } from './shared/mocking';
 import { addServices } from './shared/common';
@@ -82,6 +82,12 @@ test.describe('View Dropdown Functionality', () => {
     await page.click('#view-dropdown .dropbtn');
     await page.click('#view-control a[data-action="delete"]');
 
+    // Wait for DOM change: one simple way is to wait for widgets to disappear
+    await page.waitForFunction(() => {
+      const container = document.getElementById('widget-container');
+      return container && container.querySelectorAll('.widget-wrapper').length === 0;
+    });
+
     // Verify the view was deleted
     const boards = await getBoardsFromLocalStorage(page);
     const currentBoardId = await page.locator('.board').getAttribute('id');
@@ -99,13 +105,20 @@ test.describe('View Dropdown Functionality', () => {
     await page.on('dialog', dialog => dialog.accept());
     await page.click('#view-dropdown .dropbtn');
     await page.click('#view-control a[data-action="reset"]');
+    
+    // Wait for DOM change: one simple way is to wait for widgets to disappear
+    await page.waitForFunction(() => {
+      const container = document.getElementById('widget-container');
+      return container && container.querySelectorAll('.widget-wrapper').length === 0;
+    });
+    await page.evaluate(() => window.asd.widgetStore.idle())
 
     // Verify the view was reset
     const boards = await getBoardsFromLocalStorage(page);
     const currentBoardId = await page.locator('.board').getAttribute('id');
     const currentBoard = boards.find(board => board.id === currentBoardId);
     const resetView = currentBoard.views.find(view => view.name === defaultViewName);
-
+    
     expect(resetView.widgetState.length).toBe(0);
   });
 

--- a/tests/viewDropdown.spec.ts
+++ b/tests/viewDropdown.spec.ts
@@ -33,6 +33,28 @@ test.describe('View Dropdown Functionality', () => {
     expect(newView).toBeDefined();
   });
 
+  test('should create a new view and set it as active', async ({ page }) => {
+     // Set the prompt to return the new view name
+    await handleDialog(page, 'prompt', newViewName);
+
+    await page.click('#view-dropdown .dropbtn');
+    await page.click('#view-control a[data-action="create"]');
+
+    // **VERIFICATION**: Verify that the new view is the SELECTED option
+    await verifyCurrentViewName(page, newViewName);
+
+    // Verifieer dat de view correct is opgeslagen in localStorage
+    const boards = await getBoardsFromLocalStorage(page);
+    const currentBoardId = await page.locator('.board').getAttribute('id');
+    const currentBoard = boards.find(board => board.id === currentBoardId);
+    const newView = currentBoard.views.find(view => view.name === newViewName);
+    expect(newView).toBeDefined();
+
+    // Verify that 'lastUsedViewId' matches the new view
+    const lastUsedViewId = await page.evaluate(() => localStorage.getItem('lastUsedViewId'));
+    expect(lastUsedViewId).toBe(newView.id);
+  });
+
   test('Rename a view', async ({ page }) => {
     // Verify the current view is the expected one
     await verifyCurrentViewName(page, defaultViewName);

--- a/tests/viewStateIsolation.spec.ts
+++ b/tests/viewStateIsolation.spec.ts
@@ -1,5 +1,5 @@
 // @ts-check
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { routeServicesConfig } from './shared/mocking.js';
 import { selectServiceByName } from './shared/common.js';
 

--- a/tests/widgetLimits.spec.ts
+++ b/tests/widgetLimits.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "./fixtures";
+import { ciConfig } from "./data/ciConfig";
+import { ciServices } from "./data/ciServices";
+
+async function routeLimits(page, boards, services, maxSize = 2) {
+  await page.route("**/services.json", (route) =>
+    route.fulfill({ json: services }),
+  );
+  await page.route("**/config.json", (route) =>
+    route.fulfill({ json: { ...ciConfig, boards } }),
+  );
+  await page.addInitScript((size) => {
+    const apply = () => {
+      if (window.asd?.widgetStore) {
+        window.asd.widgetStore.maxSize = size;
+      } else {
+        setTimeout(apply, 0);
+      }
+    };
+    apply();
+  }, maxSize);
+}
+
+test.describe("Widget limits", () => {
+  test("per service maxInstances navigates to existing widget", async ({
+    page,
+  }) => {
+    const boards = [
+      {
+        id: "b1",
+        name: "B1",
+        order: 0,
+        views: [
+          {
+            id: "v1",
+            name: "V1",
+            widgetState: [
+              {
+                order: "0",
+                url: "http://localhost:8000/asd/toolbox",
+                type: "web",
+                dataid: "W1",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "b2",
+        name: "B2",
+        order: 1,
+        views: [{ id: "v2", name: "V2", widgetState: [] }],
+      },
+    ];
+    const services = ciServices.map((s) =>
+      s.name === "ASD-toolbox" ? { ...s, maxInstances: 1 } : s,
+    );
+    await routeLimits(page, boards, services, 5);
+    await page.goto("/");
+    await page.locator(".widget-wrapper").first().waitFor();
+
+    await page.locator("#board-selector").selectOption("b2");
+    await page.selectOption("#service-selector", { label: "ASD-toolbox" });
+    await page.click("#add-widget-button");
+
+    await page.waitForFunction(() =>
+      document.querySelectorAll('.widget-wrapper').length === 1
+    );
+  });
+
+  test("evicts selected widget when store is full", async ({ page }) => {
+    const widgetState = [
+      {
+        order: "0",
+        url: "http://localhost:8000/asd/toolbox",
+        type: "web",
+        dataid: "W1",
+        metadata: { title: "w1" },
+      },
+    ];
+    const boards = [
+      {
+        id: "b",
+        name: "B",
+        order: 0,
+        views: [{ id: "v", name: "V", widgetState }],
+      },
+    ];
+    await routeLimits(page, boards, ciServices, 1);
+    await page.goto("/");
+    await page.locator(".widget-wrapper").first().waitFor();
+
+    await page.selectOption("#service-selector", { label: "ASD-terminal" });
+    await page.click("#add-widget-button");
+
+    const modal = page.locator("#eviction-modal");
+    await expect(modal).toBeVisible();
+    await modal.locator('button:has-text("Remove")').click();
+    await page.evaluate(() => window.asd.widgetStore.idle());
+    await expect(modal).toBeHidden();
+    await page.waitForFunction(() =>
+      document.querySelectorAll('.widget-wrapper').length === 1
+    );
+    const ids = await page.$$eval('.widget-wrapper', (els) =>
+      els.map((e) => e.getAttribute('data-dataid')),
+    );
+    expect(ids).not.toContain('W1');
+  });
+
+  test('simultaneous instance request uses single widget', async ({ page }) => {
+    const boards = [
+      { id: 'b1', name: 'B1', order: 0, views: [{ id: 'v1', name: 'V1', widgetState: [] }] },
+      { id: 'b2', name: 'B2', order: 1, views: [{ id: 'v2', name: 'V2', widgetState: [] }] }
+    ];
+    const services = ciServices.map((s) =>
+      s.name === 'ASD-toolbox' ? { ...s, maxInstances: 1 } : s
+    );
+    await routeLimits(page, boards, services, 5);
+    await page.goto('/');
+    await page.waitForSelector('#service-selector');
+
+    await page.evaluate(async () => {
+      const { addWidget } = await import('/component/widget/widgetManagement.js');
+      const url = 'http://localhost:8000/asd/toolbox';
+      await Promise.all([
+        addWidget(url, 1, 1, 'web', 'b1', 'v1'),
+        addWidget(url, 1, 1, 'web', 'b2', 'v2')
+      ]);
+    });
+
+    await page.waitForFunction(() =>
+      document.querySelectorAll('.widget-wrapper').length === 1
+    );
+    const selectedBoard = await page.locator('#board-selector').inputValue();
+    const boardWithWidget = await page.evaluate(() => {
+      const boards = JSON.parse(localStorage.getItem('boards') || '[]');
+      return boards.find(b => b.views.some(v => v.widgetState && v.widgetState.length > 0))?.id;
+    });
+    expect(selectedBoard).toBe(boardWithWidget);
+  });
+});


### PR DESCRIPTION
### Summary

This PR implements **phase 1** of our widget management overhaul:

- Adds per-service widget limits via `maxInstances` in `services.json`
- Replaces automatic LRU eviction with a **user-driven modal** using `openModal()`
- Stabilizes widget tests and improves test observability
- Includes auxiliary UI improvements and test harness fixes

---

### Features

#### ✅ 1. Per-service widget limits
- `maxInstances` is now a first-class property in `services.json`
- Supported values:
  - `undefined`: unlimited (default)
  - `0`: disallow entirely
  - `1..N`: limit to N instances per service
- Limits are hydrated from `localStorage`, like other service metadata

#### ✅ 2. Enforce limits in `addWidget()`
- Adds guard in `widgetStore` to count active instances per service
- Prevents over-instantiation
- If a duplicate exists, `switchToWidget()` is triggered instead
- If `maxInstances === 0`, the UI disables launch (with tooltip)

#### ✅ 3. Global widget eviction reworked
- If widget count hits global limit (`maxSize`), a modal is shown:
  - Option to select an existing widget to evict
  - Option to cancel
  - Default fallback: LRU eviction fallback is preserved but not triggered automatically

---

### Testing

- ✅ Playwright tests updated to reflect new widget load behavior
- ✅ Eviction modal selection behavior tested
- ✅ Hydration order and LRU restored after reload verified
- ✅ View and board creation tests re-enabled and stabilized

---

### Misc

- Fixes debounce on resize handlers
- Improves overflow styling to reduce double scrollbars
- Minor hover/aria visual improvements
