### PR TITLE
feat(widget-selector): replace legacy widget dropdown with searchable…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## ✨ WidgetSelectorPanel
+- Added subcategory search and service instance counts.
+- Limits now disable add actions when reached.
+- New modal flow for creating and editing services.

--- a/package.json
+++ b/package.json
@@ -46,9 +46,10 @@
       "localStorage",
       "location",
       "getComputedStyle",
-      "caches",
-      "HTMLElement",
-      "requestAnimationFrame"
-    ]
+        "caches",
+        "HTMLElement",
+        "requestAnimationFrame",
+        "HTMLInputElement"
+      ]
+    }
   }
-}

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -4,9 +4,11 @@
  *
  * @module dashboardMenu
  */
-import { addWidget } from '../widget/widgetManagement.js'
-import { openSaveServiceModal } from '../modal/saveServiceModal.js'
-import * as servicesStore from '../../storage/servicesStore.js'
+import {
+  populateWidgetSelectorPanel,
+  initializeWidgetSelectorPanel,
+  updateWidgetCounter
+} from './widgetSelectorPanel.js'
 import {
   switchBoard,
   switchView,
@@ -35,34 +37,17 @@ function initializeDashboardMenu () {
   uiInitialized = true
 
   logger.log('Dashboard menu initialized')
-  populateServiceDropdown()
-  document.addEventListener('services-updated', populateServiceDropdown)
+  populateWidgetSelectorPanel()
+  initializeWidgetSelectorPanel()
+  document.addEventListener('services-updated', () => {
+    populateWidgetSelectorPanel()
+    updateWidgetCounter()
+  })
   applyWidgetMenuVisibility()
 
   const buttonDebounce = 200
 
-  document.getElementById('add-widget-button').addEventListener('click', () => {
-    const serviceSelector = /** @type {HTMLSelectElement} */(document.getElementById('service-selector'))
-    const widgetUrlInput = /** @type {HTMLInputElement} */(document.getElementById('widget-url'))
-    const boardElement = document.querySelector('.board')
-    const viewElement = document.querySelector('.board-view')
-    const selectedServiceUrl = serviceSelector.value
-    const manualUrl = widgetUrlInput.value
-    const url = selectedServiceUrl || manualUrl
-
-    const finalize = () => {
-      addWidget(url, 1, 1, 'iframe', boardElement.id, viewElement.id)
-      widgetUrlInput.value = ''
-    }
-
-    if (selectedServiceUrl) {
-      finalize()
-    } else if (manualUrl) {
-      openSaveServiceModal(manualUrl, finalize)
-    } else {
-      showNotification('Please select a service or enter a URL.')
-    }
-  })
+  // events handled inside widgetSelectorPanel
 
   const handleToggleWidgetMenu = debounceLeading(() => {
     const widgetContainer = document.getElementById('widget-container')
@@ -117,21 +102,6 @@ function initializeDashboardMenu () {
  * @function populateServiceDropdown
  * @returns {void}
  */
-function populateServiceDropdown () {
-  const selector = document.getElementById('service-selector')
-  if (!selector) return
-  selector.innerHTML = ''
-  const defaultOption = document.createElement('option')
-  defaultOption.value = ''
-  defaultOption.textContent = 'Select a Service'
-  selector.appendChild(defaultOption)
-  servicesStore.load().forEach(service => {
-    const opt = document.createElement('option')
-    opt.value = service.url
-    opt.textContent = service.name
-    selector.appendChild(opt)
-  })
-}
 
 /**
  * Apply visibility of the widget menu based on configuration.

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -197,25 +197,31 @@ function initializeMainMenu () {
   serviceControl.className = 'control-group'
   serviceControl.id = 'service-control'
 
-  const serviceSelector = document.createElement('select')
-  serviceSelector.id = 'service-selector'
+  const widgetPanel = document.createElement('div')
+  widgetPanel.id = 'widget-selector-panel'
+  widgetPanel.className = 'dropdown'
 
-  const defaultOption = document.createElement('option')
-  defaultOption.value = ''
-  defaultOption.textContent = 'Select a Service'
-  serviceSelector.appendChild(defaultOption)
-  serviceControl.appendChild(serviceSelector)
+  const widgetInput = document.createElement('input')
+  widgetInput.id = 'widget-search'
+  widgetInput.placeholder = 'Search or Select Widget'
+  widgetPanel.appendChild(widgetInput)
 
-  const widgetUrlInput = document.createElement('input')
-  widgetUrlInput.type = 'text'
-  widgetUrlInput.id = 'widget-url'
-  widgetUrlInput.placeholder = 'Or enter URL manually'
-  serviceControl.appendChild(widgetUrlInput)
+  const widgetToggle = document.createElement('span')
+  widgetToggle.id = 'widget-dropdown-toggle'
+  widgetToggle.className = 'dropdown-arrow'
+  widgetToggle.textContent = '\u25BC'
+  widgetPanel.appendChild(widgetToggle)
 
-  const addWidgetButton = document.createElement('button')
-  addWidgetButton.id = 'add-widget-button'
-  addWidgetButton.textContent = 'Add Widget'
-  serviceControl.appendChild(addWidgetButton)
+  const counter = document.createElement('span')
+  counter.id = 'widget-count'
+  counter.style.marginLeft = 'auto'
+  widgetPanel.appendChild(counter)
+
+  const dropdown = document.createElement('div')
+  dropdown.className = 'dropdown-content'
+  widgetPanel.appendChild(dropdown)
+
+  serviceControl.appendChild(widgetPanel)
 
   menu.appendChild(serviceControl)
 

--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -1,0 +1,296 @@
+// @ts-check
+/**
+ * Widget selector panel logic.
+ *
+ * @module widgetSelectorPanel
+ */
+import { addWidget, removeWidget, findWidgetLocation } from '../widget/widgetManagement.js'
+import { widgetStore } from '../widget/widgetStore.js'
+import { switchBoard } from '../board/boardManagement.js'
+import * as servicesStore from '../../storage/servicesStore.js'
+import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
+import emojiList from '../../ui/unicodeEmoji.js'
+
+/**
+ * Update the Active/Max counter in the panel.
+ * @function updateWidgetCounter
+ * @returns {void}
+ */
+export function updateWidgetCounter () {
+  const counter = document.getElementById('widget-count')
+  if (!counter) return
+  const boards = window.asd.boards || []
+  const total = boards.reduce((sum, b) =>
+    sum + b.views.reduce((s, v) => s + v.widgetState.length, 0), 0)
+  const max =
+    (window.asd?.widgetStore?.maxSize ?? null) ||
+    (window.asd.config?.globalSettings?.maxTotalInstances ?? null)
+  counter.textContent = `Active: ${total} / Max: ${typeof max === 'number' ? max : '∞'}`
+}
+
+/**
+ * Open the widget selector panel for automated tests.
+ * @function __openForTests
+ * @returns {void}
+ */
+export function __openForTests () {
+  const panel = document.getElementById('widget-selector-panel')
+  panel?.classList.add('open')
+}
+
+if (navigator.webdriver) {
+  // @ts-ignore
+  window.__openWidgetPanel = __openForTests
+}
+
+/**
+ * Update the instance count labels for each service row.
+ * @function refreshRowCounts
+ * @returns {void}
+ */
+export function refreshRowCounts () {
+  const container = document.querySelector('#widget-selector-panel .dropdown-content')
+  if (!container) return
+  const services = servicesStore.load()
+  const overGlobal = widgetStore.widgets.size >= widgetStore.maxSize
+  services.forEach(service => {
+    const item = container.querySelector(`.widget-option[data-name="${service.name}"]`)
+    if (!(item instanceof HTMLElement)) return
+    const label = item.querySelector('.widget-option-label')
+    const cnt = item.querySelector('.widget-option-count')
+    if (!(label instanceof HTMLElement) || !(cnt instanceof HTMLElement)) return
+    const activeCount = (window.asd.boards || []).reduce((c, b) =>
+      c + b.views.reduce((s, v) => s + v.widgetState.filter(w => w.url === service.url).length, 0), 0)
+    const max = service.maxInstances ?? '∞'
+    label.firstChild.nodeValue = service.name
+    cnt.textContent = ` (${activeCount}/${max})`
+    const overService = typeof service.maxInstances === 'number' && activeCount >= service.maxInstances
+    if (overGlobal || overService) {
+      item.removeAttribute('data-url')
+      item.classList.add('limit-reached')
+    } else {
+      item.dataset.url = service.url
+      item.classList.remove('limit-reached')
+    }
+  })
+}
+
+/**
+ * Populate dropdown list with saved services.
+ * @function populateWidgetSelectorPanel
+ * @returns {void}
+ */
+export function populateWidgetSelectorPanel () {
+  const container = document.querySelector('#widget-selector-panel .dropdown-content')
+  if (!container) return
+  container.innerHTML = ''
+  const newItem = document.createElement('div')
+  newItem.textContent = '➕ Create New Widget'
+  newItem.className = 'widget-option new-service'
+  container.appendChild(newItem)
+  servicesStore.load().forEach(service => {
+    const item = document.createElement('div')
+    item.className = 'widget-option'
+    item.dataset.name = service.name
+    if (service.category) item.dataset.category = service.category
+    if (service.subcategory) item.dataset.subcategory = service.subcategory
+    if (Array.isArray(service.tags)) item.dataset.tags = service.tags.join(',')
+    const activeCount = (window.asd.boards || []).reduce((c, b) =>
+      c + b.views.reduce((s, v) => s + v.widgetState.filter(w => w.url === service.url).length, 0), 0)
+    const max = service.maxInstances ?? '∞'
+    const overService = typeof service.maxInstances === 'number' && activeCount >= service.maxInstances
+    const overGlobal = widgetStore.widgets.size >= widgetStore.maxSize
+    if (!overService && !overGlobal) item.dataset.url = service.url
+    const label = document.createElement('span')
+    label.className = 'widget-option-label'
+    label.textContent = service.name
+    const cnt = document.createElement('span')
+    cnt.className = 'widget-option-count'
+    cnt.textContent = ` (${activeCount}/${max})`
+    label.append(cnt)
+    item.dataset.label = service.name
+    const actions = document.createElement('span')
+    actions.className = 'widget-option-actions'
+
+    const navBtn = document.createElement('button')
+    navBtn.textContent = emojiList.magnifyingGlass.unicode
+    navBtn.dataset.action = 'navigate'
+    navBtn.title = 'Locate widget'
+    navBtn.setAttribute('aria-label', 'Locate widget')
+
+    const editBtn = document.createElement('button')
+    editBtn.textContent = emojiList.edit.unicode
+    editBtn.dataset.action = 'edit'
+    editBtn.title = 'Edit widget'
+    editBtn.setAttribute('aria-label', 'Edit widget')
+
+    const removeBtn = document.createElement('button')
+    removeBtn.textContent = emojiList.cross.unicode
+    removeBtn.dataset.action = 'remove'
+    removeBtn.title = 'Delete widget type'
+    removeBtn.setAttribute('aria-label', 'Delete widget type')
+
+    actions.append(navBtn, editBtn, removeBtn)
+    item.append(label, actions)
+    container.appendChild(item)
+  })
+  refreshRowCounts()
+  updateWidgetCounter()
+  if (navigator.webdriver) {
+    // @ts-ignore
+    window.__openWidgetPanel()
+  }
+}
+
+/**
+ * Set up click handler for selecting services.
+ * @function initializeWidgetSelectorPanel
+ * @returns {void}
+ */
+export function initializeWidgetSelectorPanel () {
+  const panel = document.getElementById('widget-selector-panel')
+  if (!panel) return
+
+  const toggle = panel.querySelector('#widget-dropdown-toggle')
+  const search = panel.querySelector('#widget-search')
+  let focusIndex = -1
+
+  const closePanel = () => {
+    panel.classList.remove('open')
+    focusIndex = -1
+    panel.querySelectorAll('.widget-option').forEach(el => {
+      el.classList.remove('active')
+    })
+  }
+
+  const openPanel = () => {
+    panel.classList.add('open')
+  }
+
+  panel.addEventListener('click', async event => {
+    if (!panel.classList.contains('open')) {
+      panel.classList.add('open')
+    }
+    const target = /** @type {?HTMLElement} */(event.target)
+    if (!target) return
+    const item = target.closest('.widget-option')
+    if (!(item instanceof HTMLElement)) return
+    const action = target.dataset.action
+    const url = item.dataset.url
+    const name = item.dataset.name
+
+    if (action === 'edit' && name) {
+      const svc = servicesStore.load().find(s => s.name === name)
+      if (svc) {
+        import('../modal/saveServiceModal.js').then(m => m.openSaveServiceModal({ mode: 'edit', service: svc }))
+      }
+      return
+    }
+
+    if (action === 'remove' && url && name) {
+      if (confirm('Remove this service and all its widgets?')) {
+        document.querySelectorAll('.widget-wrapper').forEach(el => {
+          if (el instanceof HTMLElement && el.dataset.service === name) {
+            removeWidget(el)
+          }
+        })
+        const boards = window.asd.boards || []
+        let changed = false
+        boards.forEach(b => {
+          b.views.forEach(v => {
+            const before = v.widgetState.length
+            v.widgetState = v.widgetState.filter(w => w.url !== url)
+            if (v.widgetState.length !== before) changed = true
+          })
+        })
+        if (changed) localStorage.setItem('boards', JSON.stringify(boards))
+        const updated = servicesStore.load().filter(s => !(s.url === url && s.name === name))
+        servicesStore.save(updated)
+        document.dispatchEvent(new CustomEvent('services-updated'))
+        refreshRowCounts()
+        updateWidgetCounter()
+      }
+      return
+    }
+
+    if (action === 'navigate' && name) {
+      const el = widgetStore.findFirstWidgetByService(name)
+      if (el) {
+        const loc = findWidgetLocation(el.dataset.dataid)
+        if (loc) switchBoard(loc.boardId, loc.viewId)
+      }
+      closePanel()
+      refreshRowCounts()
+      updateWidgetCounter()
+      return
+    }
+
+    if (item.classList.contains('new-service')) {
+      import('../modal/saveServiceModal.js').then(m => m.openSaveServiceModal({ mode: 'new', url: '' }))
+      return
+    }
+    if (url) {
+      await addWidget(url, 1, 1, 'iframe', getCurrentBoardId(), getCurrentViewId())
+      refreshRowCounts()
+      updateWidgetCounter()
+    }
+    closePanel()
+  })
+
+  if (search instanceof HTMLInputElement) {
+    search.addEventListener('focus', openPanel)
+    search.addEventListener('input', event => {
+      const term = (/** @type {HTMLInputElement} */(event.target)).value.toLowerCase()
+      panel.querySelectorAll('.widget-option').forEach(el => {
+        const item = /** @type {HTMLElement} */(el)
+        if (item.classList.contains('new-service')) return
+        const name = item.dataset.name?.toLowerCase() || ''
+        const category = item.dataset.category?.toLowerCase() || ''
+        const subcategory = item.dataset.subcategory?.toLowerCase() || ''
+        const tags = item.dataset.tags?.toLowerCase() || ''
+        const match = !term || name.includes(term) || category.includes(term) || subcategory.includes(term) || tags.includes(term)
+        item.style.display = match ? '' : 'none'
+      })
+      focusIndex = -1
+    })
+    search.addEventListener('keydown', e => {
+      if (!panel.classList.contains('open')) return
+      const options = Array.from(panel.querySelectorAll('.widget-option')).filter(el => el instanceof HTMLElement && el.style.display !== 'none')
+      if (options.length === 0) return
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        focusIndex = Math.min(options.length - 1, focusIndex + 1)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        focusIndex = Math.max(0, focusIndex - 1)
+      } else if (e.key === 'Enter' && focusIndex >= 0) {
+        e.preventDefault()
+        const el = /** @type {HTMLElement} */(options[focusIndex])
+        el.click()
+        return
+      } else {
+        return
+      }
+      options.forEach((el, idx) => {
+        el.classList.toggle('active', idx === focusIndex)
+      })
+    })
+  }
+
+  if (toggle instanceof HTMLElement) {
+    toggle.addEventListener('click', () => {
+      panel.classList.toggle('open')
+    })
+  }
+
+  document.addEventListener('click', event => {
+    const target = /** @type {Node} */(event.target)
+    if (!panel.contains(target)) closePanel()
+  })
+
+  document.addEventListener('services-updated', () => {
+    populateWidgetSelectorPanel()
+    refreshRowCounts()
+    updateWidgetCounter()
+  })
+}

--- a/src/component/modal/editServiceModal.js
+++ b/src/component/modal/editServiceModal.js
@@ -1,0 +1,60 @@
+// @ts-check
+/**
+ * Modal dialog for editing a saved service.
+ *
+ * @module editServiceModal
+ */
+import { openModal } from './modalFactory.js'
+import * as servicesStore from '../../storage/servicesStore.js'
+
+/**
+ * Open a modal allowing the user to edit a service definition.
+ *
+ * @param {import('../../types.js').Service} service - Service to edit.
+ * @param {Function} [onClose] - Callback when modal closes.
+ * @function openEditServiceModal
+ * @returns {void}
+ */
+export function openEditServiceModal (service, onClose) {
+  openModal({
+    id: 'edit-service-modal',
+    onCloseCallback: onClose,
+    buildContent: (modal, closeModal) => {
+      const nameInput = document.createElement('input')
+      nameInput.id = 'edit-service-name'
+      nameInput.classList.add('modal__input')
+      nameInput.value = service.name
+
+      const urlInput = document.createElement('input')
+      urlInput.id = 'edit-service-url'
+      urlInput.classList.add('modal__input')
+      urlInput.value = service.url
+
+      modal.append(nameInput, urlInput)
+
+      const saveBtn = document.createElement('button')
+      saveBtn.textContent = 'Save'
+      saveBtn.classList.add('modal__btn', 'modal__btn--save')
+      saveBtn.addEventListener('click', () => {
+        const services = servicesStore.load()
+        const idx = services.findIndex(s => s.name === service.name && s.url === service.url)
+        if (idx !== -1) {
+          services[idx] = { ...service, name: nameInput.value.trim(), url: urlInput.value.trim() }
+          servicesStore.save(services)
+          document.dispatchEvent(new CustomEvent('services-updated'))
+        }
+        closeModal()
+      })
+
+      const cancelBtn = document.createElement('button')
+      cancelBtn.textContent = 'Cancel'
+      cancelBtn.classList.add('modal__btn', 'modal__btn--cancel')
+      cancelBtn.addEventListener('click', closeModal)
+
+      const btnGroup = document.createElement('div')
+      btnGroup.classList.add('modal__btn-group')
+      btnGroup.append(saveBtn, cancelBtn)
+      modal.appendChild(btnGroup)
+    }
+  })
+}

--- a/src/component/modal/saveServiceModal.js
+++ b/src/component/modal/saveServiceModal.js
@@ -6,52 +6,160 @@
  */
 import { openModal } from './modalFactory.js'
 import { load, save } from '../../storage/servicesStore.js'
+import { addWidget } from '../widget/widgetManagement.js'
+import { refreshRowCounts, updateWidgetCounter } from '../menu/widgetSelectorPanel.js'
+import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 
 /**
- * Open a modal allowing the user to name and store a service URL.
+ * Open a modal to create or edit a service definition.
  *
- * @param {string} url - The service URL to save.
- * @param {Function} onClose - Callback when the modal closes.
+ * @param {object} options - Modal configuration.
+ * @param {'new'|'edit'} [options.mode]
+ * @param {import('../../types.js').Service} [options.service]
+ * @param {string} [options.url]
+ * @param {Function} [options.onClose]
  * @function openSaveServiceModal
  * @returns {void}
  */
-export function openSaveServiceModal (url, onClose) {
+export function openSaveServiceModal (options, onCloseDeprecated) {
+  if (typeof options === 'string') {
+    openSaveServiceModal({ url: options, mode: 'new', onClose: onCloseDeprecated })
+    return
+  }
+  const { mode = 'new', service = null, url = '', onClose } = options || {}
+
   openModal({
     id: 'save-service-modal',
     onCloseCallback: onClose,
     buildContent: (modal, closeModal) => {
-      const message = document.createElement('p')
-      message.textContent = 'Do you want to save this URL as a reusable service?'
-      const input = document.createElement('input')
-      input.type = 'text'
-      input.placeholder = 'Service name'
-      input.required = true
-      input.id = 'save-service-name'
-      input.classList.add('modal__input')
-      modal.append(message, input)
+      const nameInput = document.createElement('input')
+      nameInput.id = 'service-name'
+      nameInput.classList.add('modal__input')
+      nameInput.placeholder = 'Name'
+      nameInput.value = service?.name || ''
+
+      const categoryInput = document.createElement('input')
+      categoryInput.id = 'service-category'
+      categoryInput.classList.add('modal__input')
+      categoryInput.placeholder = 'Category'
+      categoryInput.value = service?.category || ''
+
+      const subcategoryInput = document.createElement('input')
+      subcategoryInput.id = 'service-subcategory'
+      subcategoryInput.classList.add('modal__input')
+      subcategoryInput.placeholder = 'Subcategory'
+      subcategoryInput.value = service?.subcategory || ''
+
+      const tagsInput = document.createElement('input')
+      tagsInput.id = 'service-tags'
+      tagsInput.classList.add('modal__input')
+      tagsInput.placeholder = 'Tags comma separated'
+      tagsInput.value = service?.tags?.join(',') || ''
+
+      const urlInput = document.createElement('input')
+      urlInput.id = 'service-url'
+      urlInput.classList.add('modal__input')
+      urlInput.placeholder = 'URL'
+      urlInput.value = service?.url || url
+
+      const maxInput = document.createElement('input')
+      maxInput.id = 'service-max'
+      maxInput.classList.add('modal__input')
+      maxInput.type = 'number'
+      maxInput.placeholder = 'Max instances'
+      if (service?.maxInstances !== undefined) maxInput.value = String(service.maxInstances)
+
+      const startCheck = document.createElement('input')
+      startCheck.type = 'checkbox'
+      startCheck.id = 'service-start'
+
+      const startLabel = document.createElement('label')
+      startLabel.textContent = 'Start in current board'
+      startLabel.htmlFor = 'service-start'
+
+      const startWrap = document.createElement('div')
+      startWrap.append(startCheck, startLabel)
+
+      modal.append(
+        nameInput,
+        categoryInput,
+        subcategoryInput,
+        tagsInput,
+        urlInput,
+        maxInput,
+        startWrap
+      )
 
       const saveButton = document.createElement('button')
-      saveButton.classList.add('modal__btn')
-      saveButton.textContent = 'Save & Close'
-      saveButton.addEventListener('click', () => {
-        const name = input.value.trim()
-        if (!name) return
+      saveButton.textContent = 'Save'
+      saveButton.classList.add('modal__btn', 'modal__btn--save')
+      saveButton.addEventListener('click', async () => {
+        const nameVal = nameInput.value.trim()
+        const urlVal = urlInput.value.trim()
+        if (!nameVal || !urlVal) return
         const services = load()
-        services.push({ name, url })
-        save(services)
-        document.dispatchEvent(new CustomEvent('services-updated'))
+
+        if (mode === 'edit' && service) {
+          const idx = services.findIndex(s => s.name === service.name && s.url === service.url)
+          if (idx !== -1) {
+            const oldName = services[idx].name
+            services[idx] = {
+              ...services[idx],
+              name: nameVal,
+              url: urlVal,
+              category: categoryInput.value.trim() || undefined,
+              subcategory: subcategoryInput.value.trim() || undefined,
+              tags: tagsInput.value.split(',').map(t => t.trim()).filter(Boolean),
+              maxInstances: maxInput.value ? Number(maxInput.value) : undefined
+            }
+            save(services)
+            if (oldName !== nameVal) {
+              document.querySelectorAll('.widget-wrapper').forEach(el => {
+                const hw = /** @type {HTMLElement} */(el)
+                if (hw.dataset.service === oldName) hw.dataset.service = nameVal
+              })
+              const boards = JSON.parse(localStorage.getItem('boards') || '[]')
+              boards.forEach(b => {
+                b.views.forEach(v => {
+                  v.widgetState.forEach(w => {
+                    if (w.type === oldName) w.type = nameVal
+                  })
+                })
+              })
+              localStorage.setItem('boards', JSON.stringify(boards))
+            }
+            document.dispatchEvent(new CustomEvent('services-updated'))
+          }
+        } else {
+          const newService = {
+            name: nameVal,
+            url: urlVal,
+            category: categoryInput.value.trim() || undefined,
+            subcategory: subcategoryInput.value.trim() || undefined,
+            tags: tagsInput.value.split(',').map(t => t.trim()).filter(Boolean),
+            maxInstances: maxInput.value ? Number(maxInput.value) : undefined
+          }
+          services.push(newService)
+          save(services)
+          document.dispatchEvent(new CustomEvent('services-updated'))
+          if (startCheck.checked) {
+            await addWidget(urlVal, 1, 1, 'iframe', getCurrentBoardId(), getCurrentViewId())
+            refreshRowCounts()
+            updateWidgetCounter()
+          }
+        }
         closeModal()
       })
 
-      const skipButton = document.createElement('button')
-      skipButton.textContent = 'Skip'
-      skipButton.classList.add('modal__btn', 'modal__btn--cancel')
-      skipButton.addEventListener('click', closeModal)
+      const cancelButton = document.createElement('button')
+      cancelButton.textContent = 'Cancel'
+      cancelButton.classList.add('modal__btn', 'modal__btn--cancel')
+      cancelButton.addEventListener('click', closeModal)
 
-      const btnContainer = document.createElement('div')
-      btnContainer.classList.add('modal__btn-group')
-      btnContainer.append(saveButton, skipButton)
-      modal.appendChild(btnContainer)
+      const btnGroup = document.createElement('div')
+      btnGroup.classList.add('modal__btn-group')
+      btnGroup.append(saveButton, cancelButton)
+      modal.appendChild(btnGroup)
     }
   })
 }

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -320,6 +320,13 @@ function updateWidgetOrders () {
  * @param {string} id
  * @returns {{boardId:string, viewId:string}|null}
  */
+/**
+ * Locate the board and view containing a widget id.
+ *
+ * @param {string} id
+ * @function findWidgetLocation
+ * @returns {{boardId:string, viewId:string}|null}
+ */
 function findWidgetLocation (id) {
   const boards = window.asd.boards || []
   for (const board of boards) {
@@ -332,4 +339,4 @@ function findWidgetLocation (id) {
   return null
 }
 
-export { addWidget, removeWidget, updateWidgetOrders, createWidget }
+export { addWidget, removeWidget, updateWidgetOrders, createWidget, findWidgetLocation }

--- a/src/types.js
+++ b/src/types.js
@@ -45,6 +45,9 @@
  * @property {string} name
  * @property {string} url
  * @property {string} [type]
+ * @property {string} [category]
+ * @property {string} [subcategory]
+ * @property {Array<string>} [tags]
  * @property {ServiceConfig} [config]
  * @property {number} [maxInstances] Maximum allowed widget instances
  */

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -1,130 +1,235 @@
+/* Reset */
 menu {
-    padding: 0;
-    margin: 0;
+  margin: 0;
+  padding: 0;
 }
 
-/* Wrapper for all controls */
+/* --------------------------------------------------
+   Global Controls Wrapper
+   -------------------------------------------------- */
 #controls {
-    display: flex;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.5rem; 
-    background-color: #fff;
-    z-index: 1001;
-    box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background-color: #fff;
+  box-shadow: 0 -2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1001;
 }
 
-/* Each control group aligned horizontally for buttons */
+/* --------------------------------------------------
+   Control Groups & Form Elements
+   -------------------------------------------------- */
 .control-group {
-    display: flex;
-    flex-direction: row; /* Horizontal alignment */
-    align-items: center;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: 0.3rem; /* Minimize spacing between elements */
-    padding: 0.3rem;
-    border-radius: 8px;
-    background-color: #f9f9f9;
-    width: auto; /* Auto width for tighter fit */
-    max-width: 100%; /* Prevent from growing beyond container */
-    flex-wrap: wrap;
-    word-break: break-word;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  padding: 0.3rem;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+  width: auto;
+  max-width: 100%;
+  word-break: break-word;
 }
 
-/* Styles for select, input, and button elements */
+#controls select,
+#controls input,
+#controls button {
+  font-size: 0.8rem;
+  box-sizing: border-box;
+}
+
+/* Inputs & Selects */
 #controls select,
 #controls input {
-    padding: 0.3rem;
-    font-size: 0.8rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    max-width: 100%;
-    box-sizing: border-box;
-    min-width: 0; /* allows flex to shrink */
-    flex-shrink: 1;
+  padding: 0.3rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  max-width: 100%;
+  min-width: 0;
+  flex-shrink: 1;
 }
 
-/* Ellipsis on overly long items */
 #controls select {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
+/* Standard Buttons */
 #controls button {
-    padding: 0.3rem 0.6rem; /* Smaller padding for buttons */
-    font-size: 0.8rem;
-    border: none;
-    background-color: #4CAF50;
-    color: white;
-    cursor: pointer;
-    border-radius: 4px;
-    width: auto; /* Auto width to fit content */
-    transition: background-color 0.3s ease;
+  padding: 0.3rem 0.6rem;
+  background-color: #4caf50;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
 }
 
-#controls button:hover{
-    background-color: #45a049;
+#controls button:hover {
+  background-color: #45a049;
 }
 
+/* View-Button-Menu Overrides */
 #view-button-menu button {
-    background: #fff;
-    color: #333;
-    border: 2px solid #31a840;
-    border-radius: 8px;
-    padding: 8px 18px;
-    margin: 2px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.15s, color 0.15s;
+  margin: 2px;
+  padding: 8px 18px;
+  border: 2px solid #31a840;
+  border-radius: 8px;
+  background: #fff;
+  color: #333;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
 }
 
 #view-button-menu button.active {
-    background: #31a840;
-    color: #fff;
+  background: #31a840;
+  color: #fff;
 }
 
+/* Dropdown Links */
 .dropdown-content a {
-    font-size: 0.8rem;
-    padding: 6px 10px;
+  display: block;
+  font-size: 0.8rem;
+  padding: 6px 10px;
 }
 
-
-/* Service Worker Toggle */
-/* Hide the original checkbox input */
+/* --------------------------------------------------
+   Icon Toggles & Admin Labels
+   -------------------------------------------------- */
 #sw-toggle {
-    display: none;
+  display: none;
 }
 
-/* Style the label to act as a clickable icon */
 #toggle-widget-menu,
 #localStorage-edit-button,
 .icon-checkbox {
-    cursor: pointer;
-    font-size: 1.2rem; /* Adjust the icon size */
-    display: inline-block;
-    user-select: none;
+  display: inline-block;
+  cursor: pointer;
+  font-size: 1.2rem;
+  user-select: none;
 }
 
 #admin-control label {
-    position: relative;
+  position: relative;
+  cursor: pointer;
+  transition: font-size 0.2s;
 }
-
 #admin-control label:hover {
-    font-size: 1.4rem;
+  font-size: 1.4rem;
+}
+#admin-control label:hover::after {
+  content: attr(aria-label);
+  position: absolute;
+  top: 2.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  z-index: 10;
 }
 
