### PR TITLE
Add dropdown open/close logic

### DIFF
--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -206,6 +206,12 @@ function initializeMainMenu () {
   widgetInput.placeholder = 'Search or Select Widget'
   widgetPanel.appendChild(widgetInput)
 
+  const widgetToggle = document.createElement('span')
+  widgetToggle.id = 'widget-dropdown-toggle'
+  widgetToggle.className = 'dropdown-arrow'
+  widgetToggle.textContent = '\u25BC'
+  widgetPanel.appendChild(widgetToggle)
+
   const counter = document.createElement('span')
   counter.id = 'widget-count'
   counter.style.marginLeft = 'auto'

--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -76,6 +76,23 @@ export function populateWidgetSelectorPanel () {
 export function initializeWidgetSelectorPanel () {
   const panel = document.getElementById('widget-selector-panel')
   if (!panel) return
+
+  const toggle = panel.querySelector('#widget-dropdown-toggle')
+  const search = panel.querySelector('#widget-search')
+  let focusIndex = -1
+
+  const closePanel = () => {
+    panel.classList.remove('open')
+    focusIndex = -1
+    panel.querySelectorAll('.widget-option').forEach(el => {
+      el.classList.remove('active')
+    })
+  }
+
+  const openPanel = () => {
+    panel.classList.add('open')
+  }
+
   panel.addEventListener('click', event => {
     const target = /** @type {?HTMLElement} */(event.target)
     if (!target) return
@@ -139,10 +156,11 @@ export function initializeWidgetSelectorPanel () {
       addWidget(url, 1, 1, 'iframe', getCurrentBoardId(), getCurrentViewId())
       updateWidgetCounter()
     }
+    closePanel()
   })
 
-  const search = panel.querySelector('#widget-search')
   if (search instanceof HTMLInputElement) {
+    search.addEventListener('focus', openPanel)
     search.addEventListener('input', event => {
       const term = (/** @type {HTMLInputElement} */(event.target)).value.toLowerCase()
       panel.querySelectorAll('.widget-option').forEach(el => {
@@ -154,6 +172,40 @@ export function initializeWidgetSelectorPanel () {
         const match = !term || name.includes(term) || category.includes(term) || tags.includes(term)
         item.style.display = match ? '' : 'none'
       })
+      focusIndex = -1
+    })
+    search.addEventListener('keydown', e => {
+      if (!panel.classList.contains('open')) return
+      const options = Array.from(panel.querySelectorAll('.widget-option')).filter(el => el instanceof HTMLElement && el.style.display !== 'none')
+      if (options.length === 0) return
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        focusIndex = Math.min(options.length - 1, focusIndex + 1)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        focusIndex = Math.max(0, focusIndex - 1)
+      } else if (e.key === 'Enter' && focusIndex >= 0) {
+        e.preventDefault()
+        const el = /** @type {HTMLElement} */(options[focusIndex])
+        el.click()
+        return
+      } else {
+        return
+      }
+      options.forEach((el, idx) => {
+        el.classList.toggle('active', idx === focusIndex)
+      })
     })
   }
+
+  if (toggle instanceof HTMLElement) {
+    toggle.addEventListener('click', () => {
+      panel.classList.toggle('open')
+    })
+  }
+
+  document.addEventListener('click', event => {
+    const target = /** @type {Node} */(event.target)
+    if (!panel.contains(target)) closePanel()
+  })
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -111,8 +111,24 @@ main {
     background-color: #f1f1f1;
 }
 
-.dropdown:hover .dropdown-content {
+.dropdown:hover .dropdown-content,
+.dropdown.open .dropdown-content {
     display: block;
+}
+
+.dropdown-arrow {
+    cursor: pointer;
+    user-select: none;
+    margin-left: 4px;
+    transition: transform 0.2s ease;
+}
+
+.dropdown.open .dropdown-arrow {
+    transform: rotate(180deg);
+}
+
+.widget-option.active {
+    background-color: #e0e0e0;
 }
 
 /* Service option layout */

--- a/symbols.json
+++ b/symbols.json
@@ -1255,6 +1255,25 @@
     "returns": "void"
   },
   {
+    "name": "openEditServiceModal",
+    "kind": "function",
+    "file": "src/component/modal/editServiceModal.js",
+    "description": "Open a modal allowing the user to edit a service definition.",
+    "params": [
+      {
+        "name": "service",
+        "type": "import('../../types.js').Service",
+        "desc": "- Service to edit."
+      },
+      {
+        "name": "onClose",
+        "type": "Function",
+        "desc": "- Callback when modal closes."
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "openEvictionModal",
     "kind": "function",
     "file": "src/component/modal/evictionModal.js",


### PR DESCRIPTION
## Summary
- toggle dropdown panel via arrow or focus
- allow arrow key navigation through widget options
- close panel on outside click
- style dropdown arrow and active option indicator

## Testing
- `just format check`
- `just test` *(fails: network restrictions prevent browser downloads)*

------
https://chatgpt.com/codex/tasks/task_b_686ae03f193883259f55fdb4c47587ad