### PR TITLE
Implement service edit/delete

### DIFF
--- a/src/component/modal/editServiceModal.js
+++ b/src/component/modal/editServiceModal.js
@@ -1,0 +1,60 @@
+// @ts-check
+/**
+ * Modal dialog for editing a saved service.
+ *
+ * @module editServiceModal
+ */
+import { openModal } from './modalFactory.js'
+import * as servicesStore from '../../storage/servicesStore.js'
+
+/**
+ * Open a modal allowing the user to edit a service definition.
+ *
+ * @param {import('../../types.js').Service} service - Service to edit.
+ * @param {Function} [onClose] - Callback when modal closes.
+ * @function openEditServiceModal
+ * @returns {void}
+ */
+export function openEditServiceModal (service, onClose) {
+  openModal({
+    id: 'edit-service-modal',
+    onCloseCallback: onClose,
+    buildContent: (modal, closeModal) => {
+      const nameInput = document.createElement('input')
+      nameInput.id = 'edit-service-name'
+      nameInput.classList.add('modal__input')
+      nameInput.value = service.name
+
+      const urlInput = document.createElement('input')
+      urlInput.id = 'edit-service-url'
+      urlInput.classList.add('modal__input')
+      urlInput.value = service.url
+
+      modal.append(nameInput, urlInput)
+
+      const saveBtn = document.createElement('button')
+      saveBtn.textContent = 'Save'
+      saveBtn.classList.add('modal__btn', 'modal__btn--save')
+      saveBtn.addEventListener('click', () => {
+        const services = servicesStore.load()
+        const idx = services.findIndex(s => s.name === service.name && s.url === service.url)
+        if (idx !== -1) {
+          services[idx] = { ...service, name: nameInput.value.trim(), url: urlInput.value.trim() }
+          servicesStore.save(services)
+          document.dispatchEvent(new CustomEvent('services-updated'))
+        }
+        closeModal()
+      })
+
+      const cancelBtn = document.createElement('button')
+      cancelBtn.textContent = 'Cancel'
+      cancelBtn.classList.add('modal__btn', 'modal__btn--cancel')
+      cancelBtn.addEventListener('click', closeModal)
+
+      const btnGroup = document.createElement('div')
+      btnGroup.classList.add('modal__btn-group')
+      btnGroup.append(saveBtn, cancelBtn)
+      modal.appendChild(btnGroup)
+    }
+  })
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -114,3 +114,19 @@ main {
 .dropdown:hover .dropdown-content {
     display: block;
 }
+
+/* Service option layout */
+.widget-option {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 4px;
+}
+
+.widget-option-actions button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+}

--- a/tests/serviceEditDelete.spec.ts
+++ b/tests/serviceEditDelete.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+
+
+test.describe('Service Edit/Delete', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+  })
+
+  test('edit service updates list', async ({ page }) => {
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox") button[data-action="edit"]')
+    const modal = page.locator('#edit-service-modal')
+    await expect(modal).toBeVisible()
+    await page.fill('#edit-service-name', 'Toolbox X')
+    await page.fill('#edit-service-url', 'http://localhost/x')
+    await page.click('#edit-service-modal button:has-text("Save")')
+    await expect(modal).toBeHidden()
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services')))
+    expect(services.some(s => s.name === 'Toolbox X' && s.url === 'http://localhost/x')).toBeTruthy()
+    await expect(page.locator('#widget-selector-panel .widget-option')).toContainText('Toolbox X')
+  })
+
+  test('delete service removes widgets', async ({ page }) => {
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-terminal")')
+    await expect(page.locator('.widget-wrapper')).toHaveCount(1)
+
+    page.on('dialog', d => d.accept())
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-terminal") button[data-action="remove"]')
+    await page.waitForSelector('.widget-wrapper', { state: 'detached' })
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services')))
+    expect(services.find(s => s.name === 'ASD-terminal')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add service edit modal
- enhance widget selector items with action icons
- update style for new action buttons
- handle edit, remove and navigate actions
- test edit & delete flows

## Testing
- `just format check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_b_686addb6a4f88325afc856aaf71cd63c