### PR TITLE
feat(reset): preserve saved states on dashboard reset; add bulk state deletion in config modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ ASD Dashboard is architected with a focus on simplicity and adaptability:
 - **Playwright Integration & Testing**: Comprehensive testing using Playwright, with automated tests running via GitHub Actions.
 - **Custom Logger Integration**: All log statements use a custom logger for better development and debugging.
 
+## Reset & State Management
+
+The admin reset control clears boards, views, services and configuration while keeping any saved state snapshots. Bulk removal of saved states is available from the **Saved States** tab in the configuration modal via the "Delete all snapshots" button. A full wipe, including saved states, remains possible through the legacy `StorageManager.clearAll()` API.
+
 Here's the optimized version of the second part—**URL Fragment-Based Config Sharing**—to follow directly after the revised query parameter section. It's concise, technically precise, and clearly contrasts with the dynamic configuration method:
 
 ## Private Config Sharing (via URL Fragment)

--- a/src/component/menu/dashboardMenu.js
+++ b/src/component/menu/dashboardMenu.js
@@ -90,10 +90,10 @@ function initializeDashboardMenu () {
 
   const handleReset = debounceLeading(() => {
     // Show confirmation dialog
-    const confirmed = confirm('Confirm environment reset: all configurations and services will be permanently deleted.')
+    const confirmed = confirm('Reset dashboard (boards, views, services) but keep saved states?')
 
     if (confirmed) {
-      StorageManager.clearAll()
+      StorageManager.clearAllExceptState()
       clearConfigFragment()
       location.reload()
     }

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -271,8 +271,8 @@ function initializeMainMenu () {
 
   const resetButton = document.createElement('label')
   resetButton.id = 'reset-button'
-  resetButton.ariaLabel = 'Permanently reset ASD Dashboard'
-  resetButton.title = 'Permanently reset ASD Dashboard'
+  resetButton.ariaLabel = 'Reset dashboard (keeps saved states)'
+  resetButton.title = 'Reset dashboard (keeps saved states)'
   resetButton.textContent = `${emojiList.crossCycle.unicode}`
   adminControl.appendChild(resetButton)
 

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -173,6 +173,19 @@ async function populateStateTab (tab) {
   table.append(thead, tbody)
   tab.appendChild(table)
 
+  const wipeBtn = document.createElement('button')
+  wipeBtn.textContent = 'Delete all snapshots'
+  wipeBtn.ariaLabel = 'Delete all saved states'
+  wipeBtn.title = 'Delete all saved states'
+  wipeBtn.addEventListener('click', async () => {
+    if (confirm('Delete all saved states? This cannot be undone.')) {
+      await StorageManager.clearStateStore()
+      list.splice(0, list.length)
+      render()
+    }
+  })
+  tab.appendChild(wipeBtn)
+
   /**
    * Render all saved state entries as table rows inside the tab's <tbody>.
    *

--- a/src/storage/StorageManager.js
+++ b/src/storage/StorageManager.js
@@ -209,12 +209,30 @@ const StorageManager = {
   },
 
   /**
-   * Remove all persisted data.
-   * @function clearAll
-   * @returns {void}
-   */
+  * Remove all persisted data.
+  * @function clearAll
+  * @returns {void}
+  */
   clearAll () {
     Object.values(KEYS).forEach(key => localStorage.removeItem(key))
+  },
+
+  /**
+   * Remove persisted config, boards, services and last used ids while keeping saved states.
+   * @function clearAllExceptState
+   * @returns {void}
+   */
+  clearAllExceptState () {
+    [KEYS.CONFIG, KEYS.BOARDS, KEYS.SERVICES, KEYS.LAST_BOARD, KEYS.LAST_VIEW].forEach(key => localStorage.removeItem(key))
+  },
+
+  /**
+   * Reset the state store to an empty list.
+   * @function clearStateStore
+   * @returns {Promise<void>}
+   */
+  async clearStateStore () {
+    await StorageManager.saveStateStore({ version: CURRENT_VERSION, states: [] })
   },
 
   /**

--- a/symbols.json
+++ b/symbols.json
@@ -214,12 +214,28 @@
     "returns": "void"
   },
   {
+    "name": "clearAllExceptState",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Remove persisted config, boards, services and last used ids while keeping saved states.",
+    "params": [],
+    "returns": "void"
+  },
+  {
     "name": "clearConfigFragment",
     "kind": "function",
     "file": "src/utils/fragmentGuard.js",
     "description": "Remove any `#cfg` or `#svc` fragment from the current URL without triggering a reload.",
     "params": [],
     "returns": "void"
+  },
+  {
+    "name": "clearStateStore",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Reset the state store to an empty list.",
+    "params": [],
+    "returns": "Promise<void>"
   },
   {
     "name": "clearWidgetContainer",

--- a/tests/addManageWidgets.spec.ts
+++ b/tests/addManageWidgets.spec.ts
@@ -11,6 +11,7 @@ import {
 
 
 test.describe('Widgets', () => {
+  test.setTimeout(30000)
 
   test.beforeEach(async ({ page }) => {
     await routeServicesConfig(page)

--- a/tests/resetState.spec.ts
+++ b/tests/resetState.spec.ts
@@ -1,0 +1,45 @@
+// @ts-check
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+import { navigate, getConfigBoards } from './shared/common'
+
+ test.describe('dashboard reset', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await navigate(page,'/')
+  })
+
+  test('preserves snapshots and allows wiping state store', async ({ page }) => {
+    await page.evaluate(async () => {
+      const { default: sm } = await import('/storage/StorageManager.js')
+      sm.setConfig({ boards: [{ id: 'b1', name: 'B1', views: [] }, { id: 'b2', name: 'B2', views: [] }] })
+      sm.setServices([{ name: 'svc1', url: '' }])
+      await sm.saveStateSnapshot({ name: 'snap', type: 'manual', cfg: 'a', svc: 'b' })
+    })
+
+    page.once('dialog', dialog => {
+      expect(dialog.message()).toContain('keep saved states')
+      dialog.accept()
+    })
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click('#reset-button')
+    ])
+
+    const boards = await getConfigBoards(page)
+    expect(boards.some(b => b.id === 'b2')).toBeFalsy()
+    const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services') || '[]'))
+    expect(services.some(s => s.name === 'svc1')).toBeFalsy()
+
+    await page.click('#open-config-modal')
+    await page.click('button:has-text("Saved States")')
+    await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
+
+    page.once('dialog', dialog => {
+      expect(dialog.message()).toContain('Delete all saved states')
+      dialog.accept()
+    })
+    await page.click('text=Delete all snapshots')
+    await expect(page.locator('#stateTab tbody tr')).toHaveCount(0)
+  })
+ })


### PR DESCRIPTION
## Summary
- Keep saved state snapshots when using dashboard reset and add clearAllExceptState/clearStateStore in StorageManager
- Update admin reset button labeling and confirmation text; add "Delete all snapshots" control in Saved States tab
- Document selective reset behavior and add tests for selective reset and state wiping

## Testing
- `just check`
- `just test`