### PR TITLE
Fix view isolation test race condition

### DIFF
--- a/tests/shared/common.ts
+++ b/tests/shared/common.ts
@@ -1,90 +1,183 @@
-import { type Page, expect } from '@playwright/test';
+import { type Page, expect } from "@playwright/test";
 
 // Helper function to add services
+/**
+ *
+ * @param page
+ * @param count
+ */
 export async function addServices(page: Page, count: number) {
-    for (let i = 0; i < count; i++) {
-      await page.selectOption('#service-selector', { index: i + 1 });
-      await page.click('#add-widget-button');
-    }
+  for (let i = 0; i < count; i++) {
+    await page.selectOption("#service-selector", { index: i + 1 });
+    await page.click("#add-widget-button");
   }
+}
 
+/**
+ * Select a service by its label and click the add widget button.
+ *
+ * @param {Page} page - Playwright page instance.
+ * @param {string} serviceName - Service display name.
+ * @returns {Promise<void>} Resolves when the widget is added.
+ */
 export async function selectServiceByName(page: Page, serviceName: string) {
-    await page.waitForSelector('#service-selector', { timeout: 3000 });
-    await page.selectOption('#service-selector', { label: serviceName });
-    await page.click('#add-widget-button');
+  await page.waitForSelector("#service-selector", { timeout: 3000 });
+  await page.selectOption("#service-selector", { label: serviceName });
+  await page.click("#add-widget-button");
+}
+
+/**
+ * Change the current view by selecting it from the dropdown and
+ * wait until the DOM reflects the new active view.
+ *
+ * @param {Page} page - Playwright page instance.
+ * @param {string} viewLabel - Visible name of the view to select.
+ * @returns {Promise<void>} Resolves when the view is switched.
+ */
+export async function selectViewByLabel(page: Page, viewLabel: string) {
+  const viewSelector = page.locator("#view-selector");
+  const optionValue = await page
+    .locator("#view-selector option", { hasText: viewLabel })
+    .getAttribute("value");
+  await viewSelector.selectOption({ label: viewLabel });
+  if (optionValue) {
+    await page.waitForFunction(
+      (expected) => document.querySelector(".board-view")?.id === expected,
+      optionValue,
+    );
+  }
 }
 
 // Helper function to handle dialog interactions
