### PR TITLE
Fix double-navigation and snapshot saving in environment switch flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The admin reset control clears boards, views, services and configuration while k
 
 ### Snapshot de-duplication
 
-Repeated exports with identical configuration and services no longer create duplicate snapshots. If the MD5 hash matches an existing snapshot, its timestamp is refreshed and it moves to the top of the list instead.
+Repeated exports with identical configuration and services no longer create duplicate snapshots. If the MD5 hash matches an existing snapshot, its timestamp is refreshed and it moves to the top of the list instead. Snapshots are de-duplicated by MD5 but keep their provided names.
 
 Here's the optimized version of the second part—**URL Fragment-Based Config Sharing**—to follow directly after the revised query parameter section. It's concise, technically precise, and clearly contrasts with the dynamic configuration method:
 
@@ -53,6 +53,7 @@ ASD Dashboard also supports sharing full configuration and service state using t
   * **Gzipped** and **base64url-encoded** for compactness
   * Decoded locally using modern browser APIs (e.g. `DecompressionStream`)
   * Persisted to `localStorage` when the page loads
+  * Switching environments triggers a single reload after clearing the fragment and saves the snapshot under the provided name (MD5-deduplicated)
 
 * **No servers are involved**: data stays fully client-side.
 

--- a/src/component/modal/fragmentDecisionModal.js
+++ b/src/component/modal/fragmentDecisionModal.js
@@ -36,6 +36,8 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam }) {
         clearConfigFragment()
         logger.log('Fragment decision modal closed')
         resolve()
+        // Perform a single reload after clearing the hash
+        location.reload()
       },
       buildContent: (modal, closeModal) => {
         const msg1 = document.createElement('p')
@@ -110,14 +112,18 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam }) {
             const finalName = nameEl && 'value' in nameEl && typeof nameEl.value === 'string'
               ? nameEl.value.trim() || 'Imported'
               : 'Imported'
+            await StorageManager.saveStateSnapshot({
+              name: finalName,
+              type: 'imported',
+              cfg: cfgParam ?? '',
+              svc: svcParam ?? ''
+            })
             StorageManager.setConfig(cfgObj)
             StorageManager.setServices(svcArr)
-            await StorageManager.saveStateSnapshot({ name: finalName, type: 'imported', cfg: cfgParam || '', svc: svcParam || '' })
           } catch (e) {
             logger.error('Error applying fragment:', e)
           } finally {
             closeModal()
-            location.reload()
           }
         }
       }

--- a/tests/fragment.spec.ts
+++ b/tests/fragment.spec.ts
@@ -32,6 +32,7 @@ test.describe("Secure fragments loading configuration", () => {
     // Trigger overwrite (this reloads the page)
     await page.locator('#switch-environment').click();
     await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('load');
 
     // Now re-import StorageManager in a fresh JS context
     // ToDo: refactor logic below

--- a/tests/snapshotDedupe.spec.ts
+++ b/tests/snapshotDedupe.spec.ts
@@ -55,6 +55,7 @@ import { injectSnapshot } from './shared/state.js'
   await expect(page.locator('#switch-environment')).toHaveText(/Switch environment/)
   await page.click('#switch-environment')
   await page.waitForLoadState('networkidle')
+  await page.waitForLoadState('load')
   const count = await page.evaluate(async () => {
     const { default: sm } = await import('/storage/StorageManager.js')
     return (await sm.loadStateStore()).states.length

--- a/tests/stateTab.spec.ts
+++ b/tests/stateTab.spec.ts
@@ -21,7 +21,9 @@ test.describe.skip('Saved States tab', () => {
 
     await page.locator('#stateTab tbody tr:first-child button[data-action="switch"]').click()
     await page.click('#switch-environment')
-    
+    await page.waitForLoadState('networkidle')
+    await page.waitForLoadState('load')
+
     const boards = await getBoardCount(page);
     expect(boards).toBeGreaterThan(0)
 


### PR DESCRIPTION
## Summary
- ensure fragment modal reloads once after clearing hash
- persist imported snapshot names and types before applying config/services
- wait for hash-change and reload in environment-switch tests

## Testing
- `node scripts/extract-symbol-index.mjs`
- `just format check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_689a3b3620c88325a81c6f2f8b4caac9