### PR TITLE
feat(state): de-duplicate snapshot exports by md5; rename restore to “switch environment”

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The admin reset control clears boards, views, services and configuration while k
 
 ### Snapshot de-duplication
 
-Repeated exports with identical configuration and services no longer create duplicate snapshots. If the MD5 hash matches an existing snapshot, its timestamp is refreshed and it moves to the top of the list instead.
+Repeated exports with identical configuration and services no longer create duplicate snapshots. If the MD5 hash matches an existing snapshot, its timestamp is refreshed and it moves to the top of the list instead. Snapshots are de-duplicated by MD5 but keep their provided names.
 
 Here's the optimized version of the second part—**URL Fragment-Based Config Sharing**—to follow directly after the revised query parameter section. It's concise, technically precise, and clearly contrasts with the dynamic configuration method:
 
@@ -53,6 +53,7 @@ ASD Dashboard also supports sharing full configuration and service state using t
   * **Gzipped** and **base64url-encoded** for compactness
   * Decoded locally using modern browser APIs (e.g. `DecompressionStream`)
   * Persisted to `localStorage` when the page loads
+  * Switching environments triggers a single reload after clearing the fragment and saves the snapshot under the provided name (MD5-deduplicated)
 
 * **No servers are involved**: data stays fully client-side.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ ASD Dashboard is architected with a focus on simplicity and adaptability:
 
 The admin reset control clears boards, views, services and configuration while keeping any saved state snapshots. Bulk removal of saved states is available from the **Saved States** tab in the configuration modal via the "Delete all snapshots" button. A full wipe, including saved states, remains possible through the legacy `StorageManager.clearAll()` API.
 
+### Snapshot de-duplication
+
+Repeated exports with identical configuration and services no longer create duplicate snapshots. If the MD5 hash matches an existing snapshot, its timestamp is refreshed and it moves to the top of the list instead.
+
 Here's the optimized version of the second part—**URL Fragment-Based Config Sharing**—to follow directly after the revised query parameter section. It's concise, technically precise, and clearly contrasts with the dynamic configuration method:
 
 ## Private Config Sharing (via URL Fragment)

