### PR TITLE
refactor(import): move silent-import flow out of main.js; add URL cleanup

### DIFF
--- a/src/feature/silentImport.js
+++ b/src/feature/silentImport.js
@@ -1,0 +1,78 @@
+// @ts-check
+/**
+ * Orchestrates the silent import flow triggered via URL flags.
+ *
+ * @module silentImport
+ */
+
+import { loadFromFragment } from '../utils/fragmentLoader.js'
+import { clearConfigFragment } from '../utils/fragmentGuard.js'
+import StorageManager from '../storage/StorageManager.js'
+import { autosaveIfPresent, saveImportedSnapshot } from './snapshots.js'
+import { getImportFlags, removeImportFlagsFromUrl } from '../utils/urlParams.js'
+import { Logger } from '../utils/Logger.js'
+
+const logger = new Logger('feature/silentImport.js')
+
+// Guard against multiple simultaneous runs
+let inflight = null
+
+/**
+ * Execute the silent import flow if requested by the current URL.
+ *
+ * @function runImportFlowIfRequested
+ * @returns {Promise<boolean>} True if the import flow executed
+ */
+export async function runImportFlowIfRequested () {
+  const { isImport, importName } = getImportFlags()
+  if (!isImport) return false
+
+  if (!inflight) {
+    inflight = (async () => {
+      logger.log('import.start', importName || undefined)
+
+      const autosaveName = await autosaveIfPresent()
+      if (autosaveName) logger.log('snapshot.saved', autosaveName)
+
+      StorageManager.misc.setLastBoardId(null)
+      StorageManager.misc.setLastViewId(null)
+
+      const imported = (await loadFromFragment(true)) || { cfg: null, svc: null, name: '' }
+      clearConfigFragment()
+
+      if (imported.cfg || imported.svc) {
+        const snapshotName = await saveImportedSnapshot(
+          sanitizeName(importName || imported.name),
+          imported.cfg,
+          imported.svc
+        )
+        logger.log('import.success', snapshotName)
+
+        const newCfg = StorageManager.getConfig()
+        const firstBoardId = newCfg?.boards?.[0]?.id || null
+        const firstViewId = newCfg?.boards?.[0]?.views?.[0]?.id || null
+        StorageManager.misc.setLastBoardId(firstBoardId)
+        StorageManager.misc.setLastViewId(firstViewId)
+      } else {
+        logger.log('import.skip', 'no-fragment-data')
+      }
+
+      removeImportFlagsFromUrl()
+      return true
+    })()
+  }
+
+  await inflight
+  return true
+}
+
+/**
+ * Sanitize a snapshot name to a safe ASCII string.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function sanitizeName (raw) {
+  if (!raw) return ''
+  return raw.replace(/[^\x20-\x7E]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 120)
+}

--- a/src/feature/snapshots.js
+++ b/src/feature/snapshots.js
@@ -1,0 +1,59 @@
+// @ts-check
+/**
+ * Utilities for persisting dashboard state snapshots.
+ *
+ * @module snapshots
+ */
+
+import StorageManager from '../storage/StorageManager.js'
+import { gzipJsonToBase64url } from '../utils/compression.js'
+
+/**
+ * Save the existing dashboard state as an autosave snapshot if any state exists.
+ *
+ * @function autosaveIfPresent
+ * @returns {Promise<string|null>} Name of the snapshot or null if skipped
+ */
+export async function autosaveIfPresent () {
+  const existingCfg = StorageManager.getConfig()
+  const existingSvc = StorageManager.getServices()
+  const hasState =
+    (Array.isArray(existingCfg?.boards) && existingCfg.boards.length > 0) ||
+    (Array.isArray(existingSvc) && existingSvc.length > 0)
+
+  if (!hasState) return null
+
+  const [cfgEnc, svcEnc] = await Promise.all([
+    gzipJsonToBase64url(existingCfg),
+    gzipJsonToBase64url(existingSvc)
+  ])
+
+  const name = `autosave/${new Date().toISOString()}`
+  await StorageManager.saveStateSnapshot({
+    name,
+    type: 'autosave',
+    cfg: cfgEnc,
+    svc: svcEnc
+  })
+  return name
+}
+
+/**
+ * Persist an imported snapshot using already encoded cfg & svc strings.
+ *
+ * @function saveImportedSnapshot
+ * @param {string} name
+ * @param {string|null} cfg
+ * @param {string|null} svc
+ * @returns {Promise<string>} Final snapshot name used
+ */
+export async function saveImportedSnapshot (name, cfg, svc) {
+  const finalName = name && name.trim().length ? name.trim() : `import/${new Date().toISOString()}`
+  await StorageManager.saveStateSnapshot({
+    name: finalName,
+    type: 'imported',
+    cfg: cfg || '',
+    svc: svc || ''
+  })
+  return finalName
+}

