### PR TITLE
Implement widget selector enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## ✨ WidgetSelectorPanel
+- Added subcategory search and service instance counts.
+- Limits now disable add actions when reached.
+- New modal flow for creating and editing services.

--- a/src/component/modal/saveServiceModal.js
+++ b/src/component/modal/saveServiceModal.js
@@ -7,6 +7,7 @@
 import { openModal } from './modalFactory.js'
 import { load, save } from '../../storage/servicesStore.js'
 import { addWidget } from '../widget/widgetManagement.js'
+import { refreshRowCounts, updateWidgetCounter } from '../menu/widgetSelectorPanel.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 
 /**
@@ -117,6 +118,15 @@ export function openSaveServiceModal (options, onCloseDeprecated) {
                 const hw = /** @type {HTMLElement} */(el)
                 if (hw.dataset.service === oldName) hw.dataset.service = nameVal
               })
+              const boards = JSON.parse(localStorage.getItem('boards') || '[]')
+              boards.forEach(b => {
+                b.views.forEach(v => {
+                  v.widgetState.forEach(w => {
+                    if (w.type === oldName) w.type = nameVal
+                  })
+                })
+              })
+              localStorage.setItem('boards', JSON.stringify(boards))
             }
             document.dispatchEvent(new CustomEvent('services-updated'))
           }
@@ -134,6 +144,8 @@ export function openSaveServiceModal (options, onCloseDeprecated) {
           document.dispatchEvent(new CustomEvent('services-updated'))
           if (startCheck.checked) {
             await addWidget(urlVal, 1, 1, 'iframe', getCurrentBoardId(), getCurrentViewId())
+            refreshRowCounts()
+            updateWidgetCounter()
           }
         }
         closeModal()

--- a/symbols.json
+++ b/symbols.json
@@ -1370,8 +1370,8 @@
     "params": [
       {
         "name": "options",
-        "type": "object|string",
-        "desc": "- Options or legacy URL string."
+        "type": "object",
+        "desc": "- Modal configuration."
       },
       {
         "name": "options.mode",
@@ -1451,6 +1451,14 @@
     "kind": "function",
     "file": "src/component/menu/widgetSelectorPanel.js",
     "description": "Populate dropdown list with saved services.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "refreshRowCounts",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Update the instance count labels for each service row.",
     "params": [],
     "returns": "void"
   },

--- a/tests/widgetCounter.spec.ts
+++ b/tests/widgetCounter.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+
+
+test.describe('Widget counters', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.addInitScript(() => {
+      const apply = () => {
+        if (window.asd?.widgetStore) {
+          window.asd.widgetStore.maxSize = 1
+        } else {
+          setTimeout(apply, 0)
+        }
+      }
+      apply()
+    })
+    await page.goto('/')
+    await page.waitForSelector('#widget-selector-panel')
+  })
+
+  test('row and global counts update', async ({ page }) => {
+    await page.click('#widget-dropdown-toggle')
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')
+    await page.locator('.widget-wrapper').first().waitFor()
+
+    await expect(page.locator('#widget-count')).toHaveText('Active: 1 / Max: 1')
+
+    await page.click('#widget-dropdown-toggle')
+    const row = page.locator('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')
+    await expect(row).toContainText('(1/20)')
+    await row.click()
+    await expect(page.locator('.widget-wrapper')).toHaveCount(1)
+  })
+})


### PR DESCRIPTION
## Summary
- refine widget panel counts and limits
- add refreshRowCounts helper
- update service edit modal to rename widgets
- add changelog entry
- test counters

## Testing
- `npm run lint-fix`
- `npm run check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_686af0512e18832582ecf25c56e12d39