-#admin-control label:hover::after {
-    content: attr(aria-label);
-    position: absolute;
-    top: 2.5rem;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.8);
-    color: #fff;
-    padding: 2px 6px;
-    border-radius: 4px;
-    font-size: 0.8rem;
-    white-space: nowrap;
-    z-index: 10;
+/* --------------------------------------------------
+   Widget-Selector Panel
+   -------------------------------------------------- */
+#widget-selector-panel {
+  align-items: center;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+#widget-search {
+  flex: 1 1 auto;
+}
+
+#widget-count {
+  margin-left: auto;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+#widget-dropdown-toggle {
+  cursor: pointer;
+  user-select: none;
+  transition: transform 0.2s ease;
+}
+#widget-selector-panel.open #widget-dropdown-toggle {
+  transform: rotate(180deg);
+}
+
+/* --------------------------------------------------
+   Widget Options (hover, select, actions)
+   -------------------------------------------------- */
+#widget-selector-panel .widget-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  transition: background-color 0.2s, transform 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+}
+
+#widget-selector-panel .widget-option > span:first-child {
+  flex: 1 1 auto;
+  margin-right: 0.5rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+#widget-selector-panel .widget-option:hover {
+  background-color: #eef7ff;
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+#widget-selector-panel .widget-option.selected {
+  background-color: #e0f7fa;
+  outline: 2px solid #31a840;
+  transform: scale(1.01);
+}
+
+/* Actions (🔍 ✏️ ❌) */
+#widget-selector-panel .widget-option-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  opacity: 0;
+  pointer-events: none;
+  position: relative;
+  z-index: 1;
+  transition: opacity 0.15s ease;
+}
+#widget-selector-panel .widget-option:hover .widget-option-actions,
+#widget-selector-panel .widget-option.selected .widget-option-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#widget-selector-panel .widget-option-actions button {
+  background: none;
+  border: none;
+  padding: 0.2rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+#widget-selector-panel .widget-option-actions button:hover {
+  transform: scale(1.2);
+  background-color: rgba(0,0,0,0.05);
+}
+#widget-selector-panel .widget-option-actions button[data-action="navigate"]:hover {
+  transform: scale(1.2) rotate(10deg);
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -111,6 +111,7 @@ main {
     background-color: #f1f1f1;
 }
 
