### PR TITLE
Fix widget resize debounce regression

### DIFF
--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -6,9 +6,7 @@
  */
 import { saveWidgetState } from '../../../storage/localStorage.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../../utils/elements.js'
-// import { debounce } from '../../../utils/utils.js'
-// The logger and debounce function makes resizeHandler.spec.ts flaky. Need to research why.
-// Does the test not wait for the correct size of the widget?
+import { debounce } from '../../../utils/utils.js'
 import { Logger } from '../../../utils/Logger.js'
 
 const logger = new Logger('resizeHandler.js')
@@ -86,6 +84,13 @@ async function handleResizeStart (event, widget) {
   // Create and append an overlay to capture all mouse events
   const overlay = createResizeOverlay()
 
+  const debouncedSave = debounce(() => {
+    const boardId = getCurrentBoardId()
+    const viewId = getCurrentViewId()
+    saveWidgetState(boardId, viewId)
+    logger.info('Resize stopped and widget state saved.')
+  }, 300)
+
   /**
    * Handles mouse movement during a resize operation, updating the widget's grid span.
    * @function handleResize
@@ -127,10 +132,7 @@ async function handleResizeStart (event, widget) {
       // Remove the overlay
       document.body.removeChild(overlay)
 
-      const boardId = getCurrentBoardId()
-      const viewId = getCurrentViewId()
-      saveWidgetState(boardId, viewId)
-      logger.info('Resize stopped and widget state saved.')
+      debouncedSave()
     } catch (error) {
       logger.error('Error stopping resize:', error)
     }

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -82,6 +82,7 @@ function saveWidgetState (boardId, viewId) {
     view.widgetState = updatedWidgetState
 
     saveBoardState(boards)
+    document.dispatchEvent(new CustomEvent('widget-state-saved'))
     logger.info(`Saved widget state for view: ${viewId} in board: ${boardId}`)
   } catch (error) {
     logger.error('Error saving widget state:', error)

--- a/symbols.json
+++ b/symbols.json
@@ -1051,6 +1051,20 @@
     "returns": "void"
   },
   {
+    "name": "isAdding",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Check if a service is currently being added.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "boolean"
+  },
+  {
     "name": "isJSON",
     "kind": "function",
     "file": "src/component/modal/localStorageModal.js",
@@ -1111,6 +1125,20 @@
     "description": "Loads the initial board configuration from the global config object into localStorage. This is typically called on first run to seed the dashboard.",
     "params": [],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "lock",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Acquire the lock for a service name.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
   },
   {
     "name": "log",
@@ -1377,7 +1405,7 @@
         "desc": "- The widget wrapper element to remove."
       }
     ],
-    "returns": "void"
+    "returns": "Promise<void>"
   },
   {
     "name": "renameBoard",
@@ -1434,7 +1462,7 @@
         "desc": ""
       }
     ],
-    "returns": "void"
+    "returns": "Promise<void>"
   },
   {
     "name": "resetView",
@@ -1728,6 +1756,20 @@
         "name": "widget",
         "type": "HTMLElement",
         "desc": "- The widget wrapper to modify."
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "unlock",
+    "kind": "function",
+    "file": "src/component/widget/widgetStore.js",
+    "description": "Release the lock for a service name.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": ""
       }
     ],
     "returns": "void"

--- a/tests/resizeHandler.spec.ts
+++ b/tests/resizeHandler.spec.ts
@@ -29,12 +29,16 @@ test.describe('Resize Handler Functionality', () => {
     await expect(widget).toHaveAttribute('data-columns', '1');
     await expect(widget).toHaveAttribute('data-rows', '1');
   
+    const waitForSaveMax = page.evaluate(() => new Promise<void>(resolve => {
+      document.addEventListener('widget-state-saved', () => resolve(), { once: true })
+    }))
     // Resize to maximum size allowed by config using page.mouse to drag
     if (browserName === 'firefox') {
       await resizeWidgetInFirefox(page, resizeHandle, 1200, 900);
     } else {
       await resizeWidgetWithMouse(page, resizeHandle, 1200, 900);
     }
+    await waitForSaveMax
 
     // Bug: It can resize beyond maxium with corner based resize; needs fixing
     // await expect(widget).toHaveAttribute('data-columns', `${maxColumns}`);
@@ -44,6 +48,9 @@ test.describe('Resize Handler Functionality', () => {
     await expect(widget).toHaveAttribute('data-columns', `${maxColumns}`);
     await expect(widget).toHaveAttribute('data-rows', `${maxRows}`);
   
+    const waitForSaveMin = page.evaluate(() => new Promise<void>(resolve => {
+      document.addEventListener('widget-state-saved', () => resolve(), { once: true })
+    }))
     // Resize to minimum size using page.mouse
     // Perform the resize action based on the browser (Firefox might need more explicit interaction)
     if (browserName === 'firefox') {
@@ -51,6 +58,7 @@ test.describe('Resize Handler Functionality', () => {
     } else {
       await resizeWidgetWithMouse(page, resizeHandle, -1200, -900);
     }
+    await waitForSaveMin
   
     // Reload and verify persistence of the minimum size
     await page.reload({ waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## Summary
- reintroduce debounce when saving widget state on resize
- emit a `widget-state-saved` event after saving state
- wait for that event in resize handler tests
- update symbol index

## Testing
- `just format check`
- `just test` *(fails: widgetLimits.spec.ts and UI widgetStore tests)*

------
https://chatgpt.com/codex/tasks/task_b_6866f43102788325aeb2942b96d57b64