### PR TITLE
Update state change listener

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -525,7 +525,7 @@ export async function resetView (boardId, viewId) {
  * @function updateBoardSelector
  * @returns {void}
  */
-function updateBoardSelector () {
+export function updateBoardSelector () {
   const boardSelector = /** @type {HTMLSelectElement} */(document.getElementById('board-selector'))
   boardSelector.innerHTML = ''
   StorageManager.getBoards().forEach(board => {

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -130,7 +130,7 @@ function initializeDashboardMenu () {
  * @function populateServiceDropdown
  * @returns {void}
  */
-function populateServiceDropdown () {
+export function populateServiceDropdown () {
   const selector = document.getElementById('service-selector')
   if (!selector) return
   selector.innerHTML = ''

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,8 @@
  * @module main
  */
 import { initializeMainMenu, applyControlVisibility } from './component/menu/menu.js'
-import { initializeBoards, switchBoard } from './component/board/boardManagement.js'
-import { initializeDashboardMenu, applyWidgetMenuVisibility } from './component/menu/dashboardMenu.js'
+import { initializeBoards, switchBoard, updateBoardSelector, updateViewSelector } from './component/board/boardManagement.js'
+import { initializeDashboardMenu, applyWidgetMenuVisibility, populateServiceDropdown } from './component/menu/dashboardMenu.js'
 import { initializeDragAndDrop } from './component/widget/events/dragDrop.js'
 import { fetchServices } from './utils/fetchServices.js'
 import { getConfig } from './utils/getConfig.js'
@@ -113,15 +113,31 @@ async function main () {
   document.getElementById('localStorage-edit-button').addEventListener('click', /** @type {EventListener} */(handleLocalStorageModal))
   document.getElementById('open-config-modal').addEventListener('click', /** @type {EventListener} */(handleConfigModal))
 
-  // --- PHASE 1: EVENT LISTENER FOR LOGGING ---
-  const logStateChange = (event) => {
+  // --- PHASE 2: ACTIVE EVENT LISTENER ---
+  const onStateChange = (event) => {
     const { reason } = event.detail || {}
-    logger.log(`[Event Listener] Detected state change. Reason: ${reason || 'unknown'}`)
+    logger.log(`[Event Listener] Reacting to state change. Reason: ${reason || 'unknown'}`)
+
+    const currentBoardId = window.asd.currentBoardId
+
+    switch (reason) {
+      case 'config':
+        updateBoardSelector()
+        if (currentBoardId) {
+          updateViewSelector(currentBoardId)
+        }
+        populateServiceDropdown()
+        break
+
+      case 'services':
+        populateServiceDropdown()
+        break
+    }
   }
 
-  const debouncedLogger = debounce(logStateChange, 200)
-  window.addEventListener(APP_STATE_CHANGED, /** @type {EventListener} */(debouncedLogger))
-  logger.log('Passive event listener for state changes has been initialized.')
+  const debouncedUiUpdater = debounce(onStateChange, 150)
+  window.addEventListener(APP_STATE_CHANGED, /** @type {EventListener} */(debouncedUiUpdater))
+  logger.log('Active event listener for state changes has been initialized.')
   // --- END ---
 
   logger.log('Application initialization finished')


### PR DESCRIPTION
## Summary
- export `updateBoardSelector` and `populateServiceDropdown`
- react to `APP_STATE_CHANGED` with UI updates

## Testing
- `npm run lint-fix`
- `npm run check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_b_68700ab50564832586e16d8d902fa2c1