### PR TITLE
fix: locate unloaded widgets by service name

### DIFF
--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -283,7 +283,7 @@ export function initializeWidgetSelectorPanel () {
       const location = findFirstLocationByServiceName(name)
       if (location) {
         await switchBoard(location.boardId, location.viewId)
-        showNotification(`Navigated to view containing '${name}' widget.`)
+        showNotification(`Mapped to view containing '${name}' widget.`)
       } else {
         showNotification(`Could not find a '${name}' widget in any view.`, 3000, 'error')
       }

--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -5,13 +5,14 @@
  *
  * @module widgetSelectorPanel
  */
-import { addWidget, removeWidget, findWidgetLocation } from '../widget/widgetManagement.js'
+import { addWidget, removeWidget, findFirstLocationByServiceName } from '../widget/widgetManagement.js'
 import { widgetStore } from '../widget/widgetStore.js'
 import { switchBoard } from '../board/boardManagement.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 import StorageManager from '../../storage/StorageManager.js'
 import emojiList from '../../ui/unicodeEmoji.js'
 import { resolveServiceConfig } from '../../utils/serviceUtils.js'
+import { showNotification } from '../dialog/notification.js'
 
 /**
  * Emit a standardized state change event.
@@ -279,13 +280,14 @@ export function initializeWidgetSelectorPanel () {
 
     // Navigate to first matching widget location
     if (action === 'navigate' && name) {
-      const el = widgetStore.findFirstWidgetByService(name)
-      if (el) {
-        const loc = findWidgetLocation(el.dataset.dataid)
-        if (loc) await switchBoard(loc.boardId, loc.viewId)
+      const location = findFirstLocationByServiceName(name)
+      if (location) {
+        await switchBoard(location.boardId, location.viewId)
+        showNotification(`Navigated to view containing '${name}' widget.`)
+      } else {
+        showNotification(`Could not find a '${name}' widget in any view.`, 3000, 'error')
       }
       closePanel()
-      // No local refresh; rely on state-change if something actually altered state.
       return
     }
 

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -360,6 +360,7 @@ function findWidgetLocation (id) {
 /**
  * Finds the board and view IDs for the first widget matching a service name.
  * This searches the persistent config, not the active widget store.
+ * @function findFirstLocationByServiceName
  * @param {string} serviceName The name of the service to find.
  * @returns {{boardId: string, viewId: string} | null} Location object or null if not found.
  */

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -357,4 +357,23 @@ function findWidgetLocation (id) {
   return null
 }
 
-export { addWidget, removeWidget, updateWidgetOrders, createWidget, findWidgetLocation }
+/**
+ * Finds the board and view IDs for the first widget matching a service name.
+ * This searches the persistent config, not the active widget store.
+ * @param {string} serviceName The name of the service to find.
+ * @returns {{boardId: string, viewId: string} | null} Location object or null if not found.
+ */
+function findFirstLocationByServiceName (serviceName) {
+  const boards = StorageManager.getBoards()
+  for (const board of boards) {
+    for (const view of board.views || []) {
+      const widgetFound = (view.widgetState || []).some(w => w.type === serviceName)
+      if (widgetFound) {
+        return { boardId: board.id, viewId: view.id }
+      }
+    }
+  }
+  return null
+}
+
+export { addWidget, removeWidget, updateWidgetOrders, createWidget, findWidgetLocation, findFirstLocationByServiceName }

--- a/symbols.json
+++ b/symbols.json
@@ -635,6 +635,20 @@
     "returns": "Promise<Array<Service>>"
   },
   {
+    "name": "findFirstLocationByServiceName",
+    "kind": "function",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Finds the board and view IDs for the first widget matching a service name. This searches the persistent config, not the active widget store.",
+    "params": [
+      {
+        "name": "serviceName",
+        "type": "string",
+        "desc": "The name of the service to find."
+      }
+    ],
+    "returns": "{boardId: string, viewId: string} | null"
+  },
+  {
     "name": "findFirstWidgetByService",
     "kind": "function",
     "file": "src/component/widget/widgetStore.js",


### PR DESCRIPTION
## Summary
- add `findFirstLocationByServiceName` to search boards/views for a service
- use new function in widget selector to navigate to existing widgets and notify users

## Testing
- `just format check`
- `just test`