### PR TITLE
feat(menu): add labeled Board/View submenus in Service Control

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -8,10 +8,11 @@ import { addWidget } from '../widget/widgetManagement.js'
 import { widgetStore } from '../widget/widgetStore.js'
 import { Logger } from '../../utils/Logger.js'
 import { boardGetUUID, viewGetUUID } from '../../utils/id.js'
-import StorageManager from '../../storage/StorageManager.js'
+import StorageManager, { APP_STATE_CHANGED } from '../../storage/StorageManager.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 import { saveWidgetState } from '../../storage/widgetStatePersister.js'
 import { updateWidgetCounter } from '../../component/menu/widgetSelectorPanel.js'
+import { updateServiceMenuLabels } from '../menu/serviceMenuLabels.js'
 
 /** @typedef {import('../../types.js').Board} Board */
 /** @typedef {import('../../types.js').View} View */
@@ -161,6 +162,8 @@ export async function switchView (boardId = getCurrentBoardId(), viewId) {
   }
 
   StorageManager.misc.setLastViewId(viewId)
+  updateServiceMenuLabels()
+  window.dispatchEvent(new CustomEvent(APP_STATE_CHANGED, { detail: { reason: 'switch-view' } }))
 }
 
 /**
@@ -261,6 +264,8 @@ export async function switchBoard (boardId, viewId = null) {
     updateViewSelector(boardId)
     updateWidgetCounter()
     document.dispatchEvent(new Event('view:ready'))
+    updateServiceMenuLabels()
+    window.dispatchEvent(new CustomEvent(APP_STATE_CHANGED, { detail: { reason: 'switch-board' } }))
   } else {
     logger.error(`Board with ID ${boardId} not found`)
   }
@@ -290,6 +295,8 @@ export function initializeBoards () {
       logger.log('Initializing board:', board)
       addBoardToUI(board)
     })
+
+    updateServiceMenuLabels()
 
     if (boards.length > 0) {
       const firstBoard = boards[0]
@@ -351,6 +358,9 @@ export async function renameBoard (boardId, newBoardName) {
   })
 
   if (found) {
+    updateBoardSelector()
+    updateServiceMenuLabels()
+    window.dispatchEvent(new CustomEvent(APP_STATE_CHANGED, { detail: { reason: 'rename-board' } }))
     logger.log(`Renamed board ${boardId} to ${newBoardName}`)
   } else {
     logger.error(`Board with ID ${boardId} not found`)
@@ -420,7 +430,9 @@ export async function renameView (boardId, viewId, newViewName) {
   if (!viewFound) {
     return logger.error(`View with ID ${viewId} not found`)
   }
-
+  updateViewSelector(boardId)
+  updateServiceMenuLabels()
+  window.dispatchEvent(new CustomEvent(APP_STATE_CHANGED, { detail: { reason: 'rename-view' } }))
   logger.log(`Renamed view ${viewId} to ${newViewName}`)
 }
 

--- a/src/component/menu/menu.js
+++ b/src/component/menu/menu.js
@@ -193,51 +193,55 @@ function initializeMainMenu () {
   const serviceContent = document.createElement('div')
   serviceContent.className = 'dropdown-content'
 
-  serviceContent.appendChild(widgetPanel)
-
   const boardsItem = document.createElement('div')
   boardsItem.className = 'submenu'
   boardsItem.dataset.submenu = 'board'
-  boardsItem.dataset.testid = 'submenu-boards'
-  boardsItem.textContent = 'Boards \u25B8'
-  boardsItem.setAttribute('aria-haspopup', 'true')
-  boardsItem.setAttribute('role', 'menuitem')
+  boardsItem.dataset.testid = 'menu-board'
+
+  const boardTrigger = document.createElement('button')
+  boardTrigger.className = 'submenu-trigger'
+  boardTrigger.innerHTML = '\u25BC Board: <span data-role="label-board"></span>'
+  boardsItem.appendChild(boardTrigger)
 
   const boardsMenu = document.createElement('div')
   boardsMenu.className = 'dropdown-content'
-  boardsMenu.setAttribute('role', 'menu')
+  boardsMenu.dataset.testid = 'submenu-boards'
   ;['create', 'rename', 'delete'].forEach(action => {
-    const link = document.createElement('a')
-    link.href = '#'
-    link.dataset.action = action
-    link.textContent = action.charAt(0).toUpperCase() + action.slice(1) + ' Board'
-    link.setAttribute('role', 'menuitem')
-    boardsMenu.appendChild(link)
+    const btn = document.createElement('button')
+    btn.type = 'button'
+    btn.dataset.action = action
+    btn.textContent = action.charAt(0).toUpperCase() + action.slice(1) +
+      ' Board'
+    boardsMenu.appendChild(btn)
   })
   boardsItem.appendChild(boardsMenu)
-  serviceContent.appendChild(boardsItem)
 
   const viewsItem = document.createElement('div')
   viewsItem.className = 'submenu'
   viewsItem.dataset.submenu = 'view'
-  viewsItem.dataset.testid = 'submenu-views'
-  viewsItem.textContent = 'Views \u25B8'
-  viewsItem.setAttribute('aria-haspopup', 'true')
-  viewsItem.setAttribute('role', 'menuitem')
+  viewsItem.dataset.testid = 'menu-view'
+
+  const viewTrigger = document.createElement('button')
+  viewTrigger.className = 'submenu-trigger'
+  viewTrigger.innerHTML = '\u25BC View: <span data-role="label-view"></span>'
+  viewsItem.appendChild(viewTrigger)
 
   const viewsMenu = document.createElement('div')
   viewsMenu.className = 'dropdown-content'
-  viewsMenu.setAttribute('role', 'menu')
+  viewsMenu.dataset.testid = 'submenu-views'
   ;['create', 'rename', 'delete', 'reset'].forEach(action => {
-    const link = document.createElement('a')
-    link.href = '#'
-    link.dataset.action = action
-    link.textContent = action.charAt(0).toUpperCase() + action.slice(1) + ' View'
-    link.setAttribute('role', 'menuitem')
-    viewsMenu.appendChild(link)
+    const btn = document.createElement('button')
+    btn.type = 'button'
+    btn.dataset.action = action
+    btn.textContent = action.charAt(0).toUpperCase() + action.slice(1) +
+      ' View'
+    viewsMenu.appendChild(btn)
   })
   viewsItem.appendChild(viewsMenu)
+
+  serviceContent.appendChild(boardsItem)
   serviceContent.appendChild(viewsItem)
+  serviceContent.appendChild(widgetPanel)
 
   serviceMenu.appendChild(serviceContent)
   serviceControl.appendChild(serviceMenu)

--- a/src/component/menu/serviceMenuController.js
+++ b/src/component/menu/serviceMenuController.js
@@ -22,6 +22,17 @@ export function initServiceMenu (root) {
     root.classList.remove('open'); dropdown?.classList.remove('open')
     root.querySelectorAll('.submenu.open').forEach(el => el.classList.remove('open'))
   }
+  const openSub = (sub, focus = false) => {
+    root.querySelectorAll('.submenu.open').forEach(el => { if (el !== sub) el.classList.remove('open') })
+    sub.classList.add('open')
+    if (focus) {
+      const first = /** @type {HTMLElement|null} */(sub.querySelector('[data-action]'))
+      first?.focus()
+    }
+  }
+  const closeSub = (sub) => {
+    sub.classList.remove('open')
+  }
   const handleEnter = () => {
     clearTimeout(state.timer)
     state.timer = setTimeout(open, 0)
@@ -35,11 +46,11 @@ export function initServiceMenu (root) {
 
   root.addEventListener('mouseenter', e => {
     const sub = /** @type {HTMLElement} */(e.target).closest('[data-submenu]')
-    if (sub && root.contains(sub)) sub.classList.add('open')
+    if (sub && root.contains(sub)) openSub(sub)
   }, true)
   root.addEventListener('mouseleave', e => {
     const sub = /** @type {HTMLElement} */(e.target).closest('[data-submenu]')
-    if (sub && root.contains(sub)) setTimeout(() => sub.classList.remove('open'), 200)
+    if (sub && root.contains(sub)) setTimeout(() => closeSub(sub), 200)
   }, true)
 
   root.addEventListener('click', e => {
@@ -56,9 +67,11 @@ export function initServiceMenu (root) {
 
   root.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
-      const sub = root.querySelector('.submenu.open')
+      const sub = /** @type {HTMLElement|null} */(root.querySelector('.submenu.open'))
       if (sub) {
-        sub.classList.remove('open')
+        closeSub(sub)
+        const trigger = /** @type {HTMLElement|null} */(sub.querySelector('.submenu-trigger'))
+        trigger?.focus()
       } else {
         close()
       }
@@ -66,10 +79,14 @@ export function initServiceMenu (root) {
       if (!root.classList.contains('open')) open()
     } else if (e.key === 'ArrowRight') {
       const focused = /** @type {HTMLElement|null} */(document.activeElement)?.closest('[data-submenu]')
-      if (focused) focused.classList.add('open')
+      if (focused) openSub(focused, true)
     } else if (e.key === 'ArrowLeft') {
-      const openSub = root.querySelector('.submenu.open')
-      if (openSub) openSub.classList.remove('open')
+      const openEl = /** @type {HTMLElement|null} */(root.querySelector('.submenu.open'))
+      if (openEl) {
+        closeSub(openEl)
+        const trigger = /** @type {HTMLElement|null} */(openEl.querySelector('.submenu-trigger'))
+        trigger?.focus()
+      }
     }
   })
 

--- a/src/component/menu/serviceMenuLabels.js
+++ b/src/component/menu/serviceMenuLabels.js
@@ -1,0 +1,46 @@
+// @ts-check
+/**
+ * Synchronize board and view labels within the service menu.
+ *
+ * @module serviceMenuLabels
+ */
+import StorageManager from '../../storage/StorageManager.js'
+
+/**
+ * Update the board and view label elements with current names.
+ *
+ * @function syncBoardViewLabels
+ * @param {HTMLElement|Document} [root=document] - Root element to scope the query.
+ * @returns {void}
+ */
+export function syncBoardViewLabels (root = document) {
+  const scope = /** @type {HTMLElement|Document} */ (root)
+  const boards = StorageManager.getBoards()
+  const boardId = StorageManager.misc.getLastBoardId()
+  const viewId = StorageManager.misc.getLastViewId()
+  const board = boards.find(b => b.id === boardId)
+  const boardName = board ? board.name : ''
+  const viewName = board?.views.find(v => v.id === viewId)?.name || ''
+
+  const boardLabel = scope.querySelector('[data-role="label-board"]')
+  const viewLabel = scope.querySelector('[data-role="label-view"]')
+  if (boardLabel) {
+    boardLabel.textContent = boardName
+    boardLabel.setAttribute('title', boardName)
+  }
+  if (viewLabel) {
+    viewLabel.textContent = viewName
+    viewLabel.setAttribute('title', viewName)
+  }
+}
+
+/**
+ * Convenience helper that syncs labels against the service menu root.
+ *
+ * @function updateServiceMenuLabels
+ * @returns {void}
+ */
+export function updateServiceMenuLabels () {
+  const root = document.getElementById('service-control')
+  if (root) syncBoardViewLabels(root)
+}

--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -78,6 +78,7 @@ export function __openForTests () {
   const panel = document.getElementById('widget-selector-panel')
   panel?.classList.add('open')
   const root = panel?.closest('#service-control')
+  root?.dispatchEvent(new Event('mouseenter'))
   root?.classList.add('open')
   root?.querySelector('[data-testid="service-menu"]')?.classList.add('open')
 }

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ import { widgetStore } from './component/widget/widgetStore.js'
 import { debounce, debounceLeading } from './utils/utils.js'
 import StorageManager, { APP_STATE_CHANGED } from './storage/StorageManager.js'
 import { runSilentImportFlowIfRequested } from './flows/silentImportFlow.js'
+import { updateServiceMenuLabels } from './component/menu/serviceMenuLabels.js'
 
 // NEW: widget selector panel (replaces populateServiceDropdown())
 import {
@@ -74,14 +75,14 @@ async function main () {
       const detail = /** @type {any} */ (e).detail || {}
       const { scope, action } = detail
       if (scope === 'board') {
-        if (action === 'create') void handleCreateBoard()
-        else if (action === 'rename') void handleRenameBoard()
-        else if (action === 'delete') void handleDeleteBoard()
+        if (action === 'create') void handleCreateBoard().then(updateServiceMenuLabels)
+        else if (action === 'rename') void handleRenameBoard().then(updateServiceMenuLabels)
+        else if (action === 'delete') void handleDeleteBoard().then(updateServiceMenuLabels)
       } else if (scope === 'view') {
-        if (action === 'create') void handleCreateView()
-        else if (action === 'rename') void handleRenameView()
-        else if (action === 'delete') void handleDeleteView()
-        else if (action === 'reset') void handleResetView()
+        if (action === 'create') void handleCreateView().then(updateServiceMenuLabels)
+        else if (action === 'rename') void handleRenameView().then(updateServiceMenuLabels)
+        else if (action === 'delete') void handleDeleteView().then(updateServiceMenuLabels)
+        else if (action === 'reset') void handleResetView().then(updateServiceMenuLabels)
       }
     })
     /* eslint-enable no-void */
@@ -135,6 +136,7 @@ async function main () {
     logger.log(`Switching to initial board: ${boardIdToLoad}, view: ${viewIdToLoad}`)
     await switchBoard(boardIdToLoad, viewIdToLoad)
     updateViewSelector(boardIdToLoad)
+    updateServiceMenuLabels()
   } else {
     logger.warn('No boards available to display.')
   }
@@ -159,6 +161,10 @@ async function main () {
     logger.log(`[Event Listener] Reacting to state change. Reason: ${reason || 'unknown'}`)
 
     const currentBoardId = getCurrentBoardId()
+
+    if (['config', 'switch-board', 'switch-view', 'rename-board', 'rename-view'].includes(reason)) {
+      updateServiceMenuLabels()
+    }
 
     switch (reason) {
       case 'config':

--- a/src/ui/controls.css
+++ b/src/ui/controls.css
@@ -245,5 +245,20 @@ menu {
 }
 .dropdown.open > .dropdown-content { display: block; }
 .submenu { position: relative; }
-.submenu > .dropdown-content { top: 0; left: 100%; }
+.submenu > .dropdown-content {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  min-width: 220px;
+  display: none;
+  z-index: 11;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+  padding: 4px 0;
+}
 .submenu.open > .dropdown-content { display: block; }
+.submenu-trigger {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 28ch;
+}

--- a/tests/persistence.spec.ts
+++ b/tests/persistence.spec.ts
@@ -13,8 +13,9 @@ test.describe('Board persistence', () => {
 
   test('new board persists after reload', async ({ page }) => {
     await handleDialog(page, 'prompt', boardName)
-    await page.click('#board-dropdown .dropbtn')
-    await page.click('#board-control a[data-action="create"]')
+    await page.hover('[data-testid="service-menu"]')
+    await page.hover('[data-testid="menu-board"]')
+    await page.click('[data-testid="submenu-boards"] [data-action="create"]')
     await expect(page.locator('#board-selector')).toContainText(boardName)
 
     await page.reload()
@@ -25,8 +26,9 @@ test.describe('Board persistence', () => {
 
   test('last view persists after reload', async ({ page }) => {
     await handleDialog(page, 'prompt', 'Second View')
-    await page.click('#view-dropdown .dropbtn')
-    await page.click('#view-control a[data-action="create"]')
+    await page.hover('[data-testid="service-menu"]')
+    await page.hover('[data-testid="menu-view"]')
+    await page.click('[data-testid="submenu-views"] [data-action="create"]')
     await expect(page.locator('#view-selector option:checked')).toHaveText('Second View')
 
     await page.reload()


### PR DESCRIPTION
## Summary
- add side dropdowns for Board and View actions under Service Control
- sync submenu labels with current board and view
- update controller for nested hover and keyboard navigation

## Testing
- `just format`
- `just check`
- `just test` *(fails: dynamicConfig.spec.ts:147, dynamicConfig.spec.ts:169, persistence.spec.ts, serviceMenu.spec.ts, widgetCounter.spec.ts, widgetLimits.spec.ts, widgetSearch.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_b_689a7166af1c8325b98a9b38207b4ab5