### PR TITLE
Remove outdated UI updates in board services

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -61,9 +61,6 @@ export async function createBoard (boardName, boardId = null, viewId = null) {
   StorageManager.misc.setLastViewId(defaultViewId)
   logger.log(`Saved last used boardId: ${newBoardId} and viewId: ${defaultViewId}`)
 
-  // Update the board selector
-  updateBoardSelector()
-
   return StorageManager.getBoards().find(b => b.id === newBoardId)
 }
 
@@ -354,7 +351,6 @@ export async function renameBoard (boardId, newBoardName) {
 
   if (found) {
     logger.log(`Renamed board ${boardId} to ${newBoardName}`)
-    updateBoardSelector()
   } else {
     logger.error(`Board with ID ${boardId} not found`)
   }
@@ -380,7 +376,6 @@ export async function deleteBoard (boardId) {
 
   if (removed) {
     logger.log(`Deleted board ${boardId}`)
-    updateBoardSelector()
     const boards = StorageManager.getBoards()
     if (boards.length > 0) {
       const firstBoardId = boards[0].id
@@ -426,7 +421,6 @@ export async function renameView (boardId, viewId, newViewName) {
   }
 
   logger.log(`Renamed view ${viewId} to ${newViewName}`)
-  updateViewSelector(boardId)
 }
 
 /**
@@ -467,7 +461,6 @@ export async function deleteView (boardId, viewId) {
   }
 
   logger.log(`Deleted view ${viewId} and evicted its widgets.`)
-  updateViewSelector(boardId)
 
   const board = StorageManager.getBoards().find(b => b.id === boardId)
   if (board && board.views.length > 0) {

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -36,7 +36,6 @@ function initializeDashboardMenu () {
 
   logger.log('Dashboard menu initialized')
   populateServiceDropdown()
-  document.addEventListener('services-updated', populateServiceDropdown)
   applyWidgetMenuVisibility()
 
   const buttonDebounce = 200

--- a/src/component/modal/saveServiceModal.js
+++ b/src/component/modal/saveServiceModal.js
@@ -39,7 +39,6 @@ export function openSaveServiceModal (url, onClose) {
         const services = StorageManager.getServices()
         services.push({ name, url })
         StorageManager.setServices(services)
-        document.dispatchEvent(new CustomEvent('services-updated'))
         closeModal()
       })
 


### PR DESCRIPTION
## Summary
- decouple board management from UI updates by removing selector refresh calls
- drop `services-updated` event usage

## Testing
- `just format`
- `just check`
- `just test` *(fails: TimeoutError: page.waitForSelector: Timeout 3000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_b_68701182cef4832597ac2cd3d4f46add