### PR TITLE
Refactor widget eviction flow for clarity

### DIFF
--- a/src/component/modal/evictionModal.js
+++ b/src/component/modal/evictionModal.js
@@ -5,13 +5,14 @@
  * @module evictionModal
  */
 import { openModal } from './modalFactory.js'
+import emojiList from '../../ui/unicodeEmoji.js'
 
 /**
  * Display a modal to choose a widget for removal.
  *
  * @param {Map<string, HTMLElement>} widgets - Current widget map.
  * @function openEvictionModal
- * @returns {Promise<string|null>} Resolves with selected widget id or null if cancelled.
+ * @returns {Promise<{id:string, title:string}|null>} Resolves with selected widget info or null.
  */
 export function openEvictionModal (widgets) {
   return new Promise((resolve) => {
@@ -26,12 +27,16 @@ export function openEvictionModal (widgets) {
         const select = document.createElement('select')
         select.id = 'eviction-select'
         for (const [id, el] of widgets.entries()) {
-          let label = id
+          let title = id
           if (el.dataset.metadata) {
             try {
-              label = JSON.parse(el.dataset.metadata).title || id
+              title = JSON.parse(el.dataset.metadata).title || id
             } catch {}
           }
+          const service = el.dataset.service || ''
+          const key = service.toLowerCase().split('asd-')[1] || service.toLowerCase()
+          const emoji = emojiList[key]?.unicode || '🧱'
+          const label = `${emoji} ${service} – ${title}`
           const opt = document.createElement('option')
           opt.value = id
           opt.textContent = label
@@ -43,7 +48,7 @@ export function openEvictionModal (widgets) {
         removeBtn.classList.add('modal__btn', 'modal__btn--save')
         removeBtn.addEventListener('click', () => {
           closeModal()
-          resolve(select.value)
+          resolve({ id: select.value, title: select.selectedOptions[0].textContent || '' })
         })
 
         const cancelBtn = document.createElement('button')

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -22,7 +22,6 @@ import { toggleFullScreen } from './events/fullscreenToggle.js'
 import { initializeResizeHandles } from './events/resizeHandler.js'
 import { Logger } from '../../utils/Logger.js'
 import { showServiceModal } from '../modal/serviceLaunchModal.js'
-import { openEvictionModal } from '../modal/evictionModal.js'
 import { switchBoard } from '../board/boardManagement.js'
 import { widgetGetUUID } from '../../utils/id.js'
 
@@ -211,9 +210,7 @@ async function addWidget (
       window.asd.widgetStore.widgets.values()
     ).filter((el) => el.dataset.service === serviceName).length
     if (activeCount >= serviceObj.maxInstances) {
-      const existing = Array.from(window.asd.widgetStore.widgets.values()).find(
-        (el) => el.dataset.service === serviceName
-      )
+      const existing = window.asd.widgetStore.findFirstWidgetByService(serviceName)
       if (existing) {
         const loc = findWidgetLocation(existing.dataset.dataid)
         if (loc) await switchBoard(loc.boardId, loc.viewId)
@@ -222,11 +219,8 @@ async function addWidget (
     }
   }
 
-  if (window.asd.widgetStore.widgets.size >= window.asd.widgetStore.maxSize) {
-    const idToRemove = await openEvictionModal(window.asd.widgetStore.widgets)
-    if (!idToRemove) return
-    window.asd.widgetStore.requestRemoval(idToRemove)
-  }
+  const proceed = await window.asd.widgetStore.confirmCapacity()
+  if (!proceed) return
 
   if (dataid && window.asd.widgetStore.has(dataid)) {
     window.asd.widgetStore.show(dataid)

--- a/src/types.js
+++ b/src/types.js
@@ -62,6 +62,7 @@
  * @property {boolean|string} [globalSettings.showMenuWidget]
  * @property {{showViewOptionsAsButtons:boolean|string, viewToShow:string}} [globalSettings.views]
  * @property {{enabled:string, loadDashboardFromConfig:string, defaultBoard?:string, defaultView?:string}} [globalSettings.localStorage]
+ * @property {number} [globalSettings.maxTotalInstances]
  * @property {Array<Board>} [boards]
  * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} [styling]
  */

--- a/symbols.json
+++ b/symbols.json
@@ -244,6 +244,14 @@
     "returns": "Promise<void>"
   },
   {
+    "name": "confirmCapacity",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Ensure capacity before adding a widget. Prompts for eviction when full.",
+    "params": [],
+    "returns": "Promise<boolean>"
+  },
+  {
     "name": "createBoard",
     "kind": "function",
     "file": "src/component/board/boardManagement.js",
@@ -539,6 +547,20 @@
     "description": "Fetch the service list and update the service selector on the page.",
     "params": [],
     "returns": "Promise<Array<Service>>"
+  },
+  {
+    "name": "findFirstWidgetByService",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Find the first widget instance for a given service name.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "HTMLElement|undefined"
   },
   {
     "name": "get",
@@ -1176,6 +1198,20 @@
     "description": "Open a modal dialog allowing the user to edit and save configuration JSON.",
     "params": [],
     "returns": "void"
+  },
+  {
+    "name": "openEvictionModal",
+    "kind": "function",
+    "file": "src/component/modal/evictionModal.js",
+    "description": "Display a modal to choose a widget for removal.",
+    "params": [
+      {
+        "name": "widgets",
+        "type": "Map<string, HTMLElement>",
+        "desc": "- Current widget map."
+      }
+    ],
+    "returns": "Promise<{id:string, title:string}|null>"
   },
   {
     "name": "openFragmentDecisionModal",


### PR DESCRIPTION
## Summary
- centralize capacity logic with `confirmCapacity`
- return rich info from eviction modal
- add helper `findFirstWidgetByService`
- refactor addWidget to use the new helpers
- test simultaneous widget requests

## Testing
- `just format`
- `just check`
- `just test` *(fails: npm warns about http-proxy and requires network)*

------
https://chatgpt.com/codex/tasks/task_b_6866d0afb96083258bc26b7a5f63b653