### PR TITLE
Add widget search filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,10 @@
       "localStorage",
       "location",
       "getComputedStyle",
-      "caches",
-      "HTMLElement",
-      "requestAnimationFrame"
-    ]
+        "caches",
+        "HTMLElement",
+        "requestAnimationFrame",
+        "HTMLInputElement"
+      ]
+    }
   }
-}

--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -41,6 +41,9 @@ export function populateWidgetSelectorPanel () {
     item.textContent = service.name
     item.className = 'widget-option'
     item.dataset.url = service.url
+    item.dataset.name = service.name
+    if (service.category) item.dataset.category = service.category
+    if (Array.isArray(service.tags)) item.dataset.tags = service.tags.join(',')
     container.appendChild(item)
   })
   updateWidgetCounter()
@@ -77,4 +80,20 @@ export function initializeWidgetSelectorPanel () {
       updateWidgetCounter()
     }
   })
+
+  const search = panel.querySelector('#widget-search')
+  if (search instanceof HTMLInputElement) {
+    search.addEventListener('input', event => {
+      const term = (/** @type {HTMLInputElement} */(event.target)).value.toLowerCase()
+      panel.querySelectorAll('.widget-option').forEach(el => {
+        const item = /** @type {HTMLElement} */(el)
+        if (item.classList.contains('new-service')) return
+        const name = item.dataset.name?.toLowerCase() || ''
+        const category = item.dataset.category?.toLowerCase() || ''
+        const tags = item.dataset.tags?.toLowerCase() || ''
+        const match = !term || name.includes(term) || category.includes(term) || tags.includes(term)
+        item.style.display = match ? '' : 'none'
+      })
+    })
+  }
 }

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -95,6 +95,9 @@ export const fetchServices = async () => {
       item.textContent = service.name
       item.className = 'widget-option'
       item.dataset.url = service.url
+      item.dataset.name = service.name
+      if (service.category) item.dataset.category = service.category
+      if (Array.isArray(service.tags)) item.dataset.tags = service.tags.join(',')
       container.appendChild(item)
     })
     const { updateWidgetCounter } = await import('../component/menu/widgetSelectorPanel.js')

--- a/symbols.json
+++ b/symbols.json
@@ -1062,6 +1062,14 @@
     "returns": "void"
   },
   {
+    "name": "initializeWidgetSelectorPanel",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Set up click handler for selecting services.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "initSW",
     "kind": "function",
     "file": "src/component/menu/menu.js",
@@ -1387,6 +1395,14 @@
     "kind": "function",
     "file": "src/component/menu/dashboardMenu.js",
     "description": "Populate the service drop-down with saved services.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "populateWidgetSelectorPanel",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Populate dropdown list with saved services.",
     "params": [],
     "returns": "void"
   },
@@ -1835,6 +1851,14 @@
         "desc": "- Identifier of the board whose views will be shown."
       }
     ],
+    "returns": "void"
+  },
+  {
+    "name": "updateWidgetCounter",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Update the Active/Max counter in the panel.",
+    "params": [],
     "returns": "void"
   },
   {

--- a/tests/widgetSearch.spec.ts
+++ b/tests/widgetSearch.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking.js'
+
+
+test.describe('Widget search filter', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+    await page.waitForSelector('#widget-selector-panel')
+  })
+
+  test('typing filters widget options', async ({ page }) => {
+    const options = page.locator('#widget-selector-panel .widget-option')
+    await expect(options).toHaveCount(5)
+
+    await page.fill('#widget-search', 'terminal')
+
+    const visible = page.locator('#widget-selector-panel .widget-option:not(.new-service):visible')
+    await expect(visible).toHaveCount(1)
+    await expect(visible.first()).toHaveText('ASD-terminal')
+    await expect(page.locator('#widget-selector-panel .widget-option.new-service')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- enable dataset info on services and add search filter handler
- preserve service metadata when services are loaded
- test filtering widget options by search term
- allow HTMLInputElement global in linter

## Testing
- `npm run lint`
- `npm run check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_686ada241b088325be4733168ee09b32