### PR TITLE
refactor: reorganize silent import flow

### DIFF
--- a/src/flows/silentImportFlow.js
+++ b/src/flows/silentImportFlow.js
@@ -2,17 +2,17 @@
 /**
  * Orchestrates the silent import flow triggered via URL flags.
  *
- * @module silentImport
+ * @module silentImportFlow
  */
 
 import { loadFromFragment } from '../utils/fragmentLoader.js'
 import { clearConfigFragment } from '../utils/fragmentGuard.js'
 import StorageManager from '../storage/StorageManager.js'
-import { autosaveIfPresent, saveImportedSnapshot } from './snapshots.js'
-import { getImportFlags, removeImportFlagsFromUrl } from '../utils/urlParams.js'
+import { autosaveIfPresent, saveImportedSnapshot } from '../storage/snapshots.js'
+import { getImportFlags, removeImportFlagsFromUrl } from '../utils/url.js'
 import { Logger } from '../utils/Logger.js'
 
-const logger = new Logger('feature/silentImport.js')
+const logger = new Logger('flows/silentImportFlow.js')
 
 // Guard against multiple simultaneous runs
 let inflight = null
@@ -20,10 +20,10 @@ let inflight = null
 /**
  * Execute the silent import flow if requested by the current URL.
  *
- * @function runImportFlowIfRequested
+ * @function runSilentImportFlowIfRequested
  * @returns {Promise<boolean>} True if the import flow executed
  */
-export async function runImportFlowIfRequested () {
+export async function runSilentImportFlowIfRequested () {
   const { isImport, importName } = getImportFlags()
   if (!isImport) return false
 

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ import { Logger } from './utils/Logger.js'
 import { widgetStore } from './component/widget/widgetStore.js'
 import { debounce, debounceLeading } from './utils/utils.js'
 import StorageManager, { APP_STATE_CHANGED } from './storage/StorageManager.js'
-import { runImportFlowIfRequested } from './feature/silentImport.js'
+import { runSilentImportFlowIfRequested } from './flows/silentImportFlow.js'
 
 const logger = new Logger('main.js')
 
@@ -48,7 +48,7 @@ async function main () {
   const params = new URLSearchParams(location.search)
   const force = params.get('force') === 'true'
 
-  const didImport = await runImportFlowIfRequested()
+  const didImport = await runSilentImportFlowIfRequested()
   if (!didImport) {
     await loadFromFragment(force)
   }

--- a/src/storage/snapshots.js
+++ b/src/storage/snapshots.js
@@ -5,7 +5,7 @@
  * @module snapshots
  */
 
-import StorageManager from '../storage/StorageManager.js'
+import StorageManager from './StorageManager.js'
 import { gzipJsonToBase64url } from '../utils/compression.js'
 
 /**

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -2,7 +2,7 @@
 /**
  * Helper utilities for reading and manipulating URL search parameters.
  *
- * @module urlParams
+ * @module url
  */
 
 /**


### PR DESCRIPTION
## Summary
- relocate silent import logic into dedicated flow module and rename orchestrator
- move snapshot persistence helpers into storage layer
- consolidate URL helper functions under utils/url

## Testing
- `just format`
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_6897ea867c108325930e424cdb9381ca