-.dropdown:hover .dropdown-content {
+.dropdown:hover .dropdown-content,
+.dropdown.open .dropdown-content {
     display: block;
 }

--- a/src/utils/fetchServices.js
+++ b/src/utils/fetchServices.js
@@ -82,21 +82,7 @@ export const fetchServices = async () => {
   services = services || []
   localStorage.setItem(STORAGE_KEY, JSON.stringify(services))
   window.asd.services = services
-
-  const serviceSelector = document.getElementById('service-selector')
-  if (serviceSelector) {
-    serviceSelector.innerHTML = ''
-    const defaultOption = document.createElement('option')
-    defaultOption.value = ''
-    defaultOption.textContent = 'Select a Service'
-    serviceSelector.appendChild(defaultOption)
-    services.forEach(service => {
-      const option = document.createElement('option')
-      option.value = service.url
-      option.textContent = service.name
-      serviceSelector.appendChild(option)
-    })
-  }
+  document.dispatchEvent(new CustomEvent('services-updated'))
 
   return services
 }

--- a/symbols.json
+++ b/symbols.json
@@ -582,6 +582,20 @@
     "returns": "HTMLElement|undefined"
   },
   {
+    "name": "findWidgetLocation",
+    "kind": "function",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Locate the board and view containing a widget id.",
+    "params": [
+      {
+        "name": "id",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "{boardId:string, viewId:string}|null"
+  },
+  {
     "name": "get",
     "kind": "function",
     "file": "src/component/widget/widgetStore.js",
@@ -1062,6 +1076,14 @@
     "returns": "void"
   },
   {
+    "name": "initializeWidgetSelectorPanel",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Set up click handler for selecting services.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "initSW",
     "kind": "function",
     "file": "src/component/menu/menu.js",
@@ -1247,6 +1269,25 @@
     "returns": "void"
   },
   {
+    "name": "openEditServiceModal",
+    "kind": "function",
+    "file": "src/component/modal/editServiceModal.js",
+    "description": "Open a modal allowing the user to edit a service definition.",
+    "params": [
+      {
+        "name": "service",
+        "type": "import('../../types.js').Service",
+        "desc": "- Service to edit."
+      },
+      {
+        "name": "onClose",
+        "type": "Function",
+        "desc": "- Callback when modal closes."
+      }
+    ],
+    "returns": "void"
+  },
+  {
     "name": "openEvictionModal",
     "kind": "function",
     "file": "src/component/modal/evictionModal.js",
@@ -1325,17 +1366,32 @@
     "name": "openSaveServiceModal",
     "kind": "function",
     "file": "src/component/modal/saveServiceModal.js",
-    "description": "Open a modal allowing the user to name and store a service URL.",
+    "description": "Open a modal to create or edit a service definition.",
     "params": [
       {
-        "name": "url",
-        "type": "string",
-        "desc": "- The service URL to save."
+        "name": "options",
+        "type": "object",
+        "desc": "- Modal configuration."
       },
       {
-        "name": "onClose",
+        "name": "options.mode",
+        "type": "'new'|'edit'",
+        "desc": ""
+      },
+      {
+        "name": "options.service",
+        "type": "import('../../types.js').Service",
+        "desc": ""
+      },
+      {
+        "name": "options.url",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "options.onClose",
         "type": "Function",
-        "desc": "- Callback when the modal closes."
+        "desc": ""
       }
     ],
     "returns": "void"
@@ -1387,6 +1443,22 @@
     "kind": "function",
     "file": "src/component/menu/dashboardMenu.js",
     "description": "Populate the service drop-down with saved services.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "populateWidgetSelectorPanel",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Populate dropdown list with saved services.",
+    "params": [],
+    "returns": "void"
+  },
+  {
+    "name": "refreshRowCounts",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Update the instance count labels for each service row.",
     "params": [],
     "returns": "void"
   },
@@ -1835,6 +1907,14 @@
         "desc": "- Identifier of the board whose views will be shown."
       }
     ],
