### PR TITLE
Streamline widget service menu

### DIFF
--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -41,29 +41,6 @@ function initializeDashboardMenu () {
 
   const buttonDebounce = 200
 
-  document.getElementById('add-widget-button').addEventListener('click', () => {
-    const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
-    const widgetUrlInput = /** @type {HTMLInputElement} */(document.getElementById('widget-url'))
-    const boardElement = document.querySelector('.board')
-    const viewElement = document.querySelector('.board-view')
-    const selectedServiceUrl = serviceSelector.value
-    const manualUrl = widgetUrlInput.value
-    const url = selectedServiceUrl || manualUrl
-
-    const finalize = () => {
-      addWidget(url, 1, 1, 'iframe', boardElement.id, viewElement.id)
-      widgetUrlInput.value = ''
-    }
-
-    if (selectedServiceUrl) {
-      finalize()
-    } else if (manualUrl) {
-      openSaveServiceModal(manualUrl, finalize)
-    } else {
-      showNotification('Please select a service or enter a URL.')
-    }
-  })
-
   const handleToggleWidgetMenu = debounceLeading(() => {
     const widgetContainer = document.getElementById('widget-container')
     const toggled = widgetContainer.classList.toggle('hide-widget-menu') // true if now hidden
@@ -121,15 +98,24 @@ function populateServiceDropdown () {
   const selector = document.getElementById('service-selector')
   if (!selector) return
   selector.innerHTML = ''
-  const defaultOption = document.createElement('option')
-  defaultOption.value = ''
-  defaultOption.textContent = 'Select a Service'
-  selector.appendChild(defaultOption)
+  const newServiceBtn = document.createElement('button')
+  newServiceBtn.textContent = 'New Service'
+  newServiceBtn.addEventListener('click', () => {
+    openSaveServiceModal('', () => {
+      populateServiceDropdown()
+      const all = servicesStore.load()
+      const latest = all[all.length - 1]
+      if (latest) addWidget(latest.url)
+    })
+  })
+  selector.appendChild(newServiceBtn)
   servicesStore.load().forEach(service => {
-    const opt = document.createElement('option')
-    opt.value = service.url
-    opt.textContent = service.name
-    selector.appendChild(opt)
+    const btn = document.createElement('button')
+    btn.textContent = service.name
+    btn.addEventListener('click', () => {
+      addWidget(service.url)
+    })
+    selector.appendChild(btn)
   })
 }
 

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -197,25 +197,10 @@ function initializeMainMenu () {
   serviceControl.className = 'control-group'
   serviceControl.id = 'service-control'
 
-  const serviceSelector = document.createElement('select')
+  const serviceSelector = document.createElement('div')
   serviceSelector.id = 'service-selector'
-
-  const defaultOption = document.createElement('option')
-  defaultOption.value = ''
-  defaultOption.textContent = 'Select a Service'
-  serviceSelector.appendChild(defaultOption)
+  serviceSelector.className = 'service-dropdown'
   serviceControl.appendChild(serviceSelector)
-
-  const widgetUrlInput = document.createElement('input')
-  widgetUrlInput.type = 'text'
-  widgetUrlInput.id = 'widget-url'
-  widgetUrlInput.placeholder = 'Or enter URL manually'
-  serviceControl.appendChild(widgetUrlInput)
-
-  const addWidgetButton = document.createElement('button')
-  addWidgetButton.id = 'add-widget-button'
-  addWidgetButton.textContent = 'Add Widget'
-  serviceControl.appendChild(addWidgetButton)
 
   menu.appendChild(serviceControl)
 

--- a/src/component/modal/saveServiceModal.js
+++ b/src/component/modal/saveServiceModal.js
@@ -10,34 +10,42 @@ import { load, save } from '../../storage/servicesStore.js'
 /**
  * Open a modal allowing the user to name and store a service URL.
  *
- * @param {string} url - The service URL to save.
- * @param {Function} onClose - Callback when the modal closes.
+ * @param {string} [url=''] - Optional service URL to prefill.
+ * @param {Function} [onClose] - Callback when the modal closes.
  * @function openSaveServiceModal
  * @returns {void}
  */
-export function openSaveServiceModal (url, onClose) {
+export function openSaveServiceModal (url = '', onClose) {
   openModal({
     id: 'save-service-modal',
     onCloseCallback: onClose,
     buildContent: (modal, closeModal) => {
-      const message = document.createElement('p')
-      message.textContent = 'Do you want to save this URL as a reusable service?'
-      const input = document.createElement('input')
-      input.type = 'text'
-      input.placeholder = 'Service name'
-      input.required = true
-      input.id = 'save-service-name'
-      input.classList.add('modal__input')
-      modal.append(message, input)
+      const urlInput = document.createElement('input')
+      urlInput.type = 'text'
+      urlInput.placeholder = 'Service URL'
+      urlInput.required = true
+      urlInput.id = 'save-service-url'
+      urlInput.classList.add('modal__input')
+      urlInput.value = url
+
+      const nameInput = document.createElement('input')
+      nameInput.type = 'text'
+      nameInput.placeholder = 'Service name'
+      nameInput.required = true
+      nameInput.id = 'save-service-name'
+      nameInput.classList.add('modal__input')
+
+      modal.append(urlInput, nameInput)
 
       const saveButton = document.createElement('button')
       saveButton.classList.add('modal__btn')
       saveButton.textContent = 'Save & Close'
       saveButton.addEventListener('click', () => {
-        const name = input.value.trim()
-        if (!name) return
+        const name = nameInput.value.trim()
+        const serviceUrl = urlInput.value.trim()
+        if (!name || !serviceUrl) return
         const services = load()
-        services.push({ name, url })
+        services.push({ name, url: serviceUrl })
         save(services)
         document.dispatchEvent(new CustomEvent('services-updated'))
         closeModal()

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -128,3 +128,24 @@ menu {
     white-space: nowrap;
     z-index: 10;
 }
+
+/* Service dropdown */
+.service-dropdown {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
+.service-dropdown button {
+    padding: 0.3rem 0.6rem;
+    font-size: 0.8rem;
+    border: none;
+    background-color: #4CAF50;
+    color: white;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.service-dropdown button:hover {
+    background-color: #45a049;
+}

--- a/symbols.json
+++ b/symbols.json
@@ -1330,7 +1330,7 @@
       {
         "name": "url",
         "type": "string",
-        "desc": "- The service URL to save."
+        "desc": "- Optional service URL to prefill."
       },
       {
         "name": "onClose",

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -28,7 +28,7 @@ test.describe('Dashboard Config - Base64 via URL Params', () => {
     const config = b64(cfg);
     const services = b64(ciServices);
     await page.goto(`/?config_base64=${config}&services_base64=${services}`);
-    await expect(page.locator('#service-selector option')).toHaveCount(ciServices.length + 1);
+    await expect(page.locator('#service-selector button')).toHaveCount(ciServices.length + 1);
     const boards = await page.evaluate(() => window.asd.boards);
     expect(boards.length).toBe(ciBoards.length);
     const names = await page.$$eval('#board-selector option', opts => opts.map(o => o.textContent));
@@ -185,8 +185,7 @@ test.describe('Dashboard Functionality - Building from Services', () => {
   test('user can add board, view, and widget from services', async ({ page }) => {
     const cfg = { ...ciConfig, boards: [{ id: 'b1', name: 'b1', order: 0, views: [{ id: 'v1', name: 'v1', widgetState: [] }] }] };
     await page.goto(`/?config_base64=${b64(cfg)}&services_base64=${b64(ciServices)}`);
-    await page.selectOption('#service-selector', { index: 1 });
-    await page.click('#add-widget-button');
+    await page.click('#service-selector button:nth-of-type(2)');
     await expect(page.locator('.widget-wrapper')).toHaveCount(1);
     const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('boards')||'[]'));
     expect(stored.length).toBeGreaterThan(0);

--- a/tests/saveAndUseService.spec.ts
+++ b/tests/saveAndUseService.spec.ts
@@ -14,8 +14,7 @@ test.describe('Use saved service', () => {
   })
 
   test('selects saved service and adds widget', async ({ page }) => {
-    await page.selectOption('#service-selector', { label: saved[0].name })
-    await page.click('#add-widget-button')
+    await page.click(`#service-selector button:has-text("${saved[0].name}")`)
     const iframe = page.locator('.widget-wrapper iframe').first()
     await expect(iframe).toHaveAttribute('src', saved[0].url)
   })

--- a/tests/shared/common.ts
+++ b/tests/shared/common.ts
@@ -3,14 +3,12 @@ import { type Page, expect } from '@playwright/test';
 // Helper function to add services
 export async function addServices(page: Page, count: number) {
     for (let i = 0; i < count; i++) {
-      await page.selectOption('#service-selector', { index: i + 1 });
-      await page.click('#add-widget-button');
+      await page.click(`#service-selector button:nth-of-type(${i + 2})`);
     }
   }
   
 export async function selectServiceByName(page: Page, serviceName: string) {
-    await page.selectOption('#service-selector', { label: serviceName });
-    await page.click('#add-widget-button');
+    await page.click(`#service-selector button:has-text("${serviceName}")`);
 }
 
 // Helper function to handle dialog interactions

--- a/tests/widgetLimits.spec.ts
+++ b/tests/widgetLimits.spec.ts
@@ -60,8 +60,7 @@ test.describe("Widget limits", () => {
     await page.locator(".widget-wrapper").first().waitFor();
 
     await page.locator("#board-selector").selectOption("b2");
-    await page.selectOption("#service-selector", { label: "ASD-toolbox" });
-    await page.click("#add-widget-button");
+    await page.click('#service-selector button:has-text("ASD-toolbox")');
 
     await page.waitForFunction(() =>
       document.querySelectorAll('.widget-wrapper').length === 1
@@ -90,8 +89,7 @@ test.describe("Widget limits", () => {
     await page.goto("/");
     await page.locator(".widget-wrapper").first().waitFor();
 
-    await page.selectOption("#service-selector", { label: "ASD-terminal" });
-    await page.click("#add-widget-button");
+    await page.click('#service-selector button:has-text("ASD-terminal")');
 
     const modal = page.locator("#eviction-modal");
     await expect(modal).toBeVisible();


### PR DESCRIPTION
## Summary
- remove legacy widget URL entry and Add Widget button
- show services as a button list and add a "New Service" action
- create new services via updated modal with URL and name fields
- auto-add widget after saving a service
- update styles and Playwright specs for new flow

## Testing
- `npm run lint-fix`
- `npm run check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_68672b47cc248325ab26482363b59d84