### PR TITLE
Add debounce to admin controls

### DIFF
--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -18,6 +18,7 @@ import { showNotification } from '../dialog/notification.js'
 import emojiList from '../../ui/unicodeEmoji.js'
 import { Logger } from '../../utils/Logger.js'
 import { clearConfigFragment } from '../../utils/fragmentGuard.js'
+import { debounce } from '../../utils/utils.js'
 
 const logger = new Logger('dashboardMenu.js')
 
@@ -37,6 +38,8 @@ function initializeDashboardMenu () {
   populateServiceDropdown()
   document.addEventListener('services-updated', populateServiceDropdown)
   applyWidgetMenuVisibility()
+
+  const buttonDebounce = 200
 
   document.getElementById('add-widget-button').addEventListener('click', () => {
     const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
@@ -61,7 +64,7 @@ function initializeDashboardMenu () {
     }
   })
 
-  document.getElementById('toggle-widget-menu').addEventListener('click', () => {
+  const handleToggleWidgetMenu = debounce(() => {
     const widgetContainer = document.getElementById('widget-container')
     const toggled = widgetContainer.classList.toggle('hide-widget-menu') // true if now hidden
 
@@ -75,9 +78,10 @@ function initializeDashboardMenu () {
     }
 
     showNotification(message, 500)
-  })
+  }, buttonDebounce)
+  document.getElementById('toggle-widget-menu').addEventListener('click', /** @type {EventListener} */(handleToggleWidgetMenu))
 
-  document.getElementById('reset-button').addEventListener('click', () => {
+  const handleReset = debounce(() => {
     // Show confirmation dialog
     const confirmed = confirm('Confirm environment reset: all configurations and services will be permanently deleted.')
 
@@ -86,7 +90,8 @@ function initializeDashboardMenu () {
       clearConfigFragment()
       location.reload()
     }
-  })
+  }, buttonDebounce)
+  document.getElementById('reset-button').addEventListener('click', /** @type {EventListener} */(handleReset))
 
   document.getElementById('board-selector').addEventListener('change', (event) => {
     const target = /** @type {HTMLSelectElement} */(event.target)

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -18,7 +18,7 @@ import { showNotification } from '../dialog/notification.js'
 import emojiList from '../../ui/unicodeEmoji.js'
 import { Logger } from '../../utils/Logger.js'
 import { clearConfigFragment } from '../../utils/fragmentGuard.js'
-import { debounce } from '../../utils/utils.js'
+import { debounceLeading } from '../../utils/utils.js'
 
 const logger = new Logger('dashboardMenu.js')
 
@@ -64,7 +64,7 @@ function initializeDashboardMenu () {
     }
   })
 
-  const handleToggleWidgetMenu = debounce(() => {
+  const handleToggleWidgetMenu = debounceLeading(() => {
     const widgetContainer = document.getElementById('widget-container')
     const toggled = widgetContainer.classList.toggle('hide-widget-menu') // true if now hidden
 
@@ -81,7 +81,7 @@ function initializeDashboardMenu () {
   }, buttonDebounce)
   document.getElementById('toggle-widget-menu').addEventListener('click', /** @type {EventListener} */(handleToggleWidgetMenu))
 
-  const handleReset = debounce(() => {
+  const handleReset = debounceLeading(() => {
     // Show confirmation dialog
     const confirmed = confirm('Confirm environment reset: all configurations and services will be permanently deleted.')
 

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -6,7 +6,7 @@
  */
 import emojiList from '../../ui/unicodeEmoji.js'
 import { showNotification } from '../dialog/notification.js'
-import { debounce } from '../../utils/utils.js'
+import { debounceLeading } from '../../utils/utils.js'
 
 /**
  * Initialize service worker controls in the menu.
@@ -95,7 +95,7 @@ function initSW () {
       unregisterServiceWorker()
     }
 
-    const handleSwChange = debounce(() => {
+    const handleSwChange = debounceLeading(() => {
       const isEnabled = swToggle.checked
       localStorage.setItem('swEnabled', String(isEnabled))
       updateServiceWorkerUI(isEnabled)

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -6,6 +6,7 @@
  */
 import emojiList from '../../ui/unicodeEmoji.js'
 import { showNotification } from '../dialog/notification.js'
+import { debounce } from '../../utils/utils.js'
 
 /**
  * Initialize service worker controls in the menu.
@@ -20,6 +21,8 @@ function initSW () {
   const swCheckbox = document.querySelector('.icon-checkbox')
   const swEnabled = localStorage.getItem('swEnabled') === 'true'
   swToggle.checked = swEnabled
+
+  const buttonDebounce = 200
 
   /**
    * Updates the UI of the service worker toggle icon and attributes.
@@ -92,7 +95,7 @@ function initSW () {
       unregisterServiceWorker()
     }
 
-    swToggle.addEventListener('change', function () {
+    const handleSwChange = debounce(() => {
       const isEnabled = swToggle.checked
       localStorage.setItem('swEnabled', String(isEnabled))
       updateServiceWorkerUI(isEnabled)
@@ -103,7 +106,8 @@ function initSW () {
       } else {
         unregisterServiceWorker()
       }
-    })
+    }, buttonDebounce)
+    swToggle.addEventListener('change', /** @type {EventListener} */(handleSwChange))
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import { initializeViewDropdown } from './component/view/viewDropdown.js'
 import { loadFromFragment } from './utils/fragmentLoader.js'
 import { Logger } from './utils/Logger.js'
 import { widgetStore } from './component/widget/widgetStore.js'
+import { debounce } from './utils/utils.js'
 
 const logger = new Logger('main.js')
 
@@ -100,8 +101,11 @@ async function main () {
   }
 
   // 7. Initialize modal triggers
-  document.getElementById('localStorage-edit-button').addEventListener('click', openLocalStorageModal)
-  document.getElementById('open-config-modal').addEventListener('click', openConfigModal)
+  const buttonDebounce = 200
+  const handleLocalStorageModal = debounce(openLocalStorageModal, buttonDebounce)
+  const handleConfigModal = debounce(openConfigModal, buttonDebounce)
+  document.getElementById('localStorage-edit-button').addEventListener('click', /** @type {EventListener} */(handleLocalStorageModal))
+  document.getElementById('open-config-modal').addEventListener('click', /** @type {EventListener} */(handleConfigModal))
 
   logger.log('Application initialization finished')
   // Signal to Playwright that the initial load and render is complete.

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ import { initializeViewDropdown } from './component/view/viewDropdown.js'
 import { loadFromFragment } from './utils/fragmentLoader.js'
 import { Logger } from './utils/Logger.js'
 import { widgetStore } from './component/widget/widgetStore.js'
-import { debounce } from './utils/utils.js'
+import { debounceLeading } from './utils/utils.js'
 
 const logger = new Logger('main.js')
 
@@ -102,8 +102,8 @@ async function main () {
 
   // 7. Initialize modal triggers
   const buttonDebounce = 200
-  const handleLocalStorageModal = debounce(openLocalStorageModal, buttonDebounce)
-  const handleConfigModal = debounce(openConfigModal, buttonDebounce)
+  const handleLocalStorageModal = debounceLeading(openLocalStorageModal, buttonDebounce)
+  const handleConfigModal = debounceLeading(openConfigModal, buttonDebounce)
   document.getElementById('localStorage-edit-button').addEventListener('click', /** @type {EventListener} */(handleLocalStorageModal))
   document.getElementById('open-config-modal').addEventListener('click', /** @type {EventListener} */(handleConfigModal))
 

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -117,7 +117,7 @@ menu {
 #admin-control label:hover::after {
     content: attr(aria-label);
     position: absolute;
-    top: -1.5rem;
+    top: 2.5rem;
     left: 50%;
     transform: translateX(-50%);
     background: rgba(0, 0, 0, 0.8);

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -105,3 +105,26 @@ menu {
     display: inline-block;
     user-select: none;
 }
+
+#admin-control label {
+    position: relative;
+}
+
+#admin-control label:hover {
+    font-size: 1.4rem;
+}
+
+#admin-control label:hover::after {
+    content: attr(aria-label);
+    position: absolute;
+    top: -1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    white-space: nowrap;
+    z-index: 10;
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -26,6 +26,23 @@ function debounce (func, wait) {
 }
 
 /**
+ * Debounce function that executes immediately and ignores subsequent calls until the wait time has elapsed.
+ *
+ * @function debounceLeading
+ * @param {Function} func - Function to debounce.
+ * @param {number} wait - Delay in milliseconds.
+ * @returns {Function}
+ */
+function debounceLeading (func, wait) {
+  let timeout
+  return function executedFunction (...args) {
+    if (!timeout) func(...args)
+    clearTimeout(timeout)
+    timeout = setTimeout(() => { timeout = null }, wait)
+  }
+}
+
+/**
  * Generate a UUID using the browser crypto API when available.
  *
  * @function getUUID
@@ -43,4 +60,4 @@ function getUUID () {
   })
 }
 
-export { debounce, getUUID }
+export { debounce, debounceLeading, getUUID }

--- a/symbols.json
+++ b/symbols.json
@@ -353,6 +353,25 @@
     "returns": "Function"
   },
   {
+    "name": "debounceLeading",
+    "kind": "function",
+    "file": "src/utils/utils.js",
+    "description": "Debounce function that executes immediately and ignores subsequent calls until the wait time has elapsed.",
+    "params": [
+      {
+        "name": "func",
+        "type": "Function",
+        "desc": "- Function to debounce."
+      },
+      {
+        "name": "wait",
+        "type": "number",
+        "desc": "- Delay in milliseconds."
+      }
+    ],
+    "returns": "Function"
+  },
+  {
     "name": "decodeConfig",
     "kind": "function",
     "file": "src/utils/compression.js",


### PR DESCRIPTION
## Summary
- prevent rapid double toggles in admin controls by debouncing click/change handlers
- enlarge admin control icons on hover and show aria-label

## Testing
- `npm run lint-fix`
- `npm run check`
- `npm run test` *(fails: TimeoutError in many tests)*

------
https://chatgpt.com/codex/tasks/task_b_6866ba33dd988325a15435080ce0bba4