### PR TITLE
feat: show active and used widget counts

### DIFF
--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -49,7 +49,7 @@ function countServiceInstances (url) {
 }
 
 /**
- * Update the Global/Max counter in the panel.
+ * Update the Active/Used/Max counter in the panel.
  * @function updateWidgetCounter
  * @returns {void}
  */
@@ -57,16 +57,22 @@ export function updateWidgetCounter () {
   const counter = document.getElementById('widget-count')
   if (!counter) return
 
-  const total = getGlobalWidgetTotal()
+  // 1. Get "Active" count: widgets currently loaded in the store.
+  const active = widgetStore.widgets.size
 
-  // Max comes from widgetStore first (runtime cap), then config fallback.
+  // 2. Get "Used" count: total widgets configured across all boards/views.
+  const used = getGlobalWidgetTotal()
+
+  // 3. Get "Max" count: the store's eviction limit.
   const cfg = StorageManager.getConfig()
   const maxFromConfig = cfg?.globalSettings?.maxTotalInstances
   const max =
     (typeof widgetStore?.maxSize === 'number' ? widgetStore.maxSize : null) ??
     (typeof maxFromConfig === 'number' ? maxFromConfig : null)
+  const maxDisplay = max !== null ? max : '∞'
 
-  counter.textContent = `Global: ${total} / Max: ${max !== null ? max : '∞'}`
+  // 4. Update the UI text content with the new format.
+  counter.textContent = `Active: ${active} / Used: ${used} / Max: ${maxDisplay}`
 }
 
 /**

--- a/symbols.json
+++ b/symbols.json
@@ -2162,7 +2162,7 @@
     "name": "updateWidgetCounter",
     "kind": "function",
     "file": "src/component/menu/widgetSelectorPanel.js",
-    "description": "Update the Global/Max counter in the panel.",
+    "description": "Update the Active/Used/Max counter in the panel.",
     "params": [],
     "returns": "void"
   },

--- a/tests/widgetCounter.spec.ts
+++ b/tests/widgetCounter.spec.ts
@@ -24,7 +24,7 @@ test.describe('Widget counters', () => {
     await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')
     await page.locator('.widget-wrapper').first().waitFor()
 
-    await expect(page.locator('#widget-count')).toHaveText('Global: 1 / Max: 1')
+    await expect(page.locator('#widget-count')).toHaveText('Active: 1 / Used: 1 / Max: 1')
 
     await page.click('#widget-dropdown-toggle')
     const row = page.locator('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')


### PR DESCRIPTION
## Summary
- expand widget counter to show active, used, and max widget counts
- adjust widgetCounter test expectations for new counter format

## Testing
- `node scripts/extract-symbol-index.mjs`
- `just format`
- `just check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_b_689a3d302e148325b186f3c75e1ea678