### PR TITLE
Add StorageManager integration

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -9,6 +9,7 @@ import { addWidget } from '../widget/widgetManagement.js'
 import { widgetStore } from '../widget/widgetStore.js'
 import { Logger } from '../../utils/Logger.js'
 import { boardGetUUID, viewGetUUID } from '../../utils/id.js'
+import StorageManager from '../../storage/StorageManager.js'
 
 /** @typedef {import('../../types.js').Board} Board */
 /** @typedef {import('../../types.js').View} View */
@@ -50,10 +51,10 @@ export async function createBoard (boardName, boardId = null, viewId = null) {
   await switchBoard(newBoardId, defaultViewId)
   logger.log(`Switched to new board ${newBoardId}`)
 
-  // Save the current board and view in localStorage
-  localStorage.setItem('lastUsedBoardId', newBoardId)
-  localStorage.setItem('lastUsedViewId', defaultViewId)
-  logger.log(`Saved last used boardId: ${newBoardId} and viewId: ${defaultViewId} to localStorage`)
+  // Save the current board and view
+  StorageManager.misc.setLastBoardId(newBoardId)
+  StorageManager.misc.setLastViewId(defaultViewId)
+  logger.log(`Saved last used boardId: ${newBoardId} and viewId: ${defaultViewId}`)
 
   // Update the board selector
   updateBoardSelector()
@@ -91,9 +92,9 @@ export async function createView (boardId, viewName, viewId = null) {
     await switchView(boardId, newViewId)
     logger.log(`Switched to new view ${newViewId} in board ${boardId}`)
 
-    // Save the current view in localStorage
-    localStorage.setItem('lastUsedViewId', newViewId)
-    logger.log(`Saved last used viewId: ${newViewId} to localStorage`)
+    // Save the current view id
+    StorageManager.misc.setLastViewId(newViewId)
+    logger.log(`Saved last used viewId: ${newViewId}`)
 
     return newView
   } else {
@@ -155,7 +156,7 @@ export async function switchView (boardId, viewId) {
   }
 
   window.asd.currentViewId = viewId
-  localStorage.setItem('lastUsedViewId', viewId)
+  StorageManager.misc.setLastViewId(viewId)
   updateViewSelector(boardId)
 }
 
@@ -203,12 +204,12 @@ export function updateViewSelector (boardId) {
     })
 
     // Select the newly created or switched view
