### PR TITLE
Implement event dispatching and logging listener

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -61,9 +61,6 @@ export async function createBoard (boardName, boardId = null, viewId = null) {
   StorageManager.misc.setLastViewId(defaultViewId)
   logger.log(`Saved last used boardId: ${newBoardId} and viewId: ${defaultViewId}`)
 
-  // Update the board selector
-  updateBoardSelector()
-
   return StorageManager.getBoards().find(b => b.id === newBoardId)
 }
 
@@ -355,7 +352,6 @@ export async function renameBoard (boardId, newBoardName) {
 
   if (found) {
     logger.log(`Renamed board ${boardId} to ${newBoardName}`)
-    updateBoardSelector()
   } else {
     logger.error(`Board with ID ${boardId} not found`)
   }
@@ -381,7 +377,6 @@ export async function deleteBoard (boardId) {
 
   if (removed) {
     logger.log(`Deleted board ${boardId}`)
-    updateBoardSelector()
     const boards = StorageManager.getBoards()
     if (boards.length > 0) {
       const firstBoardId = boards[0].id
@@ -427,7 +422,6 @@ export async function renameView (boardId, viewId, newViewName) {
   }
 
   logger.log(`Renamed view ${viewId} to ${newViewName}`)
-  updateViewSelector(boardId)
 }
 
 /**
@@ -468,7 +462,6 @@ export async function deleteView (boardId, viewId) {
   }
 
   logger.log(`Deleted view ${viewId} and evicted its widgets.`)
-  updateViewSelector(boardId)
 
   const board = StorageManager.getBoards().find(b => b.id === boardId)
   if (board && board.views.length > 0) {

--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -526,7 +526,7 @@ export async function resetView (boardId, viewId) {
  * @function updateBoardSelector
  * @returns {void}
  */
-function updateBoardSelector () {
+export function updateBoardSelector () {
   const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   boardSelector.innerHTML = ''
   StorageManager.getBoards().forEach(board => {

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -130,7 +130,7 @@ function initializeDashboardMenu () {
  * @function populateServiceDropdown
  * @returns {void}
  */
-function populateServiceDropdown () {
+export function populateServiceDropdown () {
   const selector = document.getElementById('service-selector')
   if (!selector) return
   selector.innerHTML = ''

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,7 +36,6 @@ function initializeDashboardMenu () {
 
   logger.log('Dashboard menu initialized')
   populateServiceDropdown()
-  document.addEventListener('services-updated', populateServiceDropdown)
   applyWidgetMenuVisibility()
 
   const buttonDebounce = 200

--- a/src/component/modal/saveServiceModal.js
+++ b/src/component/modal/saveServiceModal.js
@@ -39,7 +39,6 @@ export function openSaveServiceModal (url, onClose) {
         const services = StorageManager.getServices()
         services.push({ name, url })
         StorageManager.setServices(services)
-        document.dispatchEvent(new CustomEvent('services-updated'))
         closeModal()
       })
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@
  */
 import { initializeMainMenu, applyControlVisibility } from './component/menu/menu.js'
 import { initializeBoards, switchBoard, updateBoardSelector, updateViewSelector } from './component/board/boardManagement.js'
+import { getCurrentBoardId } from './utils/elements.js'
 import { initializeDashboardMenu, applyWidgetMenuVisibility, populateServiceDropdown } from './component/menu/dashboardMenu.js'
 import { initializeDragAndDrop } from './component/widget/events/dragDrop.js'
 import { fetchServices } from './utils/fetchServices.js'
@@ -102,6 +103,7 @@ async function main () {
   if (boardIdToLoad) {
     logger.log(`Switching to initial board: ${boardIdToLoad}, view: ${viewIdToLoad}`)
     await switchBoard(boardIdToLoad, viewIdToLoad)
+    updateViewSelector(boardIdToLoad)
   } else {
     logger.warn('No boards available to display.')
   }
@@ -118,7 +120,7 @@ async function main () {
     const { reason } = event.detail || {}
     logger.log(`[Event Listener] Reacting to state change. Reason: ${reason || 'unknown'}`)
 
-    const currentBoardId = window.asd.currentBoardId
+    const currentBoardId = getCurrentBoardId()
 
     switch (reason) {
       case 'config':

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,8 @@
  * @module main
  */
 import { initializeMainMenu, applyControlVisibility } from './component/menu/menu.js'
-import { initializeBoards, switchBoard } from './component/board/boardManagement.js'
-import { initializeDashboardMenu, applyWidgetMenuVisibility } from './component/menu/dashboardMenu.js'
+import { initializeBoards, switchBoard, updateBoardSelector, updateViewSelector } from './component/board/boardManagement.js'
+import { initializeDashboardMenu, applyWidgetMenuVisibility, populateServiceDropdown } from './component/menu/dashboardMenu.js'
 import { initializeDragAndDrop } from './component/widget/events/dragDrop.js'
 import { fetchServices } from './utils/fetchServices.js'
 import { getConfig } from './utils/getConfig.js'
@@ -113,15 +113,31 @@ async function main () {
   document.getElementById('localStorage-edit-button').addEventListener('click', /** @type {EventListener} */(handleLocalStorageModal))
   document.getElementById('open-config-modal').addEventListener('click', /** @type {EventListener} */(handleConfigModal))
 
-  // --- PHASE 1: EVENT LISTENER FOR LOGGING ---
-  const logStateChange = (event) => {
+  // --- PHASE 2: ACTIVE EVENT LISTENER ---
+  const onStateChange = (event) => {
     const { reason } = event.detail || {}
-    logger.log(`[Event Listener] Detected state change. Reason: ${reason || 'unknown'}`)
+    logger.log(`[Event Listener] Reacting to state change. Reason: ${reason || 'unknown'}`)
+
+    const currentBoardId = window.asd.currentBoardId
+
+    switch (reason) {
+      case 'config':
+        updateBoardSelector()
+        if (currentBoardId) {
+          updateViewSelector(currentBoardId)
+        }
+        populateServiceDropdown()
+        break
+
+      case 'services':
+        populateServiceDropdown()
+        break
+    }
   }
 
-  const debouncedLogger = debounce(logStateChange, 200)
-  window.addEventListener(APP_STATE_CHANGED, /** @type {EventListener} */(debouncedLogger))
-  logger.log('Passive event listener for state changes has been initialized.')
+  const debouncedUiUpdater = debounce(onStateChange, 150)
+  window.addEventListener(APP_STATE_CHANGED, /** @type {EventListener} */(debouncedUiUpdater))
+  logger.log('Active event listener for state changes has been initialized.')
   // --- END ---
 
   logger.log('Application initialization finished')

--- a/src/main.js
+++ b/src/main.js
@@ -17,8 +17,8 @@ import { initializeViewDropdown } from './component/view/viewDropdown.js'
 import { loadFromFragment } from './utils/fragmentLoader.js'
 import { Logger } from './utils/Logger.js'
 import { widgetStore } from './component/widget/widgetStore.js'
-import { debounceLeading } from './utils/utils.js'
-import StorageManager from './storage/StorageManager.js'
+import { debounce, debounceLeading } from './utils/utils.js'
+import StorageManager, { APP_STATE_CHANGED } from './storage/StorageManager.js'
 
 const logger = new Logger('main.js')
 
@@ -112,6 +112,17 @@ async function main () {
   const handleConfigModal = debounceLeading(openConfigModal, buttonDebounce)
   document.getElementById('localStorage-edit-button').addEventListener('click', /** @type {EventListener} */(handleLocalStorageModal))
   document.getElementById('open-config-modal').addEventListener('click', /** @type {EventListener} */(handleConfigModal))
+
+  // --- PHASE 1: EVENT LISTENER FOR LOGGING ---
+  const logStateChange = (event) => {
+    const { reason } = event.detail || {}
+    logger.log(`[Event Listener] Detected state change. Reason: ${reason || 'unknown'}`)
+  }
+
+  const debouncedLogger = debounce(logStateChange, 200)
+  window.addEventListener(APP_STATE_CHANGED, /** @type {EventListener} */(debouncedLogger))
+  logger.log('Passive event listener for state changes has been initialized.')
+  // --- END ---
 
   logger.log('Application initialization finished')
   // Signal to Playwright that the initial load and render is complete.

--- a/src/storage/StorageManager.js
+++ b/src/storage/StorageManager.js
@@ -15,6 +15,12 @@ import { deepMerge } from '../utils/objectUtils.js'
  */
 export const CURRENT_VERSION = 1
 
+/**
+ * Custom event dispatched whenever the application state changes.
+ * @constant {string}
+ */
+export const APP_STATE_CHANGED = 'appStateChanged'
+
 const KEYS = {
   CONFIG: 'config',
   BOARDS: 'boards',
@@ -100,6 +106,7 @@ const StorageManager = {
       version: CURRENT_VERSION,
       data: mergeWithDefaults(cfg)
     })
+    window.dispatchEvent(new CustomEvent(APP_STATE_CHANGED, { detail: { reason: 'config' } }))
   },
 
   /**
@@ -165,6 +172,7 @@ const StorageManager = {
    */
   setServices (services) {
     jsonSet(KEYS.SERVICES, services)
+    window.dispatchEvent(new CustomEvent(APP_STATE_CHANGED, { detail: { reason: 'services' } }))
   },
 
   /**


### PR DESCRIPTION
refactor(ui-sync): centralize board/view/service selector updates via event listener

Moves all `updateBoardSelector`, `updateViewSelector`, and `populateServiceDropdown` calls into a centralized debounced listener tied to `APP_STATE_CHANGED`. Removes redundant UI updates from `boardManagement`, `saveServiceModal`, and `dashboardMenu` components. Ensures consistent UI hydration on state change reasons ('config', 'services').

Also updates `createBoard` and `createView` to persist last used IDs before side effects.

Tested: UI reflects changes after board/view/service mutations; Playwright tests pass.

