### PR TITLE
fix: stabilize snapshot dedupe environment switch

### DIFF
--- a/tests/data/ciServices.ts
+++ b/tests/data/ciServices.ts
@@ -1,5 +1,6 @@
 export const ciServices = [
   {
+    id: "toolbox",
     name: "ASD-toolbox",
     url: "http://localhost:8000/asd/toolbox",
     type: "api",
@@ -12,6 +13,7 @@ export const ciServices = [
     },
   },
   {
+    id: "terminal",
     name: "ASD-terminal",
     url: "http://localhost:8000/asd/terminal",
     type: "web",
@@ -24,6 +26,7 @@ export const ciServices = [
     },
   },
   {
+    id: "tunnel",
     name: "ASD-tunnel",
     url: "http://localhost:8000/asd/tunnel",
     type: "web",
@@ -36,6 +39,7 @@ export const ciServices = [
     },
   },
   {
+    id: "containers",
     name: "ASD-containers",
     url: "http://localhost:8000/asd/containers",
     type: "web",

--- a/tests/snapshotDedupe.spec.ts
+++ b/tests/snapshotDedupe.spec.ts
@@ -53,9 +53,11 @@ import { injectSnapshot } from './shared/state.js'
   await page.click('.tabs button[data-tab="stateTab"]')
   await page.locator('#stateTab tbody tr:first-child button[data-action="switch"]').click()
   await expect(page.locator('#switch-environment')).toHaveText(/Switch environment/)
-  await page.click('#switch-environment')
-  await page.waitForLoadState('networkidle')
-  await page.waitForLoadState('load')
+  await Promise.all([
+    page.waitForNavigation(),
+    page.click('#switch-environment')
+  ])
+  await page.waitForFunction(() => document.body.dataset.ready === 'true')
   const count = await page.evaluate(async () => {
     const { default: sm } = await import('/storage/StorageManager.js')
     return (await sm.loadStateStore()).states.length


### PR DESCRIPTION
## Summary
- add required `id` fields to CI service fixtures
- wait for navigation and app readiness in snapshot dedupe environment switch test

## Testing
- `just format check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_689a6d1bfae08325974a408a98fd8d50