### PR TITLE
feat(widgetStore): enforce widget limits with eviction modal

### DIFF
--- a/src/component/modal/evictionModal.js
+++ b/src/component/modal/evictionModal.js
@@ -1,0 +1,65 @@
+// @ts-check
+/**
+ * Modal dialog prompting which widget to evict when the widgetStore is full.
+ *
+ * @module evictionModal
+ */
+import { openModal } from './modalFactory.js'
+
+/**
+ * Display a modal to choose a widget for removal.
+ *
+ * @param {Map<string, HTMLElement>} widgets - Current widget map.
+ * @function openEvictionModal
+ * @returns {Promise<string|null>} Resolves with selected widget id or null if cancelled.
+ */
+export function openEvictionModal (widgets) {
+  return new Promise((resolve) => {
+    openModal({
+      id: 'eviction-modal',
+      showCloseIcon: false,
+      onCloseCallback: () => resolve(null),
+      buildContent: (modal, closeModal) => {
+        const msg = document.createElement('p')
+        msg.textContent = 'Select a widget to remove:'
+
+        const select = document.createElement('select')
+        select.id = 'eviction-select'
+        for (const [id, el] of widgets.entries()) {
+          let label = id
+          if (el.dataset.metadata) {
+            try {
+              label = JSON.parse(el.dataset.metadata).title || id
+            } catch {}
+          }
+          const opt = document.createElement('option')
+          opt.value = id
+          opt.textContent = label
+          select.appendChild(opt)
+        }
+
+        const removeBtn = document.createElement('button')
+        removeBtn.textContent = 'Remove'
+        removeBtn.classList.add('modal__btn', 'modal__btn--save')
+        removeBtn.addEventListener('click', () => {
+          closeModal()
+          resolve(select.value)
+        })
+
+        const cancelBtn = document.createElement('button')
+        cancelBtn.textContent = 'Cancel'
+        cancelBtn.classList.add('modal__btn', 'modal__btn--cancel')
+        cancelBtn.addEventListener('click', () => {
+          closeModal()
+          resolve(null)
+        })
+
+        const btnGroup = document.createElement('div')
+        btnGroup.classList.add('modal__btn-group')
+        btnGroup.append(removeBtn, cancelBtn)
+
+        modal.append(msg, select, btnGroup)
+      }
+    })
+  })
+}

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -6,7 +6,12 @@
  */
 import { saveWidgetState } from '../../storage/localStorage.js'
 import { fetchData } from './utils/fetchData.js'
-import { showResizeMenu, hideResizeMenu, showResizeMenuBlock, hideResizeMenuBlock } from './menu/resizeMenu.js'
+import {
+  showResizeMenu,
+  hideResizeMenu,
+  showResizeMenuBlock,
+  hideResizeMenuBlock
+} from './menu/resizeMenu.js'
 import emojiList from '../../ui/unicodeEmoji.js'
 import { debounce } from '../../utils/utils.js'
 import { fetchServices } from './utils/fetchServices.js'
@@ -17,6 +22,8 @@ import { toggleFullScreen } from './events/fullscreenToggle.js'
 import { initializeResizeHandles } from './events/resizeHandler.js'
 import { Logger } from '../../utils/Logger.js'
 import { showServiceModal } from '../modal/serviceLaunchModal.js'
+import { openEvictionModal } from '../modal/evictionModal.js'
+import { switchBoard } from '../board/boardManagement.js'
 import { widgetGetUUID } from '../../utils/id.js'
 
 const logger = new Logger('widgetManagement.js')
@@ -31,14 +38,22 @@ const logger = new Logger('widgetManagement.js')
  * @param {string|null} [dataid=null] - An optional persistent identifier for the widget.
  * @returns {Promise<HTMLDivElement>} A promise that resolves to the widget's wrapper element.
  */