+    "returns": "void"
+  },
+  {
+    "name": "updateWidgetCounter",
+    "kind": "function",
+    "file": "src/component/menu/widgetSelectorPanel.js",
+    "description": "Update the Active/Max counter in the panel.",
+    "params": [],
     "returns": "void"
   },
   {

--- a/tests/saveAndUseService.spec.ts
+++ b/tests/saveAndUseService.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking.js'
+import { ensurePanelOpen } from './shared/common'
 
 const saved = [{ name: 'Saved Service', url: 'http://localhost/saved' }]
 
@@ -11,11 +12,11 @@ test.describe('Use saved service', () => {
     await routeServicesConfig(page)
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
+    await ensurePanelOpen(page)
   })
 
   test('selects saved service and adds widget', async ({ page }) => {
-    await page.selectOption('#service-selector', { label: saved[0].name })
-    await page.click('#add-widget-button')
+    await page.click(`#widget-selector-panel .widget-option:has-text("${saved[0].name}")`)
     const iframe = page.locator('.widget-wrapper iframe').first()
     await expect(iframe).toHaveAttribute('src', saved[0].url)
   })

--- a/tests/saveServiceModal.spec.ts
+++ b/tests/saveServiceModal.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking.js'
+import { ensurePanelOpen } from './shared/common'
 
 
 test.describe('Save Service Modal', () => {
@@ -7,30 +8,30 @@ test.describe('Save Service Modal', () => {
     await routeServicesConfig(page)
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
+    await ensurePanelOpen(page)
   })
 
   test('opens when adding widget with manual URL', async ({ page }) => {
-    await page.fill('#widget-url', 'http://localhost/manual')
-    await page.click('#add-widget-button')
+    await page.click('#widget-selector-panel .new-service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
-    await expect(modal.locator('input#save-service-name')).toBeVisible()
+    await expect(modal.locator('input#service-name')).toBeVisible()
   })
 
   test('saves manual service when confirmed', async ({ page }) => {
     const url = 'http://localhost/manual-save'
-    await page.fill('#widget-url', url)
-    await page.click('#add-widget-button')
+    await page.click('#widget-selector-panel .new-service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
-    await page.fill('#save-service-name', 'Manual Service')
-    await page.click('#save-service-modal button:has-text("Save & Close")')
+    await page.fill('#service-name', 'Manual Service')
+    await page.fill('#service-url', url)
+    await page.click('#save-service-modal button:has-text("Save")')
     await expect(modal).toBeHidden()
 
     const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
     expect(services.some(s => s.url === url && s.name === 'Manual Service')).toBeTruthy()
 
-    const options = await page.$$eval('#service-selector option', opts => opts.map(o => o.textContent))
+    const options = await page.$$eval('#widget-selector-panel .widget-option', opts => opts.map(o => (o as HTMLElement).dataset.label || o.textContent))
     expect(options).toContain('Manual Service')
 
     const iframe = page.locator('.widget-wrapper iframe').first()
@@ -39,17 +40,18 @@ test.describe('Save Service Modal', () => {
 
   test('skipping manual service does not store it', async ({ page }) => {
     const url = 'http://localhost/manual-skip'
-    await page.fill('#widget-url', url)
-    await page.click('#add-widget-button')
+    await page.click('#widget-selector-panel .new-service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
-    await page.click('#save-service-modal button:has-text("Skip")')
+    await page.fill('#service-name', 'Manual Service')
+    await page.fill('#service-url', url)
+    await page.click('#save-service-modal button:has-text("Cancel")')
     await expect(modal).toBeHidden()
 
     const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
     expect(services.some(s => s.url === url)).toBeFalsy()
 
-    const options = await page.$$eval('#service-selector option', opts => opts.map(o => o.textContent))
+    const options = await page.$$eval('#widget-selector-panel .widget-option', opts => opts.map(o => (o as HTMLElement).dataset.label || o.textContent))
     expect(options).not.toContain('Manual Service')
 
     const iframe = page.locator('.widget-wrapper iframe').first()

--- a/tests/serviceEditDelete.spec.ts
+++ b/tests/serviceEditDelete.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+import { ensurePanelOpen } from './shared/common'
+
+
+test.describe('Service Edit/Delete', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+    await page.waitForLoadState('domcontentloaded')
+    await ensurePanelOpen(page)
+  })
+
+  test('edit service updates list', async ({ page }) => {
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox") button[data-action="edit"]')
+    const modal = page.locator('#save-service-modal')
+    await expect(modal).toBeVisible()
+    await page.fill('#service-name', 'Toolbox X')
+    await page.fill('#service-url', 'http://localhost/x')
+    await page.click('#save-service-modal button:has-text("Save")')
+    await expect(modal).toBeHidden()
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services')))
+    expect(services.some(s => s.name === 'Toolbox X' && s.url === 'http://localhost/x')).toBeTruthy()
+    await expect(page.locator('#widget-selector-panel .widget-option')).toContainText('Toolbox X')
+  })
+
+  test('delete service removes widgets', async ({ page }) => {
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-terminal")')
+    await expect(page.locator('.widget-wrapper')).toHaveCount(1)
+
+    page.on('dialog', d => d.accept())
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-terminal") button[data-action="remove"]')
+    await page.waitForSelector('.widget-wrapper', { state: 'detached' })
+
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services')))
+    expect(services.find(s => s.name === 'ASD-terminal')).toBeUndefined()
+  })
+})

--- a/tests/shared/common.ts
+++ b/tests/shared/common.ts
@@ -1,16 +1,23 @@
 import { type Page, expect } from '@playwright/test';
 
+export async function ensurePanelOpen(page: Page) {
+    await page.evaluate(() => (window as any).__openWidgetPanel?.());
+    await page.waitForSelector('#widget-selector-panel.open');
+}
+
 // Helper function to add services
 export async function addServices(page: Page, count: number) {
+    await ensurePanelOpen(page);
+    await page.click('#widget-dropdown-toggle');
     for (let i = 0; i < count; i++) {
-      await page.selectOption('#service-selector', { index: i + 1 });
-      await page.click('#add-widget-button');
+      await page.locator('#widget-selector-panel .widget-option').nth(i + 1).click();
     }
   }
-  
+
 export async function selectServiceByName(page: Page, serviceName: string) {
-    await page.selectOption('#service-selector', { label: serviceName });
-    await page.click('#add-widget-button');
+    await ensurePanelOpen(page);
+    await page.click('#widget-dropdown-toggle');
+    await page.click(`#widget-selector-panel .widget-option:has-text("${serviceName}")`);
 }
 
 // Helper function to handle dialog interactions

--- a/tests/widgetCounter.spec.ts
+++ b/tests/widgetCounter.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+
+
+test.describe('Widget counters', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.addInitScript(() => {
+      const apply = () => {
+        if (window.asd?.widgetStore) {
+          window.asd.widgetStore.maxSize = 1
+        } else {
+          setTimeout(apply, 0)
+        }
+      }
+      apply()
+    })
+    await page.goto('/')
+    await page.waitForSelector('#widget-selector-panel')
+  })
+
+  test('row and global counts update', async ({ page }) => {
+    await page.click('#widget-dropdown-toggle')
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')
+    await page.locator('.widget-wrapper').first().waitFor()
+
+    await expect(page.locator('#widget-count')).toHaveText('Active: 1 / Max: 1')
+
+    await page.click('#widget-dropdown-toggle')
+    const row = page.locator('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')
+    await expect(row).toContainText('(1/20)')
+    await row.click()
+    await expect(page.locator('.widget-wrapper')).toHaveCount(1)
+  })
+})

--- a/tests/widgetLimits.spec.ts
+++ b/tests/widgetLimits.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "./fixtures";
 import { ciConfig } from "./data/ciConfig";
 import { ciServices } from "./data/ciServices";
+import { ensurePanelOpen } from "./shared/common";
 
 async function routeLimits(page, boards, services, maxSize = 2) {
   await page.route("**/services.json", (route) =>
@@ -55,13 +56,13 @@ test.describe("Widget limits", () => {
     const services = ciServices.map((s) =>
       s.name === "ASD-toolbox" ? { ...s, maxInstances: 1 } : s,
     );
-    await routeLimits(page, boards, services, 5);
-    await page.goto("/");
-    await page.locator(".widget-wrapper").first().waitFor();
+  await routeLimits(page, boards, services, 5);
+  await page.goto("/");
+  await page.locator(".widget-wrapper").first().waitFor();
+  await ensurePanelOpen(page);
 
     await page.locator("#board-selector").selectOption("b2");
-    await page.selectOption("#service-selector", { label: "ASD-toolbox" });
-    await page.click("#add-widget-button");
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox")');
 
     await page.waitForFunction(() =>
       document.querySelectorAll('.widget-wrapper').length === 1
@@ -86,12 +87,12 @@ test.describe("Widget limits", () => {
         views: [{ id: "v", name: "V", widgetState }],
       },
     ];
-    await routeLimits(page, boards, ciServices, 1);
-    await page.goto("/");
-    await page.locator(".widget-wrapper").first().waitFor();
+  await routeLimits(page, boards, ciServices, 1);
+  await page.goto("/");
+  await page.locator(".widget-wrapper").first().waitFor();
+  await ensurePanelOpen(page);
 
-    await page.selectOption("#service-selector", { label: "ASD-terminal" });
-    await page.click("#add-widget-button");
+    await page.click('#widget-selector-panel .widget-option:has-text("ASD-terminal")');
 
     const modal = page.locator("#eviction-modal");
     await expect(modal).toBeVisible();
@@ -115,9 +116,10 @@ test.describe("Widget limits", () => {
     const services = ciServices.map((s) =>
       s.name === 'ASD-toolbox' ? { ...s, maxInstances: 1 } : s
     );
-    await routeLimits(page, boards, services, 5);
-    await page.goto('/');
-    await page.waitForSelector('#service-selector');
+  await routeLimits(page, boards, services, 5);
+  await page.goto('/');
+  await page.waitForSelector('#widget-selector-panel');
+  await ensurePanelOpen(page);
 
     await page.evaluate(async () => {
       const { addWidget } = await import('/component/widget/widgetManagement.js');

--- a/tests/widgetSearch.spec.ts
+++ b/tests/widgetSearch.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking.js'
+
+
+test.describe('Widget search filter', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+    await page.waitForSelector('#widget-selector-panel')
+  })
+
+  test('typing filters widget options', async ({ page }) => {
+    const options = page.locator('#widget-selector-panel .widget-option')
+    await expect(options).toHaveCount(5)
+
+    await page.fill('#widget-search', 'terminal')
+
+    const visible = page.locator('#widget-selector-panel .widget-option:not(.new-service):visible')
+    await expect(visible).toHaveCount(1)
+    await expect(visible.first()).toContainText('ASD-terminal')
+    await expect(page.locator('#widget-selector-panel .widget-option.new-service')).toBeVisible()
+  })
+})


### PR DESCRIPTION

- Introduced `widgetSelectorPanel` with full support for subcategory search, tag matching, and keyboard navigation.
- Replaced service `<select>` and manual URL input with unified interactive panel and counter.
- Enforced `maxInstances` limits by disabling add actions and applying `.limit-reached` class.
- Integrated locate, edit, and delete buttons for each saved service row using emoji actions (🔍 ✏️ ⛔).
- Refactored `saveServiceModal` to support both 'new' and 'edit' modes with full metadata.
- Added `editServiceModal` for backwards-compatible editing workflows.
- Updated tests to target new UI, including search filter, limit enforcement, and modal flows.
- Removed legacy `populateServiceDropdown` and related DOM logic.