-    const lastUsedViewId = localStorage.getItem('lastUsedViewId')
+    const lastUsedViewId = StorageManager.misc.getLastViewId()
     if (lastUsedViewId) {
       viewSelector.value = lastUsedViewId
       logger.log(`Set view selector value to last used viewId: ${lastUsedViewId}`)
     } else {
-      logger.log('No last used viewId found in localStorage')
+      logger.log('No last used viewId found in storage')
     }
   } else {
     logger.error(`Board with ID ${boardId} not found`)
@@ -240,11 +241,11 @@ export async function switchBoard (boardId, viewId = null) {
       clearWidgetContainer()
       document.querySelector('.board-view').id = ''
       window.asd.currentViewId = null
-      localStorage.removeItem('lastUsedViewId')
+      StorageManager.misc.setLastViewId(null)
     }
 
     window.asd.currentBoardId = boardId
-    localStorage.setItem('lastUsedBoardId', boardId)
+    StorageManager.misc.setLastBoardId(boardId)
     updateViewSelector(boardId)
   } else {
     logger.error(`Board with ID ${boardId} not found`)
@@ -310,7 +311,7 @@ export function addBoardToUI (board) {
   boardSelector.appendChild(option)
 
   // Select the newly created or switched board
-  const lastUsedBoardId = localStorage.getItem('lastUsedBoardId')
+  const lastUsedBoardId = StorageManager.misc.getLastBoardId()
   if (lastUsedBoardId) {
     boardSelector.value = lastUsedBoardId
   }
@@ -430,7 +431,7 @@ export async function deleteView (boardId, viewId) {
         if (viewSelector) viewSelector.innerHTML = ''
         document.querySelector('.board-view').id = ''
         window.asd.currentViewId = null
-        localStorage.removeItem('lastUsedViewId')
+        StorageManager.misc.setLastViewId(null)
       }
     } else {
       logger.error(`View with ID ${viewId} not found`)
@@ -486,7 +487,7 @@ function updateBoardSelector () {
   })
 
   // Select the newly created or switched board
-  const lastUsedBoardId = localStorage.getItem('lastUsedBoardId')
+  const lastUsedBoardId = StorageManager.misc.getLastBoardId()
   if (lastUsedBoardId) {
     boardSelector.value = lastUsedBoardId
   }

--- a/src/component/configModal/exportConfig.js
+++ b/src/component/configModal/exportConfig.js
@@ -1,0 +1,57 @@
+// @ts-check
+/**
+ * Export dashboard configuration and services to a sharable URL.
+ *
+ * @module configModal/exportConfig
+ */
+import { showNotification } from '../dialog/notification.js'
+import { gzipJsonToBase64url } from '../../utils/compression.js'
+import { Logger } from '../../utils/Logger.js'
+import StorageManager from '../../storage/StorageManager.js'
+
+const logger = new Logger('exportConfig.js')
+
+/**
+ * Generate shareable URL from stored config and services,
+ * copy it to the clipboard and persist a snapshot.
+ *
+ * @function exportConfig
+ * @returns {Promise<void>}
+ */
+export async function exportConfig () {
+  try {
+    const cfg = StorageManager.getConfig()
+    const svc = StorageManager.getServices()
+
+    if (!cfg || !svc) {
+      logger.warn('Export aborted: missing config or services')
+      showNotification('❌ Cannot export: config or services are missing', 4000, 'error')
+      return
+    }
+
+    const [cfgEnc, svcEnc] = await Promise.all([
+      gzipJsonToBase64url(cfg),
+      gzipJsonToBase64url(svc)
+    ])
+
+    const defaultName = `Snapshot ${new Date().toISOString()}`
+    const name = prompt('Name this export', defaultName) || defaultName
+
+    const url = `${location.origin}${location.pathname}#cfg=${cfgEnc}&svc=${svcEnc}&name=${encodeURIComponent(name)}`
+    await navigator.clipboard.writeText(url)
+
+    const kb = (url.length / 1024).toFixed(1)
+    showNotification(`✅ URL copied to clipboard! (${kb} KB)`, 4000, 'success')
+    logger.info(`Exported config URL (${url.length} chars) named ${name}`)
+
+    if (url.length > 60000) {
+      showNotification('⚠️ URL is very large and may not work in all browsers', 6000, 'error')
+      logger.warn(`Exported URL length: ${url.length}`)
+    }
+
+    await StorageManager.saveStateSnapshot({ name, type: 'exported', cfg: cfgEnc, svc: svcEnc })
+  } catch (e) {
+    showNotification('❌ Failed to export config', 4000, 'error')
+    logger.error('Export failed', e)
+  }
+}

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -18,6 +18,7 @@ import { showNotification } from '../dialog/notification.js'
 import emojiList from '../../ui/unicodeEmoji.js'
 import { Logger } from '../../utils/Logger.js'
 import { clearConfigFragment } from '../../utils/fragmentGuard.js'
+import StorageManager from '../../storage/StorageManager.js'
 import { debounceLeading } from '../../utils/utils.js'
 
 const logger = new Logger('dashboardMenu.js')
@@ -74,7 +75,7 @@ function initializeDashboardMenu () {
 
     if (window.asd && window.asd.config && window.asd.config.globalSettings) {
       window.asd.config.globalSettings.showMenuWidget = !toggled
-      localStorage.setItem('config', JSON.stringify(window.asd.config))
+      StorageManager.setConfig(window.asd.config)
     }
 
     showNotification(message, 500)
@@ -86,7 +87,7 @@ function initializeDashboardMenu () {
     const confirmed = confirm('Confirm environment reset: all configurations and services will be permanently deleted.')
 
     if (confirmed) {
-      localStorage.clear()
+      StorageManager.clearAll()
       clearConfigFragment()
       location.reload()
     }

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import { loadFromFragment } from './utils/fragmentLoader.js'
 import { Logger } from './utils/Logger.js'
 import { widgetStore } from './component/widget/widgetStore.js'
 import { debounceLeading } from './utils/utils.js'
+import StorageManager from './storage/StorageManager.js'
 
 const logger = new Logger('main.js')
 
@@ -31,6 +32,8 @@ window.asd = {
   currentViewId: null,
   widgetStore
 }
+
+window.addEventListener('hashchange', () => loadFromFragment(false))
 
 /**
  * Main application initialization function.
@@ -77,8 +80,8 @@ async function main () {
   // 6. Initialize boards and switch to the last used or default board/view
   const initialBoardView = await initializeBoards() // initializeBoards is now fully async
 
-  const lastUsedBoardId = localStorage.getItem('lastUsedBoardId')
-  const lastUsedViewId = localStorage.getItem('lastUsedViewId')
+  const lastUsedBoardId = StorageManager.misc.getLastBoardId()
+  const lastUsedViewId = StorageManager.misc.getLastViewId()
 
   const boardExists = boards.some(board => board.id === lastUsedBoardId)
 

--- a/src/ui/configTabs.css
+++ b/src/ui/configTabs.css
@@ -1,0 +1,20 @@
+.tabs {
+  display: flex;
+  gap: 5px;
+  margin-bottom: 10px;
+}
+.tabs button {
+  flex: 1 1 auto;
+  padding: 6px 8px;
+  border: 1px solid #ccc;
+  background: #eee;
+  cursor: pointer;
+}
+.tabs button.active {
+  background: #ddd;
+  font-weight: bold;
+}
+#stateTab {
+  max-height: 50vh;
+  overflow: auto;
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -3,6 +3,7 @@
 @import url('/ui/modal.css');
 @import url('/ui/notification.css');
 @import url('/ui/service-action.css');
+@import url('/ui/configTabs.css');
 
 /* Universal box-sizing */
 *, *::before, *::after {

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -6,11 +6,11 @@
  */
 import { Logger } from './Logger.js'
 import { showNotification } from '../component/dialog/notification.js'
+import StorageManager from '../storage/StorageManager.js'
 
 /** @typedef {import('../types.js').Service} Service */
 
 const logger = new Logger('fetchServices.js')
-const STORAGE_KEY = 'services'
 
 /**
  * Parses a base64 encoded JSON string.
@@ -65,13 +65,9 @@ export const fetchServices = async () => {
   }
 
   if (!services) {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored) {
-      try {
-        services = JSON.parse(stored)
-      } catch (e) {
-        logger.error('Failed to parse services from localStorage:', e)
-      }
+    const stored = StorageManager.getServices()
+    if (stored.length > 0) {
+      services = stored
     }
   }
 
@@ -80,7 +76,7 @@ export const fetchServices = async () => {
   }
 
   services = services || []
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(services))
+  StorageManager.setServices(services)
   window.asd.services = services
 
   const serviceSelector = document.getElementById('service-selector')

--- a/src/utils/fragmentLoader.js
+++ b/src/utils/fragmentLoader.js
@@ -11,6 +11,7 @@ import { Logger } from './Logger.js'
 import { showNotification } from '../component/dialog/notification.js'
 import { gunzipBase64urlToJson } from './compression.js'
 import { openFragmentDecisionModal } from '../component/modal/fragmentDecisionModal.js'
+import StorageManager from '../storage/StorageManager.js'
 
 const logger = new Logger('fragmentLoader.js')
 
@@ -40,30 +41,28 @@ export async function loadFromFragment (wasExplicitLoad = false) {
   const params = new URLSearchParams(hash)
   const cfgParam = params.get('cfg')
   const svcParam = params.get('svc')
+  const nameParam = params.get('name') || 'Imported'
 
   const hasLocalData =
-    localStorage.getItem('config') ||
-    localStorage.getItem('services') ||
-    localStorage.getItem('boards')
+    StorageManager.getConfig() ||
+    StorageManager.getServices().length > 0 ||
+    StorageManager.getBoards().length > 0
 
   if ((cfgParam || svcParam) && hasLocalData && !wasExplicitLoad) {
-    await openFragmentDecisionModal(cfgParam, svcParam)
+    await openFragmentDecisionModal({ cfgParam, svcParam, nameParam })
     return
   }
 
   try {
     if (cfgParam) {
       const cfg = await gunzipBase64urlToJson(cfgParam)
-      localStorage.setItem('config', JSON.stringify(cfg))
-      if (Array.isArray(cfg.boards)) {
-        localStorage.setItem('boards', JSON.stringify(cfg.boards))
-      }
+      StorageManager.setConfig(cfg)
       logger.info('✅ Config geladen uit fragment')
     }
 
     if (svcParam) {
       const svc = await gunzipBase64urlToJson(svcParam)
-      localStorage.setItem('services', JSON.stringify(svc))
+      StorageManager.setServices(svc)
       logger.info('✅ Services geladen uit fragment')
     }
   } catch (e) {

--- a/symbols.json
+++ b/symbols.json
@@ -206,6 +206,14 @@
     "returns": "boolean"
   },
   {
+    "name": "clearAll",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Remove all persisted data.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "clearConfigFragment",
     "kind": "function",
     "file": "src/utils/fragmentGuard.js",
@@ -491,6 +499,14 @@
     "returns": ""
   },
   {
+    "name": "exportConfig",
+    "kind": "function",
+    "file": "src/component/configModal/exportConfig.js",
+    "description": "Generate shareable URL from stored config and services, copy it to the clipboard and persist a snapshot.",
+    "params": [],
+    "returns": "Promise<void>"
+  },
+  {
     "name": "fetchData",
     "kind": "function",
     "file": "src/component/widget/utils/fetchData.js",
@@ -604,12 +620,28 @@
     "returns": "string"
   },
   {
+    "name": "getBoards",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Retrieve stored boards array.",
+    "params": [],
+    "returns": "Array<Board>"
+  },
+  {
     "name": "getCallingFunctionName",
     "kind": "function",
     "file": "src/utils/Logger.js",
     "description": "Extracts the function name of the caller (if available) from the stack trace.",
     "params": [],
     "returns": "string"
+  },
+  {
+    "name": "getConfig",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Get the persisted dashboard configuration.",
+    "params": [],
+    "returns": "DashboardConfig"
   },
   {
     "name": "getConfig",
@@ -644,6 +676,22 @@
     "returns": "string"
   },
   {
+    "name": "getLastBoardId",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Retrieve the last used board id.",
+    "params": [],
+    "returns": "string|null"
+  },
+  {
+    "name": "getLastViewId",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Retrieve the last used view id.",
+    "params": [],
+    "returns": "string|null"
+  },
+  {
     "name": "getLocalStorageData",
     "kind": "function",
     "file": "src/component/modal/localStorageModal.js",
@@ -672,6 +720,14 @@
       }
     ],
     "returns": "Promise<string>"
+  },
+  {
+    "name": "getServices",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Retrieve stored services array.",
+    "params": [],
+    "returns": "Array<Service>"
   },
   {
     "name": "getUUID",
@@ -1098,6 +1154,44 @@
     "returns": "boolean"
   },
   {
+    "name": "jsonGet",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Read and parse JSON value from localStorage.",
+    "params": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "fallback",
+        "type": "any|null",
+        "desc": ""
+      }
+    ],
+    "returns": "any"
+  },
+  {
+    "name": "jsonSet",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Stringify and store value in localStorage.",
+    "params": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "obj",
+        "type": "any",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "listLoggedFiles",
     "kind": "function",
     "file": "src/utils/Logger.js",
@@ -1144,6 +1238,14 @@
     "description": "Loads the initial board configuration from the global config object into localStorage. This is typically called on first run to seed the dashboard.",
     "params": [],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "loadStateStore",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Load and return the entire state store.",
+    "params": [],
+    "returns": "Promise<{version:number,states:Array}>"
   },
   {
     "name": "lock",
@@ -1267,14 +1369,9 @@
     "description": "Display modal asking user to overwrite or merge fragment data.",
     "params": [
       {
-        "name": "cfgParam",
-        "type": "string|null",
-        "desc": "- Encoded config fragment."
-      },
-      {
-        "name": "svcParam",
-        "type": "string|null",
-        "desc": "- Encoded service fragment."
+        "name": "params",
+        "type": "{cfgParam:string|null,svcParam:string|null,nameParam:string}",
+        "desc": "cfgParam - Encoded config fragment. svcParam - Encoded service fragment. nameParam - Default snapshot name."
       }
     ],
     "returns": "Promise<void>"
@@ -1583,6 +1680,34 @@
     "returns": "void"
   },
   {
+    "name": "saveStateSnapshot",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Save the current state snapshot.",
+    "params": [
+      {
+        "name": "snapshot",
+        "type": "{name:string,type:string,cfg:string,svc:string}",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<string>"
+  },
+  {
+    "name": "saveStateStore",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist the entire state store object.",
+    "params": [
+      {
+        "name": "store",
+        "type": "{version:number,states:Array}",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<void>"
+  },
+  {
     "name": "saveWidgetState",
     "kind": "function",
     "file": "src/storage/localStorage.js",
@@ -1614,6 +1739,76 @@
       }
     ],
     "returns": "import('../types.js').Widget"
+  },
+  {
+    "name": "setBoards",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist the provided boards array.",
+    "params": [
+      {
+        "name": "boards",
+        "type": "Array<Board>",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "setConfig",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist the dashboard configuration.",
+    "params": [
+      {
+        "name": "cfg",
+        "type": "DashboardConfig",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "setLastBoardId",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist the last used board id.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string|null",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "setLastViewId",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist the last used view id.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string|null",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "setServices",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist the provided services array.",
+    "params": [
+      {
+        "name": "services",
+        "type": "Array<Service>",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
   },
   {
     "name": "show",

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from './fixtures'
+import { ciConfig } from './data/ciConfig'
+import { ciServices } from './data/ciServices'
+import { gzipJsonToBase64url } from '../src/utils/compression.js'
+
+async function encode (obj: any) {
+  return gzipJsonToBase64url(obj)
+}
+
+test('import modal pre-fills name and saves snapshot', async ({ page }) => {
+  const cfg = await encode(ciConfig)
+  const svc = await encode(ciServices)
+  const name = 'MySnapshot'
+  await page.goto(`/#cfg=${cfg}&svc=${svc}&name=${encodeURIComponent(name)}`)
+  await page.waitForSelector('#fragment-decision-modal', { timeout: 5000 })
+  await expect(page.locator('#importName')).toHaveValue(name)
+  await page.locator('#fragment-decision-modal button:has-text("Overwrite")').click()
+  await page.waitForLoadState('domcontentloaded')
+  const store = await page.evaluate(async () => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    return await sm.loadStateStore()
+  })
+  expect(store.states[0].name).toBe(name)
+  expect(store.states[0].type).toBe('imported')
+})

--- a/tests/persistence.spec.ts
+++ b/tests/persistence.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+import { handleDialog, getBoardsFromLocalStorage } from './shared/common'
+
+const boardName = 'Persist Board'
+
+test.describe('Board persistence', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+  })
+
+  test('new board persists after reload', async ({ page }) => {
+    await handleDialog(page, 'prompt', boardName)
+    await page.click('#board-dropdown .dropbtn')
+    await page.click('#board-control a[data-action="create"]')
+    await expect(page.locator('#board-selector')).toContainText(boardName)
+
+    await page.reload()
+    const boards = await getBoardsFromLocalStorage(page)
+    expect(boards.some(b => b.name === boardName)).toBeTruthy()
+  })
+})

--- a/tests/stateTab.spec.ts
+++ b/tests/stateTab.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from './fixtures'
+import { ciConfig } from './data/ciConfig'
+import { ciServices } from './data/ciServices'
+import { gzipJsonToBase64url } from '../src/utils/compression.js'
+
+async function encode(obj: any) {
+  return gzipJsonToBase64url(obj)
+}
+
+test.describe('Saved States tab', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+    const cfg = await encode(ciConfig)
+    const svc = await encode(ciServices)
+    await page.evaluate(async ({ cfg, svc }) => {
+      const { default: sm } = await import('/storage/StorageManager.js')
+      await sm.saveStateSnapshot({ name: 'one', type: 'imported', cfg, svc })
+      await sm.saveStateSnapshot({ name: 'two', type: 'imported', cfg, svc })
+    }, { cfg, svc })
+  })
+
+  test('restore and delete snapshot', async ({ page }) => {
+    await page.click('#open-config-modal')
+    await page.click('.tabs button[data-tab="state"]')
+    await expect(page.locator('#stateTab tbody tr')).toHaveCount(2)
+
+    await page.locator('#stateTab tbody tr:first-child button:has-text("Restore")').click()
+    await page.click('#fragment-decision-modal button:has-text("Overwrite")')
+    await page.waitForLoadState('domcontentloaded')
+    const boards = await page.evaluate(() => JSON.parse(localStorage.getItem('boards')||'[]'))
+    expect(boards.length).toBeGreaterThan(0)
+
+    await page.click('#open-config-modal')
+    await page.click('.tabs button[data-tab="state"]')
+    page.on('dialog', d => d.accept())
+    await page.locator('#stateTab tbody tr:nth-child(2) button:has-text("Delete")').click()
+    await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
+
+    await page.reload()
+    await page.click('#open-config-modal')
+    await page.click('.tabs button[data-tab="state"]')
+    await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
+  })
+})

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+import crypto from 'crypto'
+
+test.describe('StorageManager', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+  })
+
+  test('setConfig wraps version and syncs boards', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { default: sm } = await import('/storage/StorageManager.js')
+      localStorage.clear()
+      window.asd.boards = []
+      const cfg = { boards: [{ id: 'b1', name: 'B1', views: [] }] }
+      sm.setConfig(cfg)
+      return {
+        raw: localStorage.getItem('config'),
+        boards: localStorage.getItem('boards'),
+        cfg: sm.getConfig(),
+        globalBoards: window.asd.boards
+      }
+    })
+    expect(JSON.parse(result.raw)).toEqual({ version: 1, data: { boards: [{ id: 'b1', name: 'B1', views: [] }] } })
+    expect(JSON.parse(result.boards)).toEqual([{ id: 'b1', name: 'B1', views: [] }])
+    expect(result.cfg).toEqual({ boards: [{ id: 'b1', name: 'B1', views: [] }] })
+    expect(result.globalBoards).toEqual([{ id: 'b1', name: 'B1', views: [] }])
+  })
+
+  test('saveStateSnapshot persists and hashes', async ({ page }) => {
+    const { hash, store } = await page.evaluate(async () => {
+      const { default: sm } = await import('/storage/StorageManager.js')
+      localStorage.clear()
+      const hash = await sm.saveStateSnapshot({ name: 'one', type: 'manual', cfg: 'a', svc: 'b' })
+      const store = await sm.loadStateStore()
+      return { hash, store }
+    })
+    const expected = crypto.createHash('md5').update('ab').digest('hex')
+    expect(hash).toBe(expected)
+    expect(store.states[0].md5).toBe(expected)
+  })
+
+  test('clearAll removes stored keys', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { default: sm } = await import('/storage/StorageManager.js')
+      localStorage.setItem('config', '{}')
+      localStorage.setItem('boards', '[]')
+      localStorage.setItem('services', '[]')
+      localStorage.setItem('asd-dashboard-state', '{}')
+      sm.clearAll()
+      return {
+        c: localStorage.getItem('config'),
+        b: localStorage.getItem('boards'),
+        s: localStorage.getItem('services'),
+        st: localStorage.getItem('asd-dashboard-state')
+      }
+    })
+    expect(result.c).toBeNull()
+    expect(result.b).toBeNull()
+    expect(result.s).toBeNull()
+    expect(result.st).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- centralize localStorage access through StorageManager
- add misc helpers for last used board and view
- refactor modules to use StorageManager
- cover board persistence in new tests
- enable snapshot naming on import/export
- save history via StorageManager
- add Saved States tab in config modal for restoring and deleting snapshots

## Testing
- `just format`
- `just check`
- `just test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_686adb417620832588f88937f2e0d0c7