-async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, dataid = null) {
+async function createWidget (
+  service,
+  url,
+  gridColumnSpan = 1,
+  gridRowSpan = 1,
+  dataid = null
+) {
   logger.log('Creating widget with URL:', url)
   const config = await getConfig()
   const services = await fetchServices()
-  const serviceObj = services.find(s => s.name === service) || {}
+  const serviceObj = services.find((s) => s.name === service) || {}
 
-  const minColumns = serviceObj.config?.minColumns || config.styling.widget.minColumns
-  const maxColumns = serviceObj.config?.maxColumns || config.styling.widget.maxColumns
+  const minColumns =
+    serviceObj.config?.minColumns || config.styling.widget.minColumns
+  const maxColumns =
+    serviceObj.config?.maxColumns || config.styling.widget.maxColumns
   const minRows = serviceObj.config?.minRows || config.styling.widget.minRows
   const maxRows = serviceObj.config?.maxRows || config.styling.widget.maxRows
 
@@ -72,7 +87,8 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
     const fixServiceButton = document.createElement('button')
     fixServiceButton.innerHTML = emojiList.launch.unicode
     fixServiceButton.classList.add('widget-button', 'widget-icon-action')
-    fixServiceButton.onclick = () => showServiceModal(serviceObj, widgetWrapper)
+    fixServiceButton.onclick = () =>
+      showServiceModal(serviceObj, widgetWrapper)
     widgetMenu.appendChild(fixServiceButton)
   }
 
@@ -87,25 +103,42 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
   configureButton.addEventListener('click', () => configureWidget(iframe))
 
   const buttonDebounce = 200
-  const debouncedHideResizeMenu = debounce((icon) => hideResizeMenu(icon), buttonDebounce)
-  const debouncedHideResizeMenuBlock = debounce((widgetWrapper) => hideResizeMenuBlock(widgetWrapper), buttonDebounce)
+  const debouncedHideResizeMenu = debounce(
+    (icon) => hideResizeMenu(icon),
+    buttonDebounce
+  )
+  const debouncedHideResizeMenuBlock = debounce(
+    (widgetWrapper) => hideResizeMenuBlock(widgetWrapper),
+    buttonDebounce
+  )
 
   const resizeMenuIcon = document.createElement('button')
   resizeMenuIcon.innerHTML = emojiList.triangularRuler.unicode
   resizeMenuIcon.classList.add('widget-button', 'widget-icon-resize')
-  resizeMenuIcon.addEventListener('mouseenter', () => showResizeMenu(resizeMenuIcon))
+  resizeMenuIcon.addEventListener('mouseenter', () =>
+    showResizeMenu(resizeMenuIcon)
+  )
   resizeMenuIcon.addEventListener('mouseleave', (event) => {
-    const related = /** @type {?HTMLElement} */(event.relatedTarget)
-    if (!related || !related.closest('.resize-menu')) debouncedHideResizeMenu(resizeMenuIcon)
+    const related = /** @type {?HTMLElement} */ (event.relatedTarget)
+    if (!related || !related.closest('.resize-menu')) {
+      debouncedHideResizeMenu(resizeMenuIcon)
+    }
   })
 
   const resizeMenuBlockIcon = document.createElement('button')
   resizeMenuBlockIcon.innerHTML = emojiList.puzzle.unicode
-  resizeMenuBlockIcon.classList.add('widget-button', 'widget-icon-resize-block')
-  resizeMenuBlockIcon.addEventListener('mouseenter', () => showResizeMenuBlock(resizeMenuBlockIcon, widgetWrapper))
+  resizeMenuBlockIcon.classList.add(
+    'widget-button',
+    'widget-icon-resize-block'
+  )
+  resizeMenuBlockIcon.addEventListener('mouseenter', () =>
+    showResizeMenuBlock(resizeMenuBlockIcon, widgetWrapper)
+  )
   resizeMenuBlockIcon.addEventListener('mouseleave', (event) => {
-    const related = /** @type {?HTMLElement} */(event.relatedTarget)
-    if (!related || !related.closest('.resize-menu-block')) debouncedHideResizeMenuBlock(widgetWrapper)
+    const related = /** @type {?HTMLElement} */ (event.relatedTarget)
+    if (!related || !related.closest('.resize-menu-block')) {
+      debouncedHideResizeMenuBlock(widgetWrapper)
+    }
   })
 
   const dragHandle = document.createElement('span')
@@ -121,7 +154,14 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
     toggleFullScreen(widgetWrapper)
   })
 