--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -162,7 +162,7 @@ async function populateStateTab (tab) {
   const thead = document.createElement('thead')
   const tbody = document.createElement('tbody')
 
-  const headers = ['Actions', '', 'Name', 'Type', 'Date', 'MD5']
+  const headers = ['Environment', '', 'Name', 'Type', 'Date', 'MD5']
   const headerRow = document.createElement('tr')
   headers.forEach(h => {
     const th = document.createElement('th')
@@ -191,7 +191,7 @@ async function populateStateTab (tab) {
    *
    * This function clears the existing table body and repopulates it using
    * the `list` of saved state snapshots. Each row includes buttons to:
-   * - Restore a snapshot via `openFragmentDecisionModal()`
+   * - Switch to a snapshot via `openFragmentDecisionModal()`
    * - Delete the snapshot and persist the new list
    *
    * Table rows are tagged with `data-name` for filtering via the search input.
@@ -206,9 +206,11 @@ async function populateStateTab (tab) {
       const tr = document.createElement('tr')
       tr.dataset.name = row.name
 
-      const restore = document.createElement('button')
-      restore.textContent = 'Restore'
-      restore.addEventListener('click', async () => {
+      const switchBtn = document.createElement('button')
+      switchBtn.textContent = 'Switch'
+      switchBtn.dataset.action = 'switch'
+      switchBtn.classList.add('state-switch')
+      switchBtn.addEventListener('click', async () => {
         try {
           await openFragmentDecisionModal({ cfgParam: row.cfg, svcParam: row.svc, nameParam: row.name })
         } catch (error) {
@@ -228,7 +230,7 @@ async function populateStateTab (tab) {
       })
 
       const cells = [
-        restore,
+        switchBtn,
         del,
         row.name,
         row.type,

--- a/src/component/modal/fragmentDecisionModal.js
+++ b/src/component/modal/fragmentDecisionModal.js
@@ -36,6 +36,8 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam }) {
         clearConfigFragment()
         logger.log('Fragment decision modal closed')
         resolve()
+        // Perform a single reload after clearing the hash
+        location.reload()
       },
       buildContent: (modal, closeModal) => {
         const msg1 = document.createElement('p')
@@ -110,14 +112,18 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam }) {
             const finalName = nameEl && 'value' in nameEl && typeof nameEl.value === 'string'
               ? nameEl.value.trim() || 'Imported'
               : 'Imported'
+            await StorageManager.saveStateSnapshot({
+              name: finalName,
+              type: 'imported',
+              cfg: cfgParam ?? '',
+              svc: svcParam ?? ''
+            })
             StorageManager.setConfig(cfgObj)
             StorageManager.setServices(svcArr)
-            await StorageManager.saveStateSnapshot({ name: finalName, type: 'imported', cfg: cfgParam || '', svc: svcParam || '' })
           } catch (e) {
             logger.error('Error applying fragment:', e)
           } finally {
             closeModal()
-            location.reload()
           }
         }
       }

--- a/src/component/modal/fragmentDecisionModal.js
+++ b/src/component/modal/fragmentDecisionModal.js
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * Modal prompting user to merge or overwrite when config fragment is detected.
+ * Modal prompting user to merge or switch when a config fragment is detected.
  *
  * @module fragmentDecisionModal
  */
@@ -18,7 +18,7 @@ import StorageManager from '../../storage/StorageManager.js'
 const logger = new Logger('fragmentDecisionModal.js')
 
 /**
- * Display modal asking user to overwrite or merge fragment data.
+ * Display modal asking user to switch or merge fragment data.
  *
  * @param {{cfgParam:string|null,svcParam:string|null,nameParam:string}} params
  *        cfgParam - Encoded config fragment.
@@ -47,14 +47,16 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam }) {
         nameInput.id = 'importName'
         nameInput.value = nameParam
 
-        const overwriteBtn = document.createElement('button')
-        overwriteBtn.textContent = '⬇ Overwrite existing data'
-        overwriteBtn.classList.add('modal__btn', 'modal__btn--danger')
-        overwriteBtn.addEventListener('click', async () => {
+        const switchBtn = document.createElement('button')
+        switchBtn.id = 'switch-environment'
+        switchBtn.textContent = '⬇ Switch environment'
+        switchBtn.classList.add('modal__btn', 'modal__btn--danger')
+        switchBtn.addEventListener('click', async () => {
           await applyFragment(true)
         })
 
         const mergeBtn = document.createElement('button')
+        mergeBtn.id = 'merge-environment'
         mergeBtn.textContent = '➕ Merge into current setup'
         mergeBtn.classList.add('modal__btn', 'modal__btn--save')
         mergeBtn.addEventListener('click', async () => {
@@ -62,18 +64,19 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam }) {
         })
 
         const cancelBtn = document.createElement('button')
+        cancelBtn.id = 'cancel-environment'
         cancelBtn.textContent = '✖ Cancel'
         cancelBtn.classList.add('modal__btn', 'modal__btn--cancel')
         cancelBtn.addEventListener('click', closeModal)
 
         const btnGroup = document.createElement('div')
         btnGroup.classList.add('modal__btn-group')
-        btnGroup.append(overwriteBtn, mergeBtn, cancelBtn)
+        btnGroup.append(switchBtn, mergeBtn, cancelBtn)
 
         modal.append(msg1, msg2, nameInput, btnGroup)
 
         /**
-         * Applies the configuration from the URL fragment, either by overwriting or merging.
+         * Applies the configuration from the URL fragment, either by switching or merging.
          * @function applyFragment
          * @param {boolean} overwrite - If true, existing data will be replaced.
          * @returns {Promise<void>}

--- a/src/storage/StorageManager.js
+++ b/src/storage/StorageManager.js
@@ -78,6 +78,38 @@ function jsonSet (key, obj) {
 /** @typedef {import('../types.js').Service} Service */
 
 /**
+ * Insert or update a snapshot in the state store based on MD5 hash.
+ *
+ * If a snapshot with the same MD5 exists its timestamp is refreshed and it is
+ * moved to the front of the list. Optionally updates the name when provided.
+ *
+ * @function upsertSnapshotByMd5
+ * @param {{version:number,states:Array}} store
+ * @param {{name:string,type:string,cfg:string,svc:string}} snap
+ * @returns {{store:{version:number,states:Array},md5:string,updated:boolean}}
+ */
+export function upsertSnapshotByMd5 (store, { name, type, cfg, svc }) {
+  const md5 = md5Hex(cfg + svc)
+  const list = Array.isArray(store.states) ? store.states : []
+  const idx = list.findIndex(s => s.md5 === md5)
+  const ts = Date.now()
+
+  if (idx !== -1) {
+    const existing = list[idx]
+    existing.ts = ts
+    if (name) existing.name = name
+    if (idx !== 0) {
+      list.splice(idx, 1)
+      list.unshift(existing)
+    }
+    return { store, md5, updated: true }
+  }
+
+  list.unshift({ name, type, md5, cfg, svc, ts })
+  return { store, md5, updated: false }
+}
+
+/**
  * Singleton API for storing and retrieving dashboard data.
  */
 const StorageManager = {
@@ -198,13 +230,12 @@ const StorageManager = {
   * Save the current state snapshot.
   * @function saveStateSnapshot
    * @param {{name:string,type:string,cfg:string,svc:string}} snapshot
-   * @returns {Promise<string>} Hash of the snapshot
-   */
+  * @returns {Promise<string>} Hash of the snapshot
+  */
   async saveStateSnapshot ({ name, type, cfg, svc }) {
     const store = await StorageManager.loadStateStore()
-    const md5 = md5Hex(cfg + svc)
-    store.states.unshift({ name, type, md5, cfg, svc, ts: Date.now() })
-    jsonSet(KEYS.STATES, store)
+    const { store: updated, md5 } = upsertSnapshotByMd5(store, { name, type, cfg, svc })
+    await StorageManager.saveStateStore(updated)
     return md5
   },
 

--- a/symbols.json
+++ b/symbols.json
@@ -143,7 +143,7 @@
     "name": "applyFragment",
     "kind": "function",
     "file": "src/component/modal/fragmentDecisionModal.js",
-    "description": "Applies the configuration from the URL fragment, either by overwriting or merging.",
+    "description": "Applies the configuration from the URL fragment, either by switching or merging.",
     "params": [
       {
         "name": "overwrite",
@@ -1401,7 +1401,7 @@
     "name": "openFragmentDecisionModal",
     "kind": "function",
     "file": "src/component/modal/fragmentDecisionModal.js",
-    "description": "Display modal asking user to overwrite or merge fragment data.",
+    "description": "Display modal asking user to switch or merge fragment data.",
     "params": [
       {
         "name": "params",
@@ -2106,6 +2106,25 @@
       }
     ],
     "returns": "void"
+  },
+  {
+    "name": "upsertSnapshotByMd5",
+    "kind": "function",
+    "file": "src/storage/StorageManager.js",
+    "description": "Insert or update a snapshot in the state store based on MD5 hash. If a snapshot with the same MD5 exists its timestamp is refreshed and it is moved to the front of the list. Optionally updates the name when provided.",
+    "params": [
+      {
+        "name": "store",
+        "type": "{version:number,states:Array}",
+        "desc": ""
+      },
+      {
+        "name": "snap",
+        "type": "{name:string,type:string,cfg:string,svc:string}",
+        "desc": ""
+      }
+    ],
+    "returns": "{store:{version:number,states:Array},md5:string,updated:boolean}"
   },
   {
     "name": "viewGetUUID",

--- a/tests/data/ciServices.ts
+++ b/tests/data/ciServices.ts
@@ -1,5 +1,6 @@
 export const ciServices = [
   {
+    id: "toolbox",
     name: "ASD-toolbox",
     url: "http://localhost:8000/asd/toolbox",
     type: "api",
@@ -12,6 +13,7 @@ export const ciServices = [
     },
   },
   {
+    id: "terminal",
     name: "ASD-terminal",
     url: "http://localhost:8000/asd/terminal",
     type: "web",
@@ -24,6 +26,7 @@ export const ciServices = [
     },
   },
   {
+    id: "tunnel",
     name: "ASD-tunnel",
     url: "http://localhost:8000/asd/tunnel",
     type: "web",
@@ -36,6 +39,7 @@ export const ciServices = [
     },
   },
   {
+    id: "containers",
     name: "ASD-containers",
     url: "http://localhost:8000/asd/containers",
     type: "web",

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -32,6 +32,7 @@ test.describe("Secure fragments loading configuration", () => {
     // Trigger overwrite (this reloads the page)
     await page.locator('#switch-environment').click();
     await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
 
     // Now re-import StorageManager in a fresh JS context
     // ToDo: refactor logic below

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -30,12 +30,8 @@ test.describe("Secure fragments loading configuration", () => {
     await expect(page.locator("#importName")).toHaveValue(name);
 
     // Trigger overwrite (this reloads the page)
-    await page
-      .locator('#fragment-decision-modal button:has-text("Overwrite")')
-      .click();
-
-    // Wait for reload and presence of final ready state
-    
+    await page.locator('#switch-environment').click();
+    await page.waitForLoadState('networkidle');
 
     // Now re-import StorageManager in a fresh JS context
     // ToDo: refactor logic below

--- a/tests/snapshotDedupe.spec.ts
+++ b/tests/snapshotDedupe.spec.ts
@@ -55,6 +55,7 @@ import { injectSnapshot } from './shared/state.js'
   await expect(page.locator('#switch-environment')).toHaveText(/Switch environment/)
   await page.click('#switch-environment')
   await page.waitForLoadState('networkidle')
+  await page.waitForLoadState('load')
   const count = await page.evaluate(async () => {
     const { default: sm } = await import('/storage/StorageManager.js')
     return (await sm.loadStateStore()).states.length

--- a/tests/snapshotDedupe.spec.ts
+++ b/tests/snapshotDedupe.spec.ts
@@ -53,9 +53,11 @@ import { injectSnapshot } from './shared/state.js'
   await page.click('.tabs button[data-tab="stateTab"]')
   await page.locator('#stateTab tbody tr:first-child button[data-action="switch"]').click()
   await expect(page.locator('#switch-environment')).toHaveText(/Switch environment/)
-  await page.click('#switch-environment')
-  await page.waitForLoadState('networkidle')
-  await page.waitForLoadState('load')
+  await Promise.all([
+    page.waitForNavigation(),
+    page.click('#switch-environment')
+  ])
+  await page.waitForFunction(() => document.body.dataset.ready === 'true')
   const count = await page.evaluate(async () => {
     const { default: sm } = await import('/storage/StorageManager.js')
     return (await sm.loadStateStore()).states.length

--- a/tests/snapshotDedupe.spec.ts
+++ b/tests/snapshotDedupe.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from './fixtures'
+import { ciConfig } from './data/ciConfig'
+import { ciServices } from './data/ciServices'
+import { bootWithDashboardState } from './shared/bootState.js'
+import { navigate, clearStorage } from './shared/common.js'
+import { injectSnapshot } from './shared/state.js'
+
+ test('export de-duplicates by md5', async ({ page }) => {
+  await clearStorage(page)
+  await navigate(page, '/')
+  await page.evaluate(async ({ cfg, svc }) => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    sm.setConfig(cfg)
+    sm.setServices(svc)
+  }, { cfg: ciConfig, svc: ciServices })
+  await page.evaluate(() => import('/component/modal/configModal.js').then(m => m.openConfigModal()))
+  await page.waitForSelector('#config-modal .modal__btn--export')
+  await page.evaluate(() => { (window as any).__copied=''; navigator.clipboard.writeText = async t => { (window as any).__copied = t } })
+  page.on('dialog', d => d.accept())
+  await page.click('#config-modal .modal__btn--export')
+  const first = await page.evaluate(async () => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    const store = await sm.loadStateStore()
+    return store.states[0]
+  })
+  await page.click('.tabs button[data-tab="stateTab"]')
+  await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
+  await expect(page.locator('#stateTab tbody tr td:last-child')).toHaveText(first.md5)
+  await page.click('.tabs button[data-tab="cfgTab"]')
+  await page.click('#config-modal .modal__btn--export')
+  const second = await page.evaluate(async () => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    const store = await sm.loadStateStore()
+    return store.states[0]
+  })
+  await page.click('.tabs button[data-tab="stateTab"]')
+  await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
+  expect(second.md5).toBe(first.md5)
+  expect(second.ts).toBeGreaterThan(first.ts)
+ })
+
+ test('switch environment flow', async ({ page }) => {
+  await clearStorage(page)
+  await navigate(page, '/')
+  await page.evaluate(async ({ cfg, svc }) => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    sm.setConfig(cfg)
+    sm.setServices(svc)
+  }, { cfg: ciConfig, svc: ciServices })
+  const snapCfg = { ...ciConfig, globalSettings: { ...ciConfig.globalSettings, theme: 'dark' } }
+  await injectSnapshot(page, snapCfg, ciServices, 'snap1')
+  await page.evaluate(() => import('/component/modal/configModal.js').then(m => m.openConfigModal()))
+  await page.click('.tabs button[data-tab="stateTab"]')
+  await page.locator('#stateTab tbody tr:first-child button[data-action="switch"]').click()
+  await expect(page.locator('#switch-environment')).toHaveText(/Switch environment/)
+  await page.click('#switch-environment')
+  await page.waitForLoadState('networkidle')
+  const count = await page.evaluate(async () => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    return (await sm.loadStateStore()).states.length
+  })
+  const theme = await page.evaluate(async () => {
+    const { default: sm } = await import('/storage/StorageManager.js')
+    return sm.getConfig().globalSettings.theme
+  })
+  expect(count).toBe(1)
+  expect(theme).toBe('dark')
+ })
+
+ test('no restore wording remains', async ({ page }) => {
+  await clearStorage(page)
+  await navigate(page, '/')
+  await injectSnapshot(page, ciConfig, ciServices, 'snap')
+  await page.evaluate(() => import('/component/modal/configModal.js').then(m => m.openConfigModal()))
+  await page.click('.tabs button[data-tab="stateTab"]')
+  await expect(page.locator('text=Restore')).toHaveCount(0)
+  await page.locator('#stateTab tbody tr:first-child button[data-action="switch"]').click()
+  await expect(page.locator('text=Overwrite existing data')).toHaveCount(0)
+  await page.click('#cancel-environment')
+ })

--- a/tests/stateTab.spec.ts
+++ b/tests/stateTab.spec.ts
@@ -16,17 +16,17 @@ test.describe.skip('Saved States tab', () => {
 
   test('restore and delete snapshot', async ({ page }) => {
     await page.click('#open-config-modal')
-    await page.click('.tabs button[data-tab="state"]')
+    await page.click('.tabs button[data-tab="stateTab"]')
     await expect(page.locator('#stateTab tbody tr')).toHaveCount(2)
 
-    await page.locator('#stateTab tbody tr:first-child button:has-text("Restore")').click()
-    await page.click('#fragment-decision-modal button:has-text("Overwrite")')
+    await page.locator('#stateTab tbody tr:first-child button[data-action="switch"]').click()
+    await page.click('#switch-environment')
     
     const boards = await getBoardCount(page);
     expect(boards).toBeGreaterThan(0)
 
     await page.click('#open-config-modal')
-    await page.click('.tabs button[data-tab="state"]')
+    await page.click('.tabs button[data-tab="stateTab"]')
     page.on('dialog', d => d.accept())
     await page.locator('#stateTab tbody tr:nth-child(2) button:has-text("Delete")').click()
     await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
@@ -34,7 +34,7 @@ test.describe.skip('Saved States tab', () => {
     await page.reload()
     
     await page.click('#open-config-modal')
-    await page.click('.tabs button[data-tab="state"]')
+    await page.click('.tabs button[data-tab="stateTab"]')
     await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
   })
 })

--- a/tests/stateTab.spec.ts
+++ b/tests/stateTab.spec.ts
@@ -21,7 +21,9 @@ test.describe.skip('Saved States tab', () => {
 
     await page.locator('#stateTab tbody tr:first-child button[data-action="switch"]').click()
     await page.click('#switch-environment')
-    
+    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('load')
+
     const boards = await getBoardCount(page);
     expect(boards).toBeGreaterThan(0)
 


### PR DESCRIPTION
## Summary
- add upsertSnapshotByMd5 to update timestamp & move snapshots to front when md5 matches
- rename “Restore” UI to “Switch environment” and add stable selectors
- document snapshot de-duplication and cover with unit/e2e tests

## Testing
- `just format`
- `just check`
- `just test`