### PR TITLE
Refactor StorageManager

### DIFF
--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -7,6 +7,7 @@
 import emojiList from '../../ui/unicodeEmoji.js'
 import { showNotification } from '../dialog/notification.js'
 import { debounceLeading } from '../../utils/utils.js'
+import StorageManager from '../../storage/StorageManager.js'
 
 /**
  * Initialize service worker controls in the menu.
@@ -19,7 +20,7 @@ function initSW () {
   const swIcon = document.querySelector('.sw-icon')
   /** @type {HTMLElement} */
   const swCheckbox = document.querySelector('.icon-checkbox')
-  const swEnabled = localStorage.getItem('swEnabled') === 'true'
+  const swEnabled = StorageManager.misc.getItem('swEnabled') === 'true'
   swToggle.checked = swEnabled
 
   const buttonDebounce = 200
@@ -97,7 +98,7 @@ function initSW () {
 
     const handleSwChange = debounceLeading(() => {
       const isEnabled = swToggle.checked
-      localStorage.setItem('swEnabled', String(isEnabled))
+      StorageManager.misc.setItem('swEnabled', String(isEnabled))
       updateServiceWorkerUI(isEnabled)
       showNotification(`Service Worker ${isEnabled ? 'Enabled' : 'Disabled'}`, 500)
 

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -55,7 +55,7 @@ export async function openConfigModal () {
     configData.boards = storedBoards
   }
 
-  const last = localStorage.getItem('configModalTab') || 'cfg'
+  const last = StorageManager.misc.getItem('configModalTab') || 'cfg'
   openModal({
     id: 'config-modal',
     onCloseCallback: () => logger.log('Config modal closed'),
@@ -124,7 +124,7 @@ export async function openConfigModal () {
         stateBtn.classList.toggle('active', tab === 'state')
         cfgTab.hidden = tab !== 'cfg'
         stateTab.hidden = tab !== 'state'
-        localStorage.setItem('configModalTab', tab)
+        StorageManager.misc.setItem('configModalTab', tab)
       }
       cfgBtn.addEventListener('click', () => switchTab('cfg'))
       stateBtn.addEventListener('click', () => switchTab('state'))

--- a/src/component/modal/localStorageModal.js
+++ b/src/component/modal/localStorageModal.js
@@ -7,25 +7,9 @@
 import { openModal } from './modalFactory.js'
 import { showNotification } from '../dialog/notification.js'
 import { Logger } from '../../utils/Logger.js'
+import StorageManager from '../../storage/StorageManager.js'
 
 const logger = new Logger('localStorageModal.js')
-
-/**
- * Checks if a given string is valid JSON.
- * @function isJSON
- * @param {string} value - The string to check.
- * @returns {boolean} True if the string is valid JSON, false otherwise.
- */
-function isJSON (value) {
-  try {
-    JSON.parse(value)
-    logger.log('Valid JSON:', value)
-    return true
-  } catch (e) {
-    logger.error('Invalid JSON:', value)
-    return false
-  }
-}
 
 /**
  * Retrieves and parses all JSON-formatted items from localStorage.
@@ -33,21 +17,8 @@ function isJSON (value) {
  * @returns {Record<string, any>} An object containing the parsed localStorage data.
  */
 function getLocalStorageData () {
-  const localStorageData = {}
-
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i)
-    const value = localStorage.getItem(key)
-    logger.log(`Checking key: ${key}, value: ${value}`)
-
-    if (isJSON(value)) {
-      localStorageData[key] = JSON.parse(value)
-    } else {
-      logger.warn(`Non-JSON value detected for key: ${key}. This entry will not be editable in the modal.`)
-    }
-  }
-
-  return localStorageData
+  const data = StorageManager.misc.getAllJson()
+  return data
 }
 
 /**
@@ -57,10 +28,7 @@ function getLocalStorageData () {
  * @returns {void}
  */
 function saveLocalStorageData (updatedData) {
-  for (const key in updatedData) {
-    const value = updatedData[key]
-    localStorage.setItem(key, JSON.stringify(value))
-  }
+  StorageManager.misc.setJsonRecord(updatedData)
 }
 
 /**

--- a/src/component/widget/utils/fetchServices.js
+++ b/src/component/widget/utils/fetchServices.js
@@ -5,12 +5,12 @@
  * @module fetchServices
  */
 import { Logger } from '../../../utils/Logger.js'
+import StorageManager from '../../../storage/StorageManager.js'
 
 const logger = new Logger('fetchServices.js')
 
 let serviceCache = null
 let lastFetchTime = 0
-const STORAGE_KEY = 'services'
 
 /**
  * Parses a base64 encoded JSON string.
@@ -71,13 +71,9 @@ export async function fetchServices () {
   }
 
   if (!services) {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored) {
-      try {
-        services = JSON.parse(stored)
-      } catch (e) {
-        logger.error('Failed to parse services from localStorage:', e)
-      }
+    const stored = StorageManager.getServices()
+    if (stored.length) {
+      services = stored
     }
   }
 
@@ -86,7 +82,7 @@ export async function fetchServices () {
   }
 
   services = services || []
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(services))
+  StorageManager.setServices(services)
   serviceCache = services
   lastFetchTime = currentTime
   return serviceCache

--- a/src/storage/StorageManager.js
+++ b/src/storage/StorageManager.js
@@ -223,6 +223,67 @@ const StorageManager = {
     setLastViewId (id) {
       if (id) localStorage.setItem(KEYS.LAST_VIEW, id)
       else localStorage.removeItem(KEYS.LAST_VIEW)
+    },
+
+    /**
+     * Retrieve a raw string value from localStorage.
+     *
+     * @function getItem
+     * @param {string} key
+     * @returns {string|null}
+     */
+    getItem (key) {
+      return localStorage.getItem(key)
+    },
+
+    /**
+     * Persist a raw string value under a custom key.
+     *
+     * @function setItem
+     * @param {string} key
+     * @param {string|null} value
+     * @returns {void}
+     */
+    setItem (key, value) {
+      if (value === null || value === undefined) {
+        localStorage.removeItem(key)
+      } else {
+        localStorage.setItem(key, String(value))
+      }
+    },
+
+    /**
+     * Get all JSON-parsable items from localStorage.
+     *
+     * @function getAllJson
+     * @returns {Record<string, any>}
+     */
+    getAllJson () {
+      const data = {}
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i)
+        if (!key) continue
+        const value = localStorage.getItem(key)
+        try {
+          data[key] = JSON.parse(value)
+        } catch {
+          // ignore unparsable entries
+        }
+      }
+      return data
+    },
+
+    /**
+     * Persist an object of key/value pairs as JSON strings.
+     *
+     * @function setJsonRecord
+     * @param {Record<string, any>} record
+     * @returns {void}
+     */
+    setJsonRecord (record) {
+      for (const key in record) {
+        localStorage.setItem(key, JSON.stringify(record[key]))
+      }
     }
   }
 }