-  widgetMenu.append(fullScreenButton, removeButton, configureButton, resizeMenuIcon, resizeMenuBlockIcon, dragHandle)
+  widgetMenu.append(
+    fullScreenButton,
+    removeButton,
+    configureButton,
+    resizeMenuIcon,
+    resizeMenuBlockIcon,
+    dragHandle
+  )
   widgetWrapper.append(iframe, widgetMenu)
 
   dragHandle.addEventListener('dragstart', (e) => {
@@ -145,7 +185,15 @@ async function createWidget (service, url, gridColumnSpan = 1, gridRowSpan = 1, 
  * @param {string|null} [dataid=null] - An optional persistent identifier for the widget.
  * @returns {Promise<void>}
  */
-async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId = null, viewId = null, dataid = null) {
+async function addWidget (
+  url,
+  columns = 1,
+  rows = 1,
+  type = 'iframe',
+  boardId = null,
+  viewId = null,
+  dataid = null
+) {
   logger.log('Adding widget with URL:', url)
   const widgetContainer = document.getElementById('widget-container')
   if (!widgetContainer) return logger.error('Widget container not found')
@@ -153,26 +201,57 @@ async function addWidget (url, columns = 1, rows = 1, type = 'iframe', boardId =
   boardId = boardId || window.asd.currentBoardId
   viewId = viewId || window.asd.currentViewId
 
+  const serviceName = await getServiceFromUrl(url)
+  const services = await fetchServices()
+  const serviceObj = services.find((s) => s.name === serviceName) || {}
+
+  if (typeof serviceObj.maxInstances === 'number') {
+    if (serviceObj.maxInstances === 0) return
+    const activeCount = Array.from(
+      window.asd.widgetStore.widgets.values()
+    ).filter((el) => el.dataset.service === serviceName).length
+    if (activeCount >= serviceObj.maxInstances) {
+      const existing = Array.from(window.asd.widgetStore.widgets.values()).find(
+        (el) => el.dataset.service === serviceName
+      )
+      if (existing) {
+        const loc = findWidgetLocation(existing.dataset.dataid)
+        if (loc) await switchBoard(loc.boardId, loc.viewId)
+      }
+      return
+    }
+  }
+
+  if (window.asd.widgetStore.widgets.size >= window.asd.widgetStore.maxSize) {
+    const idToRemove = await openEvictionModal(window.asd.widgetStore.widgets)
+    if (!idToRemove) return
+    window.asd.widgetStore.requestRemoval(idToRemove)
+  }
+
   if (dataid && window.asd.widgetStore.has(dataid)) {
     window.asd.widgetStore.show(dataid)
     return
   }
 
-  const service = await getServiceFromUrl(url)
-  const widgetWrapper = await createWidget(service, url, columns, rows, dataid)
+  const widgetWrapper = await createWidget(
+    serviceName,
+    url,
+    columns,
+    rows,
+    dataid
+  )
 
-  const visibleWidgetCount = Array.from(widgetContainer.children)
-    .filter(el => (el instanceof HTMLElement) && el.style.display !== 'none').length
+  const visibleWidgetCount = Array.from(widgetContainer.children).filter(
+    (el) => el instanceof HTMLElement && el.style.display !== 'none'
+  ).length
   widgetWrapper.setAttribute('data-order', String(visibleWidgetCount))
   widgetWrapper.style.order = String(visibleWidgetCount)
 
   widgetContainer.appendChild(widgetWrapper)
   window.asd.widgetStore.add(widgetWrapper)
 
-  const services = await fetchServices()
-  const serviceObj = services.find(s => s.name === service)
   if (serviceObj && serviceObj.type === 'api') {
-    fetchData(url, data => {
+    fetchData(url, (data) => {
       const iframe = widgetWrapper.querySelector('iframe')
       iframe.contentWindow.postMessage(data, '*')
     })
@@ -218,8 +297,8 @@ function updateWidgetOrders () {
   const widgetsInDomOrder = Array.from(widgetContainer.children)
 
   let visibleIndex = 0
-  widgetsInDomOrder.forEach(widget => {
-    const el = /** @type {HTMLElement} */(widget)
+  widgetsInDomOrder.forEach((widget) => {
+    const el = /** @type {HTMLElement} */ (widget)
     if (el.style.display !== 'none') {
       const newOrder = String(visibleIndex)
       el.setAttribute('data-order', newOrder)
@@ -234,6 +313,23 @@ function updateWidgetOrders () {
     // This is now a synchronous call
     saveWidgetState(boardId, viewId)
   }
+}
+
+/**
+ * Locate the board and view containing a widget id.
+ * @param {string} id
+ * @returns {{boardId:string, viewId:string}|null}
+ */
+function findWidgetLocation (id) {
+  const boards = window.asd.boards || []
+  for (const board of boards) {
+    for (const view of board.views) {
+      if (view.widgetState.some((w) => w.dataid === id)) {
+        return { boardId: board.id, viewId: view.id }
+      }
+    }
+  }
+  return null
 }
 
 export { addWidget, removeWidget, updateWidgetOrders, createWidget }

--- a/src/component/widget/widgetStore.js
+++ b/src/component/widget/widgetStore.js
@@ -38,7 +38,6 @@ export class WidgetStore {
       this.widgets.delete(id)
     }
     this.widgets.set(id, element)
-    this._ensureLimit()
   }
 
   /**

--- a/src/setup/example-services.json
+++ b/src/setup/example-services.json
@@ -1,46 +1,50 @@
 [
-    {
-        "name": "ASD-toolbox",
-        "url": "http://localhost:8000/asd/toolbox",
-        "type": "api",
-        "config": {
-          "minColumns": 1,
-          "maxColumns": 4,
-          "minRows": 1,
-          "maxRows": 4
-        }
-      },
-      {
-        "name": "ASD-terminal",
-        "url": "http://localhost:8000/asd/terminal",
-        "type": "web",
-        "config": {
-          "minColumns": 2,
-          "maxColumns": 6,
-          "minRows": 2,
-          "maxRows": 6
-        }
-      },
-      {
-        "name": "ASD-tunnel",
-        "url": "http://localhost:8000/asd/tunnel",
-        "type": "web",
-        "config": {
-          "minColumns": 1,
-          "maxColumns": 6,
-          "minRows": 1,
-          "maxRows": 6
-        }
-      },
-      {
-        "name": "ASD-containers",
-        "url": "http://localhost:8000/asd/containers",
-        "type": "web",
-        "config": {
-          "minColumns": 2,
-          "maxColumns": 4,
-          "minRows": 2,
-          "maxRows": 6
-        }
-      },
+  {
+    "name": "ASD-toolbox",
+    "url": "http://localhost:8000/asd/toolbox",
+    "type": "api",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 1,
+      "maxColumns": 4,
+      "minRows": 1,
+      "maxRows": 4
+    }
+  },
+  {
+    "name": "ASD-terminal",
+    "url": "http://localhost:8000/asd/terminal",
+    "type": "web",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 2,
+      "maxColumns": 6,
+      "minRows": 2,
+      "maxRows": 6
+    }
+  },
+  {
+    "name": "ASD-tunnel",
+    "url": "http://localhost:8000/asd/tunnel",
+    "type": "web",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 1,
+      "maxColumns": 6,
+      "minRows": 1,
+      "maxRows": 6
+    }
+  },
+  {
+    "name": "ASD-containers",
+    "url": "http://localhost:8000/asd/containers",
+    "type": "web",
+    "maxInstances": 20,
+    "config": {
+      "minColumns": 2,
+      "maxColumns": 4,
+      "minRows": 2,
+      "maxRows": 6
+    }
+  }
 ]

--- a/src/types.js
+++ b/src/types.js
@@ -46,6 +46,7 @@
  * @property {string} url
  * @property {string} [type]
  * @property {ServiceConfig} [config]
+ * @property {number} [maxInstances] Maximum allowed widget instances
  */
 
 /**
@@ -63,7 +64,7 @@
  * @property {{enabled:string, loadDashboardFromConfig:string, defaultBoard?:string, defaultView?:string}} [globalSettings.localStorage]
  * @property {Array<Board>} [boards]
  * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} [styling]
-*/
+ */
 
 /**
  * Structured entry written by {@link Logger} during tests.

--- a/tests/data/ciServices.ts
+++ b/tests/data/ciServices.ts
@@ -1,46 +1,50 @@
 export const ciServices = [
-    {
-        "name": "ASD-toolbox",
-        "url": "http://localhost:8000/asd/toolbox",
-        "type": "api",
-        "config": {
-            "minColumns": 1,
-            "maxColumns": 4,
-            "minRows": 1,
-            "maxRows": 4
-    }
+  {
+    name: "ASD-toolbox",
+    url: "http://localhost:8000/asd/toolbox",
+    type: "api",
+    maxInstances: 20,
+    config: {
+      minColumns: 1,
+      maxColumns: 4,
+      minRows: 1,
+      maxRows: 4,
     },
-    {
-        "name": "ASD-terminal",
-        "url": "http://localhost:8000/asd/terminal",
-        "type": "web",
-        "config": {
-            "minColumns": 2,
-            "maxColumns": 6,
-            "minRows": 2,
-            "maxRows": 6
-    }
+  },
+  {
+    name: "ASD-terminal",
+    url: "http://localhost:8000/asd/terminal",
+    type: "web",
+    maxInstances: 20,
+    config: {
+      minColumns: 2,
+      maxColumns: 6,
+      minRows: 2,
+      maxRows: 6,
     },
-    {
-        "name": "ASD-tunnel",
-        "url": "http://localhost:8000/asd/tunnel",
-        "type": "web",
-        "config": {
-            "minColumns": 1,
-            "maxColumns": 6,
-            "minRows": 1,
-            "maxRows": 6
-    }
+  },
+  {
+    name: "ASD-tunnel",
+    url: "http://localhost:8000/asd/tunnel",
+    type: "web",
+    maxInstances: 20,
+    config: {
+      minColumns: 1,
+      maxColumns: 6,
+      minRows: 1,
+      maxRows: 6,
     },
-    {
-        "name": "ASD-containers",
-        "url": "http://localhost:8000/asd/containers",
-        "type": "web",
-        "config": {
-            "minColumns": 2,
-            "maxColumns": 4,
-            "minRows": 2,
-            "maxRows": 6
-    }
+  },
+  {
+    name: "ASD-containers",
+    url: "http://localhost:8000/asd/containers",
+    type: "web",
+    maxInstances: 20,
+    config: {
+      minColumns: 2,
+      maxColumns: 4,
+      minRows: 2,
+      maxRows: 6,
     },
+  },
 ];

--- a/tests/ui/widgetStore.spec.js
+++ b/tests/ui/widgetStore.spec.js
@@ -18,12 +18,36 @@ function clone (obj) {
  * @returns {Promise<void>}
  */
 async function routeBase (page, boards) {
-  await page.route('**/services.json', route => route.fulfill({ json: ciServices }))
-  await page.route('**/config.json', route => route.fulfill({ json: { ...ciConfig, boards } }))
-  await page.route('**/asd/toolbox', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-toolbox' }) }))
-  await page.route('**/asd/terminal', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-terminal' }) }))
-  await page.route('**/asd/tunnel', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-tunnel' }) }))
-  await page.route('**/asd/containers', route => route.fulfill({ contentType: 'application/json', body: JSON.stringify({ name: 'ASD-containers' }) }))
+  await page.route('**/services.json', (route) =>
+    route.fulfill({ json: ciServices })
+  )
+  await page.route('**/config.json', (route) =>
+    route.fulfill({ json: { ...ciConfig, boards } })
+  )
+  await page.route('**/asd/toolbox', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-toolbox' })
+    })
+  )
+  await page.route('**/asd/terminal', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-terminal' })
+    })
+  )
+  await page.route('**/asd/tunnel', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-tunnel' })
+    })
+  )
+  await page.route('**/asd/containers', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ name: 'ASD-containers' })
+    })
+  )
 }
 
 /**
@@ -34,12 +58,14 @@ async function routeBase (page, boards) {
  * @returns {Promise<void>}
  */
 async function routeWithLRUConfig (page, widgetState, maxSize = 2) {
-  const boards = [{
-    id: 'board-lru',
-    name: 'LRU Board',
-    order: 0,
-    views: [{ id: 'view-lru', name: 'LRU View', widgetState }]
-  }]
+  const boards = [
+    {
+      id: 'board-lru',
+      name: 'LRU Board',
+      order: 0,
+      views: [{ id: 'view-lru', name: 'LRU View', widgetState }]
+    }
+  ]
 
   await page.unroute('**/config.json').catch(() => {})
   await routeBase(page, boards)
@@ -55,10 +81,12 @@ async function routeWithLRUConfig (page, widgetState, maxSize = 2) {
   }, maxSize)
 }
 
-const defaultBoards = () => [{
-  ...clone(ciBoards[0]),
-  views: [clone(ciBoards[0].views[0]), clone(ciBoards[1].views[0])]
-}]
+const defaultBoards = () => [
+  {
+    ...clone(ciBoards[0]),
+    views: [clone(ciBoards[0].views[0]), clone(ciBoards[1].views[0])]
+  }
+]
 
 test.describe('WidgetStore UI Tests', () => {
   test.beforeEach(async ({ page }) => {
@@ -71,58 +99,103 @@ test.describe('WidgetStore UI Tests', () => {
     const viewSelector = page.locator('#view-selector')
     const view1Widget = page.locator('.widget-wrapper').first()
 
-    const initialSize = await page.evaluate(() => window.asd.widgetStore.widgets.size)
+    const initialSize = await page.evaluate(
+      () => window.asd.widgetStore.widgets.size
+    )
     expect(initialSize).toBe(1)
     await expect(view1Widget).toBeVisible()
 
-    await viewSelector.selectOption({ label: 'Modified View 2' }).catch(() =>
-      viewSelector.selectOption('view-12345678')
-    )
+    await viewSelector
+      .selectOption({ label: 'Modified View 2' })
+      .catch(() => viewSelector.selectOption('view-12345678'))
     await expect(view1Widget).toHaveCSS('display', 'none')
 
-    const afterSwitchSize = await page.evaluate(() => window.asd.widgetStore.widgets.size)
+    const afterSwitchSize = await page.evaluate(
+      () => window.asd.widgetStore.widgets.size
+    )
     expect(afterSwitchSize).toBe(2)
 
-    await viewSelector.selectOption({ label: 'Modified View 1' }).catch(() =>
-      viewSelector.selectOption('view-1234567')
-    )
+    await viewSelector
+      .selectOption({ label: 'Modified View 1' })
+      .catch(() => viewSelector.selectOption('view-1234567'))
     await expect(view1Widget).not.toHaveCSS('display', 'none')
 
-    const finalSize = await page.evaluate(() => window.asd.widgetStore.widgets.size)
+    const finalSize = await page.evaluate(
+      () => window.asd.widgetStore.widgets.size
+    )
     expect(finalSize).toBe(2)
   })
 
   test('LRU Eviction Policy', async ({ page }) => {
     const widgetState = [
-      { order: '0', url: 'http://localhost:8000/asd/toolbox', columns: '1', rows: '1', type: 'web', dataid: 'W1', metadata: { title: 'w1' } },
-      { order: '1', url: 'http://localhost:8000/asd/toolbox', columns: '1', rows: '1', type: 'web', dataid: 'W2', metadata: { title: 'w2' } },
-      { order: '2', url: 'http://localhost:8000/asd/toolbox', columns: '1', rows: '1', type: 'web', dataid: 'W3', metadata: { title: 'w3' } }
+      {
+        order: '0',
+        url: 'http://localhost:8000/asd/toolbox',
+        columns: '1',
+        rows: '1',
+        type: 'web',
+        dataid: 'W1',
+        metadata: { title: 'w1' }
+      },
+      {
+        order: '1',
+        url: 'http://localhost:8000/asd/toolbox',
+        columns: '1',
+        rows: '1',
+        type: 'web',
+        dataid: 'W2',
+        metadata: { title: 'w2' }
+      },
+      {
+        order: '2',
+        url: 'http://localhost:8000/asd/toolbox',
+        columns: '1',
+        rows: '1',
+        type: 'web',
+        dataid: 'W3',
+        metadata: { title: 'w3' }
+      }
     ]
 
     await routeWithLRUConfig(page, widgetState, 2)
     await page.evaluate(() => localStorage.clear())
     await page.reload()
-    await expect(page.locator('.widget-wrapper')).toHaveCount(2)
+    await expect(page.locator('.widget-wrapper')).toHaveCount(1)
 
-    const size = await page.evaluate(() => window.asd.widgetStore.widgets.size)
-    expect(size).toBe(2)
+    await page.selectOption('#service-selector', { label: 'ASD-terminal' })
+    await page.click('#add-widget-button')
 
-    await expect(page.locator('[data-dataid="W1"]')).toHaveCount(0)
-    await expect(page.locator('[data-dataid="W2"]')).toBeVisible()
-    await expect(page.locator('[data-dataid="W3"]')).toBeVisible()
+    const modal = page.locator('#eviction-modal')
+    await expect(modal).toBeVisible()
+    await modal.locator('button:has-text("Remove")').click()
+    await expect(modal).toBeHidden()
+
+    const ids = await page.$$eval('.widget-wrapper', (els) =>
+      els.map((e) => e.getAttribute('data-dataid'))
+    )
+    expect(ids).toHaveLength(1)
+    expect(ids[0]).not.toBe('W1')
   })
 
-  test('Removes widget via UI and updates widgetStore state', async ({ page }) => {
+  test('Removes widget via UI and updates widgetStore state', async ({
+    page
+  }) => {
     const widget = page.locator('.widget-wrapper').first()
     const widgetId = await widget.getAttribute('data-dataid')
     expect(widgetId).not.toBeNull()
-    const exists = await page.evaluate(id => window.asd.widgetStore.has(id), widgetId)
+    const exists = await page.evaluate(
+      (id) => window.asd.widgetStore.has(id),
+      widgetId
+    )
     expect(exists).toBe(true)
 
     await widget.locator('.widget-icon-remove').click()
     await expect(page.locator(`[data-dataid="${widgetId}"]`)).toHaveCount(0)
 
-    const removed = await page.evaluate(id => window.asd.widgetStore.has(id), widgetId)
+    const removed = await page.evaluate(
+      (id) => window.asd.widgetStore.has(id),
+      widgetId
+    )
     expect(removed).toBe(false)
   })
 })

--- a/tests/widgetLimits.spec.ts
+++ b/tests/widgetLimits.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+import { ciConfig } from "./data/ciConfig";
+import { ciServices } from "./data/ciServices";
+
+async function routeLimits(page, boards, services, maxSize = 2) {
+  await page.route("**/services.json", (route) =>
+    route.fulfill({ json: services }),
+  );
+  await page.route("**/config.json", (route) =>
+    route.fulfill({ json: { ...ciConfig, boards } }),
+  );
+  await page.addInitScript((size) => {
+    const apply = () => {
+      if (window.asd?.widgetStore) {
+        window.asd.widgetStore.maxSize = size;
+      } else {
+        setTimeout(apply, 0);
+      }
+    };
+    apply();
+  }, maxSize);
+}
+
+test.describe("Widget limits", () => {
+  test("per service maxInstances navigates to existing widget", async ({
+    page,
+  }) => {
+    const boards = [
+      {
+        id: "b1",
+        name: "B1",
+        order: 0,
+        views: [
+          {
+            id: "v1",
+            name: "V1",
+            widgetState: [
+              {
+                order: "0",
+                url: "http://localhost:8000/asd/toolbox",
+                type: "web",
+                dataid: "W1",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "b2",
+        name: "B2",
+        order: 1,
+        views: [{ id: "v2", name: "V2", widgetState: [] }],
+      },
+    ];
+    const services = ciServices.map((s) =>
+      s.name === "ASD-toolbox" ? { ...s, maxInstances: 1 } : s,
+    );
+    await routeLimits(page, boards, services, 5);
+    await page.goto("/");
+    await page.locator(".widget-wrapper").first().waitFor();
+
+    await page.locator("#board-selector").selectOption("b2");
+    await page.selectOption("#service-selector", { label: "ASD-toolbox" });
+    await page.click("#add-widget-button");
+
+    await expect(page.locator(".widget-wrapper")).toHaveCount(1);
+  });
+
+  test("evicts selected widget when store is full", async ({ page }) => {
+    const widgetState = [
+      {
+        order: "0",
+        url: "http://localhost:8000/asd/toolbox",
+        type: "web",
+        dataid: "W1",
+        metadata: { title: "w1" },
+      },
+    ];
+    const boards = [
+      {
+        id: "b",
+        name: "B",
+        order: 0,
+        views: [{ id: "v", name: "V", widgetState }],
+      },
+    ];
+    await routeLimits(page, boards, ciServices, 1);
+    await page.goto("/");
+    await page.locator(".widget-wrapper").first().waitFor();
+
+    await page.selectOption("#service-selector", { label: "ASD-terminal" });
+    await page.click("#add-widget-button");
+
+    const modal = page.locator("#eviction-modal");
+    await expect(modal).toBeVisible();
+    await modal.locator('button:has-text("Remove")').click();
+    await expect(modal).toBeHidden();
+    await page.waitForSelector(".widget-wrapper");
+    const ids = await page.$$eval(".widget-wrapper", (els) =>
+      els.map((e) => e.getAttribute("data-dataid")),
+    );
+    expect(ids).toHaveLength(1);
+    expect(ids[0]).not.toBe("W1");
+  });
+});


### PR DESCRIPTION
## Summary
- add `maxInstances` to service type and example data
- create `evictionModal` for interactive widget removal
- enforce per-service and global limits when adding widgets
- update widgetStore to stop silent eviction
- adjust widgetStore tests and add widgetLimits spec

## Testing
- `npm run lint-fix`
- `npm run check`
- `npm run test` *(fails: Protocol error; tests interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_6866c8b849708325a460cf51cdd74d63