-export async function handleDialog(page, type, inputText = '') {
-    page.on('dialog', async dialog => {
-      expect(dialog.type()).toBe(type);
-      if (type === 'prompt') {
-        await dialog.accept(inputText);
-      } else {
-        await dialog.accept();
-      }
-    });
-  }
-
-export async function addServicesByName(page: Page, serviceName: string, count: number) {
-    for (let i = 0; i < count; i++) {
-        await selectServiceByName(page, serviceName);
+/**
+ *
+ * @param page
+ * @param type
+ * @param inputText
+ */
+export async function handleDialog(page, type, inputText = "") {
+  page.on("dialog", async (dialog) => {
+    expect(dialog.type()).toBe(type);
+    if (type === "prompt") {
+      await dialog.accept(inputText);
+    } else {
+      await dialog.accept();
     }
+  });
 }
 
+/**
+ *
+ * @param page
+ * @param serviceName
+ * @param count
+ */
+export async function addServicesByName(
+  page: Page,
+  serviceName: string,
+  count: number,
+) {
+  for (let i = 0; i < count; i++) {
+    await selectServiceByName(page, serviceName);
+  }
+}
+
+/**
+ *
+ * @param obj
+ */
 export function b64(obj: any) {
-  return Buffer.from(JSON.stringify(obj)).toString('base64');
+  return Buffer.from(JSON.stringify(obj)).toString("base64");
 }
 
+/**
+ *
+ * @param page
+ */
 export async function clearStorage(page) {
-  await page.goto('/');
+  await page.goto("/");
   await page.evaluate(() => localStorage.clear());
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getUnwrappedConfig(page) {
   return await page.evaluate(() => {
-    const raw = localStorage.getItem('config');
+    const raw = localStorage.getItem("config");
     const parsed = raw ? JSON.parse(raw) : null;
 
     const cfg = parsed?.data || parsed;
 
-    if (!cfg || typeof cfg !== 'object') return { boards: [] };
+    if (!cfg || typeof cfg !== "object") return { boards: [] };
     if (!Array.isArray(cfg.boards)) cfg.boards = [];
 
     return cfg;
   });
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getConfigBoards(page) {
   const cfg = await getUnwrappedConfig(page);
   return Array.isArray(cfg.boards) ? cfg.boards : [];
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getConfigTheme(page) {
   const cfg = await getUnwrappedConfig(page);
   return cfg?.globalSettings?.theme;
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getBoardWithWidgets(page) {
   const cfg = await getUnwrappedConfig(page);
   const boards = Array.isArray(cfg.boards) ? cfg.boards : [];
-  return boards.find(b => b.views?.some(v => v.widgetState?.length > 0))?.id || null;
+  return (
+    boards.find((b) => b.views?.some((v) => v.widgetState?.length > 0))?.id ||
+    null
+  );
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getBoardCount(page) {
   const cfg = await getUnwrappedConfig(page);
   return Array.isArray(cfg.boards) ? cfg.boards.length : 0;
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getShowMenuWidgetFlag(page) {
   const cfg = await getUnwrappedConfig(page);
   return !!cfg?.globalSettings?.showMenuWidget;
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getLastUsedViewId(page) {
-  return await page.evaluate(() => localStorage.getItem('lastUsedViewId'));
+  return await page.evaluate(() => localStorage.getItem("lastUsedViewId"));
 }
 
+/**
+ *
+ * @param page
+ */
 export async function getLastUsedBoardId(page) {
-  return await page.evaluate(() => localStorage.getItem('lastUsedBoardId'));
+  return await page.evaluate(() => localStorage.getItem("lastUsedBoardId"));
 }

--- a/tests/viewStateIsolation.spec.ts
+++ b/tests/viewStateIsolation.spec.ts
@@ -1,100 +1,107 @@
 // @ts-check
-import { test, expect } from './fixtures';
-import { routeServicesConfig } from './shared/mocking.js';
-import { selectServiceByName } from './shared/common.js';
+import { test, expect } from "./fixtures";
+import { routeServicesConfig } from "./shared/mocking.js";
+import { selectServiceByName, selectViewByLabel } from "./shared/common.js";
 
 // Define a deterministic initial state with a clean board and two empty views.
 const initialBoards = [
   {
-    id: 'board-iso-test-1',
-    name: 'State Isolation Test Board',
+    id: "board-iso-test-1",
+    name: "State Isolation Test Board",
     order: 0,
     views: [
       {
-        id: 'view-A',
-        name: 'View A',
-        widgetState: []
+        id: "view-A",
+        name: "View A",
+        widgetState: [],
       },
       {
-        id: 'view-B',
-        name: 'View B',
-        widgetState: []
-      }
-    ]
-  }
+        id: "view-B",
+        name: "View B",
+        widgetState: [],
+      },
+    ],
+  },
 ];
 
-test.describe('Widget State Isolation Between Views', () => {
-
+test.describe("Widget State Isolation Between Views", () => {
   // Before each test, set up the clean environment with our predefined board structure.
   test.beforeEach(async ({ page }) => {
     await routeServicesConfig(page);
 
     // Use addInitScript to set localStorage *before* the page loads.
     // This ensures the application initializes with our test state.
-    await page.addInitScript(({ boards, services }) => {
-      localStorage.clear();
-      localStorage.setItem('config', JSON.stringify({ boards }));
-      localStorage.setItem('services', JSON.stringify(services));
-      localStorage.setItem('lastUsedBoardId', 'board-iso-test-1');
-      localStorage.setItem('lastUsedViewId', 'view-A');
-    }, {
-      boards: initialBoards,
-      services: [
-        { name: 'ASD-toolbox', url: 'http://localhost:8000/asd/toolbox' },
-        { name: 'ASD-terminal', url: 'http://localhost:8000/asd/terminal' }
-      ]
-    });
+    await page.addInitScript(
+      ({ boards, services }) => {
+        localStorage.clear();
+        localStorage.setItem("config", JSON.stringify({ boards }));
+        localStorage.setItem("services", JSON.stringify(services));
+        localStorage.setItem("lastUsedBoardId", "board-iso-test-1");
+        localStorage.setItem("lastUsedViewId", "view-A");
+      },
+      {
+        boards: initialBoards,
+        services: [
+          { name: "ASD-toolbox", url: "http://localhost:8000/asd/toolbox" },
+          { name: "ASD-terminal", url: "http://localhost:8000/asd/terminal" },
+        ],
+      },
+    );
 
-    await page.goto('/');
-    await page.waitForSelector('body[data-ready="true"]', { timeout: 2000 });
+    await page.goto("/");
+    await page.waitForSelector('body[data-ready="true"]', { timeout: 10000 });
   });
 
-  test('widgets added to one view should not appear in another view after switching', async ({ page }) => {
+  test("widgets added to one view should not appear in another view after switching", async ({
+    page,
+  }) => {
     // Define locators for the widgets we'll be adding.
-    const widgetToolbox = page.locator('.widget-wrapper[data-service="ASD-toolbox"]');
-    const widgetTerminal = page.locator('.widget-wrapper[data-service="ASD-terminal"]');
-    const viewSelector = page.locator('#view-selector');
+    const widgetToolbox = page.locator(
+      '.widget-wrapper[data-service="ASD-toolbox"]',
+    );
+    const widgetTerminal = page.locator(
+      '.widget-wrapper[data-service="ASD-terminal"]',
+    );
+    const viewSelector = page.locator("#view-selector");
 
     // --- STEP 1: Add a widget to View A ---
-    await viewSelector.selectOption({ label: 'View A' });
-    await selectServiceByName(page, 'ASD-toolbox');
+    await selectViewByLabel(page, "View A");
+    await selectServiceByName(page, "ASD-toolbox");
 
     // VERIFY (View A): Toolbox widget is visible, and it's the only one.
     await expect(widgetToolbox).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+    await expect(page.locator(".widget-wrapper:visible")).toHaveCount(1);
 
     // --- STEP 2: Switch to View B ---
-    await viewSelector.selectOption({ label: 'View B' });
+    await selectViewByLabel(page, "View B");
 
     // VERIFY (View B): The container is now empty. The Toolbox widget should be hidden.
     await expect(widgetToolbox).toBeHidden();
-    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(0);
+    await expect(page.locator(".widget-wrapper:visible")).toHaveCount(0);
 
     // --- STEP 3: Add a different widget to View B ---
-    await selectServiceByName(page, 'ASD-terminal');
+    await selectServiceByName(page, "ASD-terminal");
 
     // VERIFY (View B): Terminal widget is visible, Toolbox is still hidden.
     await expect(widgetTerminal).toBeVisible();
     await expect(widgetToolbox).toBeHidden();
-    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+    await expect(page.locator(".widget-wrapper:visible")).toHaveCount(1);
 
     // --- STEP 4: Switch back to View A ---
-    await viewSelector.selectOption({ label: 'View A' });
+    await selectViewByLabel(page, "View A");
 
     // CRITICAL VERIFICATION:
     // Ensure View A shows ONLY the Toolbox widget. The Terminal widget must now be hidden.
     await expect(widgetToolbox).toBeVisible();
     await expect(widgetTerminal).toBeHidden();
-    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+    await expect(page.locator(".widget-wrapper:visible")).toHaveCount(1);
 
     // --- FINAL CHECK: Switch back to View B one last time ---
-    await viewSelector.selectOption({ label: 'View B' });
+    await selectViewByLabel(page, "View B");
 
     // VERIFY (View B): Correctly shows only the Terminal widget.
     await expect(widgetToolbox).toBeHidden();
     await expect(widgetTerminal).toBeVisible();
-    await expect(page.locator('.widget-wrapper:visible')).toHaveCount(1);
+    await expect(page.locator(".widget-wrapper:visible")).toHaveCount(1);
   });
-  
 });


### PR DESCRIPTION
## Summary
- wait for the board view id to update when changing views
- use new helper in viewStateIsolation test
- allow more time for page initialization

## Testing
- `npx eslint tests/shared/common.ts tests/viewStateIsolation.spec.ts`
- `npx tsc -p tsconfig.json --noEmit`
- `npx playwright test tests/viewStateIsolation.spec.ts` *(fails: page.waitForSelector timeout)*

------
https://chatgpt.com/codex/tasks/task_b_686fef5529f483258a67fbf26220ad31