### PR TITLE
feat: add service templating

### DIFF
--- a/setup/example-config.json
+++ b/setup/example-config.json
@@ -128,6 +128,18 @@
                     ]
                 }
     ],
+    "serviceTemplates": {
+        "default": {
+            "type": "iframe",
+            "maxInstances": 10,
+            "config": { "minColumns": 1, "maxColumns": 8, "minRows": 1, "maxRows": 6 }
+        },
+        "api-service": {
+            "type": "api",
+            "maxInstances": 5,
+            "config": { "minColumns": 1, "maxColumns": 2, "minRows": 1, "maxRows": 2 }
+        }
+    },
     "styling": {
         "widget": {
             "minColumns": 1,

--- a/setup/example-services.json
+++ b/setup/example-services.json
@@ -3,6 +3,7 @@
         "name": "ASD-toolbox",
         "url": "http://localhost:8000/asd/toolbox",
         "type": "api",
+        "template": "api-service",
         "maxInstances": 1,
         "config": {
           "minColumns": 1,

--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -11,6 +11,7 @@ import { switchBoard } from '../board/boardManagement.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 import StorageManager from '../../storage/StorageManager.js'
 import emojiList from '../../ui/unicodeEmoji.js'
+import { resolveServiceConfig } from '../../utils/serviceUtils.js'
 
 /**
  * Emit a standardized state change event.
@@ -96,22 +97,23 @@ export function refreshRowCounts () {
   const overGlobal = typeof widgetStore.maxSize === 'number' && widgetStore.widgets.size >= widgetStore.maxSize
 
   services.forEach(service => {
-    const item = container.querySelector(`.widget-option[data-name="${service.name}"]`)
+    const resolved = resolveServiceConfig(service)
+    const item = container.querySelector(`.widget-option[data-name="${resolved.name}"]`)
     if (!(item instanceof HTMLElement)) return
 
     const label = item.querySelector('.widget-option-label')
     const cnt = item.querySelector('.widget-option-count')
     if (!(label instanceof HTMLElement) || !(cnt instanceof HTMLElement)) return
 
-    const activeCount = countServiceInstances(service.url)
-    const max = service.maxInstances ?? '∞'
+    const activeCount = countServiceInstances(resolved.url)
+    const max = resolved.maxInstances ?? '∞'
 
     // Update text
-    label.firstChild && (label.firstChild.nodeValue = service.name)
+    label.firstChild && (label.firstChild.nodeValue = resolved.name)
     cnt.textContent = ` (${activeCount}/${max})`
 
     // Apply limit state
-    const overService = typeof service.maxInstances === 'number' && activeCount >= service.maxInstances
+    const overService = typeof resolved.maxInstances === 'number' && activeCount >= resolved.maxInstances
 
     // ToDo: Add visual queue to the interface
     if (overGlobal || overService) {
@@ -119,7 +121,7 @@ export function refreshRowCounts () {
     } else {
       item.classList.remove('limit-reached')
     }
-    item.dataset.url = service.url
+    item.dataset.url = resolved.url
   })
 }
 
@@ -143,28 +145,29 @@ export function populateWidgetSelectorPanel () {
   const overGlobal = typeof widgetStore.maxSize === 'number' && widgetStore.widgets.size >= widgetStore.maxSize
 
   services.forEach(service => {
+    const resolved = resolveServiceConfig(service)
     const item = document.createElement('div')
     item.className = 'widget-option'
-    item.dataset.name = service.name
-    if (service.category) item.dataset.category = service.category
-    if (service.subcategory) item.dataset.subcategory = service.subcategory
-    if (Array.isArray(service.tags)) item.dataset.tags = service.tags.join(',')
+    item.dataset.name = resolved.name
+    if (resolved.category) item.dataset.category = resolved.category
+    if (resolved.subcategory) item.dataset.subcategory = resolved.subcategory
+    if (Array.isArray(resolved.tags)) item.dataset.tags = resolved.tags.join(',')
 
-    const activeCount = countServiceInstances(service.url)
-    const max = service.maxInstances ?? '∞'
-    const overService = typeof service.maxInstances === 'number' && activeCount >= service.maxInstances
-    if (!overService && !overGlobal) item.dataset.url = service.url
+    const activeCount = countServiceInstances(resolved.url)
+    const max = resolved.maxInstances ?? '∞'
+    const overService = typeof resolved.maxInstances === 'number' && activeCount >= resolved.maxInstances
+    if (!overService && !overGlobal) item.dataset.url = resolved.url
 
     const label = document.createElement('span')
     label.className = 'widget-option-label'
-    label.textContent = service.name
+    label.textContent = resolved.name
 
     const cnt = document.createElement('span')
     cnt.className = 'widget-option-count'
     cnt.textContent = ` (${activeCount}/${max})`
     label.append(cnt)
 
-    item.dataset.label = service.name
+    item.dataset.label = resolved.name
 
     const actions = document.createElement('span')
     actions.className = 'widget-option-actions'

--- a/src/component/widget/events/resizeHandler.js
+++ b/src/component/widget/events/resizeHandler.js
@@ -8,6 +8,7 @@ import { saveWidgetState } from '../../../storage/widgetStatePersister.js'
 import { debounce } from '../../../utils/utils.js'
 import { Logger } from '../../../utils/Logger.js'
 import StorageManager from '../../../storage/StorageManager.js'
+import { resolveServiceConfig } from '../../../utils/serviceUtils.js'
 
 const logger = new Logger('resizeHandler.js')
 
@@ -74,7 +75,9 @@ async function handleResizeStart (event, widget) {
   const startHeight = widget.offsetHeight
 
   const widgetUrl = widget.dataset.url
-  const serviceConfig = StorageManager.getServices().find(service => service.url === widgetUrl)?.config || {}
+  const rawService = StorageManager.getServices().find(service => service.url === widgetUrl) || {}
+  const serviceObj = resolveServiceConfig(rawService)
+  const serviceConfig = serviceObj.config || {}
 
   const gridColumns = serviceConfig.maxColumns || StorageManager.getConfig().styling.widget.maxColumns
   const gridRows = serviceConfig.maxRows || StorageManager.getConfig().styling.widget.maxRows

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -26,6 +26,7 @@ import { widgetGetUUID } from '../../utils/id.js'
 import StorageManager from '../../storage/StorageManager.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 import { showNotification } from '../dialog/notification.js'
+import { resolveServiceConfig } from '../../utils/serviceUtils.js'
 
 const logger = new Logger('widgetManagement.js')
 
@@ -48,8 +49,9 @@ async function createWidget (
 ) {
   logger.log('Creating widget with URL:', url)
   const config = await getConfig()
-  const services = await fetchServices()
-  const serviceObj = services.find((s) => s.name === service) || {}
+  await fetchServices()
+  const rawService = StorageManager.getServices().find((s) => s.name === service) || {}
+  const serviceObj = resolveServiceConfig(rawService)
 
   const minColumns =
     serviceObj.config?.minColumns || config.styling.widget.minColumns
@@ -203,8 +205,9 @@ async function addWidget (
   if (window.asd.widgetStore.isAdding(serviceName)) return
   window.asd.widgetStore.lock(serviceName)
   try {
-    const services = await fetchServices()
-    const serviceObj = services.find((s) => s.name === serviceName) || {}
+    await fetchServices()
+    const rawServiceObj = StorageManager.getServices().find((s) => s.name === serviceName) || {}
+    const serviceObj = resolveServiceConfig(rawServiceObj)
 
     // Enforce global maxInstances (across live DOM and persisted config)
     const liveDataIds = Array.from(window.asd.widgetStore.widgets.values())

--- a/src/storage/StorageManager.js
+++ b/src/storage/StorageManager.js
@@ -181,7 +181,9 @@ const StorageManager = {
       subcategory: s.subcategory || '',
       tags: Array.isArray(s.tags) ? s.tags : [],
       config: s.config || {},
-      maxInstances: s.maxInstances !== undefined ? s.maxInstances : null
+      maxInstances: s.maxInstances !== undefined ? s.maxInstances : null,
+      template: s.template,
+      fallback: s.fallback
     }))
 
     jsonSet(KEYS.SERVICES, normalizedServices)

--- a/src/storage/defaultConfig.js
+++ b/src/storage/defaultConfig.js
@@ -26,6 +26,18 @@ export const DEFAULT_CONFIG_TEMPLATE = {
     }
   },
   boards: [],
+  serviceTemplates: {
+    default: {
+      type: 'iframe',
+      maxInstances: 10,
+      config: { minColumns: 1, maxColumns: 8, minRows: 1, maxRows: 6 }
+    },
+    'api-service': {
+      type: 'api',
+      maxInstances: 5,
+      config: { minColumns: 1, maxColumns: 2, minRows: 1, maxRows: 2 }
+    }
+  },
   styling: {
     widget: { minColumns: 1, maxColumns: 8, minRows: 1, maxRows: 6 }
   }

--- a/src/types.js
+++ b/src/types.js
@@ -40,6 +40,14 @@
  */
 
 /**
+ * Base template for services.
+ * @typedef {Object} ServiceTemplate
+ * @property {string} [type]
+ * @property {ServiceConfig} [config]
+ * @property {number} [maxInstances]
+ */
+
+/**
  * External service definition.
  * @typedef {Object} Service
  * @property {string} id - A unique identifier for the service definition.
@@ -51,6 +59,8 @@
  * @property {Array<string>} [tags]
  * @property {ServiceConfig} [config]
  * @property {number} [maxInstances] Maximum allowed widget instances
+ * @property {string} [template] - The key of the template to inherit from
+ * @property {{name:string,url:string,method?:string,headers?:Object}} [fallback]
  */
 
 /**
@@ -68,6 +78,7 @@
  * @property {{enabled:string, loadDashboardFromConfig:string, defaultBoard?:string, defaultView?:string}} [globalSettings.localStorage]
  * @property {number} [globalSettings.maxTotalInstances]
  * @property {Array<Board>} [boards]
+ * @property {Object.<string, ServiceTemplate>} [serviceTemplates]
  * @property {{widget: {minColumns:number, maxColumns:number, minRows:number, maxRows:number}}} [styling]
  */
 

--- a/src/utils/serviceUtils.js
+++ b/src/utils/serviceUtils.js
@@ -1,0 +1,23 @@
+// @ts-check
+/**
+ * Utilities for resolving service configurations with templates.
+ * @module utils/serviceUtils
+ */
+import StorageManager from '../storage/StorageManager.js'
+import { deepMerge } from './objectUtils.js'
+
+/**
+ * Takes a raw service object and merges it with its declared template.
+ * The service's own properties will override any property from the template.
+ * @param {Partial<import('../types.js').Service>} rawService The service object from storage.
+ * @returns {import('../types.js').Service} The fully resolved service object.
+ */
+export function resolveServiceConfig (rawService) {
+  const config = StorageManager.getConfig()
+  const templates = config.serviceTemplates || {}
+
+  const templateName = rawService.template || 'default'
+  const baseTemplate = templates[templateName] || templates.default || {}
+
+  return /** @type {import('../types.js').Service} */ (deepMerge(baseTemplate, rawService))
+}

--- a/tests/widgetLimits.spec.ts
+++ b/tests/widgetLimits.spec.ts
@@ -6,12 +6,12 @@ import { getUnwrappedConfig, navigate } from "./shared/common";
 import { waitForWidgetStoreIdle } from "./shared/state.js";
 import { ensurePanelOpen } from "./shared/common";
 
-async function routeLimits(page, boards, services, maxSize = 2) {
+async function routeLimits(page, boards, services, maxSize = 2, configOverrides = {}) {
   await page.route("**/services.json", (route) =>
     route.fulfill({ json: services }),
   );
   await page.route("**/config.json", (route) =>
-    route.fulfill({ json: { ...ciConfig, boards } }),
+    route.fulfill({ json: { ...ciConfig, ...configOverrides, boards } }),
   );
   await page.addInitScript((size) => {
     const apply = () => {
@@ -146,4 +146,5 @@ test.describe("Widget limits", () => {
     )?.id;
     expect(selectedBoard).toBe(boardWithWidget);
   });
+
 });


### PR DESCRIPTION
## Summary
- allow defining reusable service templates in config
- resolve services against templates when creating widgets and enforcing limits
- persist template metadata for services and update sample config/services

## Testing
- `node scripts/extract-symbol-index.mjs`
- `just format`
- `just check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_b_689a2e9814c4832581c67b7a7a8a30e0