--- a/src/storage/localStorage.js
+++ b/src/storage/localStorage.js
@@ -5,6 +5,7 @@
  * @module localStorage
  */
 import { Logger } from '../utils/Logger.js'
+import StorageManager from './StorageManager.js'
 
 /** @typedef {import('../types.js').Widget} Widget */
 /** @typedef {import('../types.js').Board} Board */
@@ -113,9 +114,8 @@ async function loadInitialConfig () {
  */
 function saveBoardState (boards) {
   try {
-    localStorage.setItem('boards', JSON.stringify(boards))
-    window.asd.boards = boards // Keep global state synchronized
-    logger.log('Saved board state to localStorage')
+    StorageManager.setBoards(boards)
+    logger.log('Saved board state')
   } catch (error) {
     logger.error('Error saving board state:', error)
   }
@@ -128,9 +128,7 @@ function saveBoardState (boards) {
  */
 async function loadBoardState () {
   try {
-    const boardsJSON = localStorage.getItem('boards')
-    const parsedBoards = boardsJSON ? JSON.parse(boardsJSON) : []
-    window.asd.boards = parsedBoards
+    const parsedBoards = StorageManager.getBoards()
     return parsedBoards
   } catch (error) {
     logger.error('Error loading board state:', error)

--- a/src/storage/servicesStore.js
+++ b/src/storage/servicesStore.js
@@ -1,5 +1,5 @@
 // @ts-check
-const STORAGE_KEY = 'services'
+import StorageManager from './StorageManager.js'
 
 /**
  * Loads the array of services from localStorage.
@@ -8,10 +8,9 @@ const STORAGE_KEY = 'services'
  */
 export function load () {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    return stored ? JSON.parse(stored) : []
+    return StorageManager.getServices()
   } catch (e) {
-    console.error('Failed to parse services from localStorage:', e)
+    console.error('Failed to parse services from storage:', e)
     return []
   }
 }
@@ -23,5 +22,5 @@ export function load () {
  * @returns {void}
  */
 export function save (services) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(services))
+  StorageManager.setServices(services)
 }

--- a/src/utils/Logger.js
+++ b/src/utils/Logger.js
@@ -1,4 +1,5 @@
 // @ts-check
+import StorageManager from '../storage/StorageManager.js'
 /**
  * A simple browser console logger with runtime enable/disable support.
  * @class Logger
@@ -25,7 +26,7 @@ export class Logger {
    * @returns {boolean}
    */
   checkLogStatus () {
-    const logSetting = localStorage.getItem('log')
+    const logSetting = StorageManager.misc.getItem('log')
     if (logSetting === 'all') {
       return true
     } else if (logSetting) {
@@ -136,7 +137,7 @@ export class Logger {
    * @returns {void}
    */
   static enableLogs (files = 'all') {
-    localStorage.setItem('log', files)
+    StorageManager.misc.setItem('log', files)
   }
 
   /**
@@ -146,7 +147,7 @@ export class Logger {
    * @returns {void}
    */
   static disableLogs () {
-    localStorage.removeItem('log')
+    StorageManager.misc.setItem('log', null)
   }
 
   /**
@@ -156,7 +157,7 @@ export class Logger {
    * @returns {void}
    */
   static listLoggedFiles () {
-    const logSetting = localStorage.getItem('log')
+    const logSetting = StorageManager.misc.getItem('log')
     if (logSetting === 'all') {
       console.log('Logging is enabled for all files')
     } else if (logSetting) {

--- a/symbols.json
+++ b/symbols.json
@@ -612,6 +612,14 @@
     "returns": "HTMLElement|undefined"
   },
   {
+    "name": "getAllJson",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Get all JSON-parsable items from localStorage.",
+    "params": [],
+    "returns": "Record<string, any>"
+  },
+  {
     "name": "getAuthToken",
     "kind": "function",
     "file": "src/component/widget/utils/fetchData.js",
@@ -674,6 +682,20 @@
     "description": "Get the id of the currently active view element.",
     "params": [],
     "returns": "string"
+  },
+  {
+    "name": "getItem",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Retrieve a raw string value from localStorage.",
+    "params": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "string|null"
   },
   {
     "name": "getLastBoardId",
@@ -1346,7 +1368,7 @@
     "file": "src/component/modal/configModal.js",
     "description": "Open a modal dialog allowing the user to edit and save configuration JSON.",
     "params": [],
-    "returns": "void"
+    "returns": "Promise<void>"
   },
   {
     "name": "openEvictionModal",
@@ -1763,6 +1785,39 @@
       {
         "name": "cfg",
         "type": "DashboardConfig",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "setItem",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist a raw string value under a custom key.",
+    "params": [
+      {
+        "name": "key",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "value",
+        "type": "string|null",
+        "desc": ""
+      }
+    ],
+    "returns": "void"
+  },
+  {
+    "name": "setJsonRecord",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Persist an object of key/value pairs as JSON strings.",
+    "params": [
+      {
+        "name": "record",
+        "type": "Record<string, any>",
         "desc": ""
       }
     ],

--- a/tests/persistence.spec.ts
+++ b/tests/persistence.spec.ts
@@ -21,4 +21,14 @@ test.describe('Board persistence', () => {
     const boards = await getBoardsFromLocalStorage(page)
     expect(boards.some(b => b.name === boardName)).toBeTruthy()
   })
+
+  test('last view persists after reload', async ({ page }) => {
+    await handleDialog(page, 'prompt', 'Second View')
+    await page.click('#view-dropdown .dropbtn')
+    await page.click('#view-control a[data-action="create"]')
+    await expect(page.locator('#view-selector option:checked')).toHaveText('Second View')
+
+    await page.reload()
+    await expect(page.locator('#view-selector option:checked')).toHaveText('Second View')
+  })
 })


### PR DESCRIPTION
## Summary
- centralize localStorage usage through StorageManager helpers
- update logger and menus to use StorageManager
- adapt modal helpers and fetchServices
- extend StorageManager.misc with generic accessors
- add persistence test for view selection

## Testing
- `npm run lint-fix`
- `npm run check`
- `npm run test` *(fails: 4 failed, 4 interrupted, 102 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_686aea43795c832590c821cd286d2e6e