### PR TITLE
Add widget selector panel

### DIFF
--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -197,10 +197,25 @@ function initializeMainMenu () {
   serviceControl.className = 'control-group'
   serviceControl.id = 'service-control'
 
-  const serviceSelector = document.createElement('div')
-  serviceSelector.id = 'service-selector'
-  serviceSelector.className = 'service-dropdown'
-  serviceControl.appendChild(serviceSelector)
+  const widgetPanel = document.createElement('div')
+  widgetPanel.id = 'widget-selector-panel'
+  widgetPanel.className = 'dropdown'
+
+  const widgetInput = document.createElement('input')
+  widgetInput.id = 'widget-search'
+  widgetInput.placeholder = 'Search or Select Widget'
+  widgetPanel.appendChild(widgetInput)
+
+  const counter = document.createElement('span')
+  counter.id = 'widget-count'
+  counter.style.marginLeft = 'auto'
+  widgetPanel.appendChild(counter)
+
+  const dropdown = document.createElement('div')
+  dropdown.className = 'dropdown-content'
+  widgetPanel.appendChild(dropdown)
+
+  serviceControl.appendChild(widgetPanel)
 
   menu.appendChild(serviceControl)
 

--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -1,0 +1,80 @@
+// @ts-check
+/**
+ * Widget selector panel logic.
+ *
+ * @module widgetSelectorPanel
+ */
+import { addWidget } from '../widget/widgetManagement.js'
+import * as servicesStore from '../../storage/servicesStore.js'
+import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
+
+/**
+ * Update the Active/Max counter in the panel.
+ * @function updateWidgetCounter
+ * @returns {void}
+ */
+export function updateWidgetCounter () {
+  const counter = document.getElementById('widget-count')
+  if (!counter) return
+  const boards = window.asd.boards || []
+  const total = boards.reduce((sum, b) =>
+    sum + b.views.reduce((s, v) => s + v.widgetState.length, 0), 0)
+  const max = window.asd.config?.globalSettings?.maxTotalInstances
+  counter.textContent = `Active: ${total} / Max: ${typeof max === 'number' ? max : '∞'}`
+}
+
+/**
+ * Populate dropdown list with saved services.
+ * @function populateWidgetSelectorPanel
+ * @returns {void}
+ */
+export function populateWidgetSelectorPanel () {
+  const container = document.querySelector('#widget-selector-panel .dropdown-content')
+  if (!container) return
+  container.innerHTML = ''
+  const newItem = document.createElement('div')
+  newItem.textContent = 'New Service'
+  newItem.className = 'widget-option new-service'
+  container.appendChild(newItem)
+  servicesStore.load().forEach(service => {
+    const item = document.createElement('div')
+    item.textContent = service.name
+    item.className = 'widget-option'
+    item.dataset.url = service.url
+    container.appendChild(item)
+  })
+  updateWidgetCounter()
+}
+
+/**
+ * Set up click handler for selecting services.
+ * @function initializeWidgetSelectorPanel
+ * @returns {void}
+ */
+export function initializeWidgetSelectorPanel () {
+  const panel = document.getElementById('widget-selector-panel')
+  if (!panel) return
+  panel.addEventListener('click', event => {
+    const target = /** @type {?HTMLElement} */(event.target)
+    if (!target) return
+    const item = target.closest('.widget-option')
+    if (!(item instanceof HTMLElement)) return
+    const url = item.dataset.url
+    if (item.classList.contains('new-service')) {
+      const entered = prompt('Enter service URL:')
+      if (!entered) return
+      import('../modal/saveServiceModal.js').then(m => {
+        m.openSaveServiceModal(entered, () => {
+          servicesStore.load()
+          populateWidgetSelectorPanel()
+          addWidget(entered, 1, 1, 'iframe', getCurrentBoardId(), getCurrentViewId())
+        })
+      })
+      return
+    }
+    if (url) {
+      addWidget(url, 1, 1, 'iframe', getCurrentBoardId(), getCurrentViewId())
+      updateWidgetCounter()
+    }
+  })
+}

--- a/src/types.js
+++ b/src/types.js
@@ -45,6 +45,9 @@
  * @property {string} name
  * @property {string} url
  * @property {string} [type]
+ * @property {string} [category]
+ * @property {string} [subcategory]
+ * @property {Array<string>} [tags]
  * @property {ServiceConfig} [config]
  * @property {number} [maxInstances] Maximum allowed widget instances
  */

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -83,20 +83,22 @@ export const fetchServices = async () => {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(services))
   window.asd.services = services
 
-  const serviceSelector = document.getElementById('service-selector')
-  if (serviceSelector) {
-    serviceSelector.innerHTML = ''
+  const container = document.querySelector('#widget-selector-panel .dropdown-content')
+  if (container) {
+    container.innerHTML = ''
     const newItem = document.createElement('div')
     newItem.textContent = 'New Service'
-    newItem.className = 'service-option new-service'
-    serviceSelector.appendChild(newItem)
+    newItem.className = 'widget-option new-service'
+    container.appendChild(newItem)
     services.forEach(service => {
       const item = document.createElement('div')
       item.textContent = service.name
-      item.className = 'service-option'
+      item.className = 'widget-option'
       item.dataset.url = service.url
-      serviceSelector.appendChild(item)
+      container.appendChild(item)
     })
+    const { updateWidgetCounter } = await import('../component/menu/widgetSelectorPanel.js')
+    updateWidgetCounter()
   }
 
   return services

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -28,7 +28,7 @@ test.describe('Dashboard Config - Base64 via URL Params', () => {
     const config = b64(cfg);
     const services = b64(ciServices);
     await page.goto(`/?config_base64=${config}&services_base64=${services}`);
-    await expect(page.locator('#service-selector .service-option')).toHaveCount(ciServices.length + 1);
+    await expect(page.locator('#widget-selector-panel .widget-option')).toHaveCount(ciServices.length + 1);
     const boards = await page.evaluate(() => window.asd.boards);
     expect(boards.length).toBe(ciBoards.length);
     const names = await page.$$eval('#board-selector option', opts => opts.map(o => o.textContent));
@@ -134,7 +134,7 @@ test.describe('Dashboard Config - Fallback Config Popup', () => {
     await page.waitForSelector('#config-json');
     await page.fill('#config-json', JSON.stringify(ciConfig));
     await page.click('#config-modal .modal__btn--save');
-    await page.waitForSelector('#service-selector');
+    await page.waitForSelector('#widget-selector-panel');
     const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('config') || '{}'));
     expect(stored.globalSettings.theme).toBe(ciConfig.globalSettings.theme);
   });
@@ -158,7 +158,7 @@ test.describe('Dashboard Config - LocalStorage Behavior', () => {
     const config = b64(ciConfig);
     await page.goto(`/?config_base64=${config}`);
     await page.reload();
-    await expect(page.locator('#service-selector')).toBeVisible();
+    await expect(page.locator('#widget-selector-panel')).toBeVisible();
   });
 
   test('changes via modal are saved and persist', async ({ page }) => {
@@ -185,7 +185,7 @@ test.describe('Dashboard Functionality - Building from Services', () => {
   test('user can add board, view, and widget from services', async ({ page }) => {
     const cfg = { ...ciConfig, boards: [{ id: 'b1', name: 'b1', order: 0, views: [{ id: 'v1', name: 'v1', widgetState: [] }] }] };
     await page.goto(`/?config_base64=${b64(cfg)}&services_base64=${b64(ciServices)}`);
-    await page.locator('#service-selector .service-option').nth(1).click();
+    await page.locator('#widget-selector-panel .widget-option').nth(1).click();
     await expect(page.locator('.widget-wrapper')).toHaveCount(1);
     const stored = await page.evaluate(() => JSON.parse(localStorage.getItem('boards')||'[]'));
     expect(stored.length).toBeGreaterThan(0);

--- a/tests/saveAndUseService.spec.ts
+++ b/tests/saveAndUseService.spec.ts
@@ -14,7 +14,7 @@ test.describe('Use saved service', () => {
   })
 
   test('selects saved service and adds widget', async ({ page }) => {
-    await page.click(`#service-selector .service-option:has-text("${saved[0].name}")`)
+    await page.click(`#widget-selector-panel .widget-option:has-text("${saved[0].name}")`)
     const iframe = page.locator('.widget-wrapper iframe').first()
     await expect(iframe).toHaveAttribute('src', saved[0].url)
   })

--- a/tests/saveServiceModal.spec.ts
+++ b/tests/saveServiceModal.spec.ts
@@ -12,7 +12,7 @@ test.describe('Save Service Modal', () => {
   test('opens when adding widget with manual URL', async ({ page }) => {
     const url = 'http://localhost/manual'
     page.on('dialog', d => d.accept(url))
-    await page.click('#service-selector .new-service')
+    await page.click('#widget-selector-panel .new-service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
     await expect(modal.locator('input#save-service-name')).toBeVisible()
@@ -21,7 +21,7 @@ test.describe('Save Service Modal', () => {
   test('saves manual service when confirmed', async ({ page }) => {
     const url = 'http://localhost/manual-save'
     page.on('dialog', d => d.accept(url))
-    await page.click('#service-selector .new-service')
+    await page.click('#widget-selector-panel .new-service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
     await page.fill('#save-service-name', 'Manual Service')
@@ -31,7 +31,7 @@ test.describe('Save Service Modal', () => {
     const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
     expect(services.some(s => s.url === url && s.name === 'Manual Service')).toBeTruthy()
 
-    const options = await page.$$eval('#service-selector .service-option', opts => opts.map(o => o.textContent))
+    const options = await page.$$eval('#widget-selector-panel .widget-option', opts => opts.map(o => o.textContent))
     expect(options).toContain('Manual Service')
 
     const iframe = page.locator('.widget-wrapper iframe').first()
@@ -41,7 +41,7 @@ test.describe('Save Service Modal', () => {
   test('skipping manual service does not store it', async ({ page }) => {
     const url = 'http://localhost/manual-skip'
     page.on('dialog', d => d.accept(url))
-    await page.click('#service-selector .new-service')
+    await page.click('#widget-selector-panel .new-service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
     await page.click('#save-service-modal button:has-text("Skip")')
@@ -50,7 +50,7 @@ test.describe('Save Service Modal', () => {
     const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
     expect(services.some(s => s.url === url)).toBeFalsy()
 
-    const options = await page.$$eval('#service-selector .service-option', opts => opts.map(o => o.textContent))
+    const options = await page.$$eval('#widget-selector-panel .widget-option', opts => opts.map(o => o.textContent))
     expect(options).not.toContain('Manual Service')
 
     const iframe = page.locator('.widget-wrapper iframe').first()

--- a/tests/shared/common.ts
+++ b/tests/shared/common.ts
@@ -3,12 +3,12 @@ import { type Page, expect } from '@playwright/test';
 // Helper function to add services
 export async function addServices(page: Page, count: number) {
     for (let i = 0; i < count; i++) {
-      await page.locator('#service-selector .service-option').nth(i + 1).click();
+      await page.locator('#widget-selector-panel .widget-option').nth(i + 1).click();
     }
   }
   
 export async function selectServiceByName(page: Page, serviceName: string) {
-    await page.click(`#service-selector .service-option:has-text("${serviceName}")`);
+    await page.click(`#widget-selector-panel .widget-option:has-text("${serviceName}")`);
 }
 
 // Helper function to handle dialog interactions

--- a/tests/widgetLimits.spec.ts
+++ b/tests/widgetLimits.spec.ts
@@ -60,7 +60,7 @@ test.describe("Widget limits", () => {
     await page.locator(".widget-wrapper").first().waitFor();
 
     await page.locator("#board-selector").selectOption("b2");
-    await page.click('#service-selector .service-option:has-text("ASD-toolbox")');
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox")');
 
     await page.waitForFunction(() =>
       document.querySelectorAll('.widget-wrapper').length === 1
@@ -89,7 +89,7 @@ test.describe("Widget limits", () => {
     await page.goto("/");
     await page.locator(".widget-wrapper").first().waitFor();
 
-    await page.click('#service-selector .service-option:has-text("ASD-terminal")');
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-terminal")');
 
     const modal = page.locator("#eviction-modal");
     await expect(modal).toBeVisible();
@@ -115,7 +115,7 @@ test.describe("Widget limits", () => {
     );
     await routeLimits(page, boards, services, 5);
     await page.goto('/');
-    await page.waitForSelector('#service-selector');
+    await page.waitForSelector('#widget-selector-panel');
 
     await page.evaluate(async () => {
       const { addWidget } = await import('/component/widget/widgetManagement.js');


### PR DESCRIPTION
## Summary
- implement new `widget-selector-panel` component
- update main menu to include selector panel instead of service dropdown
- refresh fetching logic for new element
- track active widget count
- update tests for `widget-selector-panel`
- extend `Service` type with optional metadata fields

## Testing
- `npm run lint-fix`
- `npm run check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_686ab8a57c248325a792f893068d4aa9