--- a/src/utils/urlParams.js
+++ b/src/utils/urlParams.js
@@ -1,0 +1,38 @@
+// @ts-check
+/**
+ * Helper utilities for reading and manipulating URL search parameters.
+ *
+ * @module urlParams
+ */
+
+/**
+ * Retrieve import-related flags from the current URL.
+ *
+ * @function getImportFlags
+ * @returns {{isImport:boolean, importName:string}}
+ */
+export function getImportFlags () {
+  const params = new URLSearchParams(location.search)
+  const isImport = params.get('import') === 'true'
+  const importName = (params.get('import_name') || '').trim()
+  return { isImport, importName }
+}
+
+/**
+ * Remove import-related flags from the URL without reloading the page.
+ * Other query parameters remain untouched.
+ *
+ * @function removeImportFlagsFromUrl
+ * @returns {void}
+ */
+export function removeImportFlagsFromUrl () {
+  const params = new URLSearchParams(location.search)
+  let mutated = false
+  if (params.has('import')) { params.delete('import'); mutated = true }
+  if (params.has('import_name')) { params.delete('import_name'); mutated = true }
+  if (!mutated) return
+
+  const search = params.toString()
+  const newUrl = `${location.pathname}${search ? `?${search}` : ''}${location.hash || ''}`
+  window.history.replaceState(null, '', newUrl)
+}

--- a/symbols.json
+++ b/symbols.json
@@ -162,6 +162,14 @@
     "returns": "void"
   },
   {
+    "name": "autosaveIfPresent",
+    "kind": "function",
+    "file": "src/feature/snapshots.js",
+    "description": "Save the existing dashboard state as an autosave snapshot if any state exists.",
+    "params": [],
+    "returns": "Promise<string|null>"
+  },
+  {
     "name": "base64UrlDecode",
     "kind": "function",
     "file": "src/utils/compression.js",
@@ -701,6 +709,14 @@
     "description": "Get the id of the currently active view element.",
     "params": [],
     "returns": "string"
+  },
+  {
+    "name": "getImportFlags",
+    "kind": "function",
+    "file": "src/utils/urlParams.js",
+    "description": "Retrieve import-related flags from the current URL.",
+    "params": [],
+    "returns": "{isImport:boolean, importName:string}"
   },
   {
     "name": "getItem",
@@ -1513,6 +1529,14 @@
     "returns": "void"
   },
   {
+    "name": "removeImportFlagsFromUrl",
+    "kind": "function",
+    "file": "src/utils/urlParams.js",
+    "description": "Remove import-related flags from the URL without reloading the page. Other query parameters remain untouched.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "removeWidget",
     "kind": "function",
     "file": "src/component/widget/widgetManagement.js",
@@ -1639,6 +1663,38 @@
       }
     ],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "runImportFlowIfRequested",
+    "kind": "function",
+    "file": "src/feature/silentImport.js",
+    "description": "Execute the silent import flow if requested by the current URL.",
+    "params": [],
+    "returns": "Promise<boolean>"
+  },
+  {
+    "name": "saveImportedSnapshot",
+    "kind": "function",
+    "file": "src/feature/snapshots.js",
+    "description": "Persist an imported snapshot using already encoded cfg & svc strings.",
+    "params": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "cfg",
+        "type": "string|null",
+        "desc": ""
+      },
+      {
+        "name": "svc",
+        "type": "string|null",
+        "desc": ""
+      }
+    ],
+    "returns": "Promise<string>"
   },
   {
     "name": "saveLocalStorageData",

--- a/tests/importQueryCleanup.spec.ts
+++ b/tests/importQueryCleanup.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from './fixtures'
+import { gzipJsonToBase64url } from '../src/utils/compression.js'
+import { ciConfig } from './data/ciConfig'
+import { ciServices } from './data/ciServices'
+import { bootWithDashboardState } from './shared/bootState.js'
+
+async function encode (obj) {
+  return gzipJsonToBase64url(obj)
+}
+
+test('removes ?import & ?import_name from URL after silent import', async ({ page }) => {
+  const cfg = await encode(ciConfig)
+  const svc = await encode(ciServices)
+
+  await bootWithDashboardState(
+    page,
+    { globalSettings: { theme: 'dark' }, boards: [] },
+    [{ name: 'Old', url: 'http://localhost/old' }],
+    { board: '', view: '' },
+    `/?import=true&import_name=ci#cfg=${cfg}&svc=${svc}`
+  )
+
+  await page.waitForFunction(() => document.body?.dataset?.ready === 'true')
+
+  const url = page.url()
+  expect(url).not.toContain('import=')
+  expect(url).not.toContain('import_name=')
+  expect(url).not.toContain('#cfg=')
+  expect(url).not.toContain('#svc=')
+})


### PR DESCRIPTION
## Summary
- extract silent import controller to feature/silentImport.js
- add snapshot and URL helper modules
- clean main.js to simply trigger imports
- test that ?import and ?import_name are removed after import

## Testing
- `just format check`
- `just test`
- `just test-failed`