### PR TITLE
Add setLastUsedIds helper

### DIFF
--- a/tests/shared/state.ts
+++ b/tests/shared/state.ts
@@ -102,3 +102,23 @@ export async function injectSnapshot (
     await sm.saveStateSnapshot({ name, type: 'imported', cfg: encodedCfg, svc: encodedSvc })
   }, { cfg, svc, name })
 }
+
+/**
+ * Persist the last used board and view identifiers.
+ * @function setLastUsedIds
+ * @param {Page} page
+ * @param {string} boardId
+ * @param {string} viewId
+ * @returns {Promise<void>}
+ */
+export async function setLastUsedIds (
+  page: Page,
+  boardId: string,
+  viewId: string
+): Promise<void> {
+  await page.evaluate(async ({ boardId, viewId }) => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    sm.misc.setLastBoardId(boardId)
+    sm.misc.setLastViewId(viewId)
+  }, { boardId, viewId })
+}

--- a/tests/viewStateIsolation.spec.ts
+++ b/tests/viewStateIsolation.spec.ts
@@ -6,7 +6,7 @@ import {
   clearLocalState,
   setLocalConfig,
   setLocalServices,
-  setLocalItem
+  setLastUsedIds
 } from './shared/state.js';
 
 // Define a deterministic initial state with a clean board and two empty views.
@@ -41,8 +41,7 @@ test.describe("Widget State Isolation Between Views", () => {
       { name: 'ASD-toolbox', url: 'http://localhost:8000/asd/toolbox' },
       { name: 'ASD-terminal', url: 'http://localhost:8000/asd/terminal' }
     ]);
-    await setLocalItem(page, 'lastUsedBoardId', 'board-iso-test-1');
-    await setLocalItem(page, 'lastUsedViewId', 'view-A');
+    await setLastUsedIds(page, 'board-iso-test-1', 'view-A');
 
     await page.goto("/");
     await page.waitForSelector('body[data-ready="true"]', { timeout: 10000 });


### PR DESCRIPTION
## Summary
- add `setLastUsedIds` helper to set last used board and view ids
- use new helper in `viewStateIsolation.spec`

## Testing
- `just format check`
- `just test` *(fails: Failed to fetch dynamically imported module)*

------
https://chatgpt.com/codex/tasks/task_b_68701496d37083258ab9d58bec4ee733