### PR TITLE
Refactor board state management

### DIFF
--- a/src/component/board/boardDropdown.js
+++ b/src/component/board/boardDropdown.js
@@ -7,6 +7,7 @@
 import { createBoard, renameBoard, deleteBoard, updateViewSelector } from './boardManagement.js'
 import { initializeDropdown } from '../utils/dropDownUtils.js'
 import { Logger } from '../../utils/Logger.js'
+import StorageManager from '../../storage/StorageManager.js'
 
 const logger = new Logger('boardDropdown.js')
 
@@ -76,8 +77,9 @@ async function handleDeleteBoard () {
     try {
       await deleteBoard(boardId)
       logger.log('Board deleted:', boardId)
-      if (window.asd.boards.length > 0) {
-        updateViewSelector(window.asd.boards[0].id)
+      const boards = StorageManager.getBoards()
+      if (boards.length > 0) {
+        updateViewSelector(boards[0].id)
       }
     } catch (error) {
       logger.error('Error deleting board:', error)

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -92,7 +92,7 @@ function initializeDashboardMenu () {
       // 4. Save only the updated config, but let's do better (see Rec 2)
       // This still has the side-effect problem, but at least the data is less stale.
       // The BEST fix is to change StorageManager.
-      StorageManager.setConfig(window.asd.config)
+      StorageManager.setConfig(updatedConfig)
     }
     // --- FIX ENDS HERE ---
 

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -24,6 +24,7 @@ import { Logger } from '../../utils/Logger.js'
 import { showServiceModal } from '../modal/serviceLaunchModal.js'
 import { switchBoard } from '../board/boardManagement.js'
 import { widgetGetUUID } from '../../utils/id.js'
+import StorageManager from '../../storage/StorageManager.js'
 
 const logger = new Logger('widgetManagement.js')
 
@@ -321,7 +322,7 @@ function updateWidgetOrders () {
  * @returns {{boardId:string, viewId:string}|null}
  */
 function findWidgetLocation (id) {
-  const boards = window.asd.boards || []
+  const boards = StorageManager.getBoards()
   for (const board of boards) {
     for (const view of board.views) {
       if (view.widgetState.some((w) => w.dataid === id)) {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,7 +5,6 @@ declare global {
     asd: {
       services: import('./types.js').Service[];
       config: import('./types.js').DashboardConfig;
-      boards: import('./types.js').Board[];
       currentBoardId: string | null;
       currentViewId: string | null;
       widgetStore: import('./component/widget/widgetStore.js').WidgetStore;

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,6 @@ Logger.enableLogs('all')
 window.asd = {
   services: [],
   config: {},
-  boards: [],
   currentBoardId: null,
   currentViewId: null,
   widgetStore
@@ -71,12 +70,14 @@ async function main () {
   applyControlVisibility()
   applyWidgetMenuVisibility()
 
-  // 5. Load boards from storage into the global state.
-  window.asd.boards = StorageManager.getBoards()
+  // 5. Load boards from storage.
+  let boards = StorageManager.getBoards()
   // If no boards exist and config specifies to load from itself, do so.
-  if (window.asd.boards.length === 0 && window.asd.config.globalSettings?.localStorage?.loadDashboardFromConfig === 'true') {
-    if (Array.isArray(window.asd.config.boards) && window.asd.config.boards.length > 0) {
-      StorageManager.setBoards(window.asd.config.boards)
+  if (boards.length === 0 && window.asd.config.globalSettings?.localStorage?.loadDashboardFromConfig === 'true') {
+    const cfgBoards = (StorageManager.getConfig() || {}).boards || []
+    if (Array.isArray(cfgBoards) && cfgBoards.length > 0) {
+      StorageManager.setBoards(cfgBoards)
+      boards = cfgBoards
     }
   }
 
@@ -86,7 +87,7 @@ async function main () {
   const lastUsedBoardId = StorageManager.misc.getLastBoardId()
   const lastUsedViewId = StorageManager.misc.getLastViewId()
 
-  const boardExists = window.asd.boards.some(board => board.id === lastUsedBoardId)
+  const boardExists = StorageManager.getBoards().some(board => board.id === lastUsedBoardId)
 
   let boardIdToLoad = initialBoardView?.boardId
   let viewIdToLoad = initialBoardView?.viewId

--- a/src/storage/StorageManager.js
+++ b/src/storage/StorageManager.js
@@ -94,8 +94,7 @@ const StorageManager = {
    */
   getBoards () {
     const boards = jsonGet(KEYS.BOARDS, [])
-    window.asd.boards = Array.isArray(boards) ? boards : []
-    return window.asd.boards
+    return Array.isArray(boards) ? boards : []
   },
 
   /**
@@ -106,7 +105,6 @@ const StorageManager = {
    */
   setBoards (boards) {
     jsonSet(KEYS.BOARDS, boards)
-    window.asd.boards = Array.isArray(boards) ? boards : []
   },
 
   /**

--- a/src/storage/widgetStatePersister.js
+++ b/src/storage/widgetStatePersister.js
@@ -54,7 +54,8 @@ export function saveWidgetState (boardId, viewId) {
 
   try {
     // ALWAYS operate on the in-memory "live" state.
-    const board = window.asd.boards.find(b => b.id === boardId)
+    const currentBoards = StorageManager.getBoards()
+    const board = currentBoards.find(b => b.id === boardId)
     if (!board) return logger.error(`Board not found for saving state: ${boardId}`)
 
     const view = board.views.find(v => v.id === viewId)
@@ -79,7 +80,7 @@ export function saveWidgetState (boardId, viewId) {
     view.widgetState = sortedVisibleWidgets.map(widget => serializeWidgetState(/** @type {HTMLElement} */(widget)))
 
     // Persist the entire updated boards structure.
-    StorageManager.setBoards(window.asd.boards)
+    StorageManager.setBoards(currentBoards)
 
     logger.info(`Saved widget state for view: ${viewId} in board: ${boardId}`)
   } catch (error) {

--- a/symbols.json
+++ b/symbols.json
@@ -1208,22 +1208,6 @@
     "returns": "void"
   },
   {
-    "name": "load",
-    "kind": "function",
-    "file": "src/storage/servicesStore.js",
-    "description": "Loads the array of services from localStorage.",
-    "params": [],
-    "returns": "Array<import('../types.js').Service>"
-  },
-  {
-    "name": "loadBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Retrieves the array of boards from localStorage.",
-    "params": [],
-    "returns": "Promise<Array<import('../types.js').Board>>"
-  },
-  {
     "name": "loadFromFragment",
     "kind": "function",
     "file": "src/utils/fragmentLoader.js",
@@ -1238,14 +1222,6 @@
     "description": "Loads configuration from various sources in a specific order: URL params, localStorage, then a default file.",
     "params": [],
     "returns": "Promise<object|null>"
-  },
-  {
-    "name": "loadInitialConfig",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Loads the initial board configuration from the global config object into localStorage. This is typically called on first run to seed the dashboard.",
-    "params": [],
-    "returns": "Promise<void>"
   },
   {
     "name": "loadStateStore",
@@ -1646,34 +1622,6 @@
     "returns": "Promise<void>"
   },
   {
-    "name": "save",
-    "kind": "function",
-    "file": "src/storage/servicesStore.js",
-    "description": "Saves the array of services to localStorage.",
-    "params": [
-      {
-        "name": "services",
-        "type": "Array<import('../types.js').Service>",
-        "desc": "- The array of services to save."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "saveBoardState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Persists the entire array of board objects to localStorage.",
-    "params": [
-      {
-        "name": "boards",
-        "type": "Array<import('../types.js').Board>",
-        "desc": "- The array of boards to save."
-      }
-    ],
-    "returns": "void"
-  },
-  {
     "name": "saveLocalStorageData",
     "kind": "function",
     "file": "src/component/modal/localStorageModal.js",
@@ -1714,39 +1662,6 @@
       }
     ],
     "returns": "Promise<void>"
-  },
-  {
-    "name": "saveWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Serializes the state of all visible widgets and saves it to localStorage.",
-    "params": [
-      {
-        "name": "boardId",
-        "type": "string",
-        "desc": "- The ID of the current board."
-      },
-      {
-        "name": "viewId",
-        "type": "string",
-        "desc": "- The ID of the current view."
-      }
-    ],
-    "returns": "void"
-  },
-  {
-    "name": "serializeWidgetState",
-    "kind": "function",
-    "file": "src/storage/localStorage.js",
-    "description": "Converts a widget DOM element into a serializable state object.",
-    "params": [
-      {
-        "name": "widget",
-        "type": "HTMLElement",
-        "desc": "- The widget element."
-      }
-    ],
-    "returns": "import('../types.js').Widget"
   },
   {
     "name": "setBoards",

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -29,7 +29,10 @@ test.describe('Dashboard Config - Base64 via URL Params', () => {
     const services = b64(ciServices);
     await page.goto(`/?config_base64=${config}&services_base64=${services}`);
     await expect(page.locator('#service-selector option')).toHaveCount(ciServices.length + 1);
-    const boards = await page.evaluate(() => window.asd.boards);
+    const boards = await page.evaluate(() => {
+      const raw = localStorage.getItem('boards') || '[]';
+      return JSON.parse(raw);
+    });
     expect(boards.length).toBe(ciBoards.length);
     const names = await page.$$eval('#board-selector option', opts => opts.map(o => o.textContent));
     expect(names).toContain(ciBoards[0].name);

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -13,14 +13,12 @@ test.describe('StorageManager', () => {
     const result = await page.evaluate(async () => {
       const { default: sm } = await import('/storage/StorageManager.js')
       localStorage.clear()
-      window.asd.boards = []
       const cfg = { boards: [{ id: 'b1', name: 'B1', views: [] }] }
       sm.setConfig(cfg)
       return {
         raw: localStorage.getItem('config'),
         boards: localStorage.getItem('boards'),
-        cfg: sm.getConfig(),
-        globalBoards: window.asd.boards
+        cfg: sm.getConfig()
       }
     })
     expect(JSON.parse(result.raw)).toMatchObject({
@@ -29,7 +27,6 @@ test.describe('StorageManager', () => {
     })
     expect(JSON.parse(result.boards)).toEqual([{ id: 'b1', name: 'B1', views: [] }])
     expect(result.cfg).toEqual({ boards: [{ id: 'b1', name: 'B1', views: [] }] })
-    expect(result.globalBoards).toEqual([{ id: 'b1', name: 'B1', views: [] }])
   })
 
   test('saveStateSnapshot persists and hashes', async ({ page }) => {


### PR DESCRIPTION
## Summary
- remove global board side effects from `StorageManager`
- drop `boards` from global object
- update board management to use `StorageManager` directly
- adjust widget persistence and widget management
- fix dashboard menu lint issue
- update tests for new storage flow

## Testing
- `just format`
- `just check`
- `just test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_b_686bd7d48b308325a6dc4b85aa31c7a3