### PR TITLE
Refactor widget counter display

### DIFF
--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -49,7 +49,7 @@ function countServiceInstances (url) {
 }
 
 /**
- * Update the Active/Used/Max counter in the panel.
+ * Update the Running/Max and total Widgets counter in the panel.
  * @function updateWidgetCounter
  * @returns {void}
  */
@@ -57,13 +57,13 @@ export function updateWidgetCounter () {
   const counter = document.getElementById('widget-count')
   if (!counter) return
 
-  // 1. Get "Active" count: widgets currently loaded in the store.
-  const active = widgetStore.widgets.size
+  // "Running" is the count of widgets currently loaded in the widgetStore.
+  const running = widgetStore.widgets.size
 
-  // 2. Get "Used" count: total widgets configured across all boards/views.
-  const used = getGlobalWidgetTotal()
+  // "Widgets" is the total count of all widgets configured across all boards and views.
+  const widgets = getGlobalWidgetTotal()
 
-  // 3. Get "Max" count: the store's eviction limit.
+  // "Max" is the eviction limit of the widgetStore.
   const cfg = StorageManager.getConfig()
   const maxFromConfig = cfg?.globalSettings?.maxTotalInstances
   const max =
@@ -71,8 +71,8 @@ export function updateWidgetCounter () {
     (typeof maxFromConfig === 'number' ? maxFromConfig : null)
   const maxDisplay = max !== null ? max : '∞'
 
-  // 4. Update the UI text content with the new format.
-  counter.textContent = `Active: ${active} / Used: ${used} / Max: ${maxDisplay}`
+  // Update the UI text content with the new format.
+  counter.textContent = `Running: ${running}/${maxDisplay} / Widgets: ${widgets}`
 }
 
 /**

--- a/symbols.json
+++ b/symbols.json
@@ -2162,7 +2162,7 @@
     "name": "updateWidgetCounter",
     "kind": "function",
     "file": "src/component/menu/widgetSelectorPanel.js",
-    "description": "Update the Active/Used/Max counter in the panel.",
+    "description": "Update the Running/Max and total Widgets counter in the panel.",
     "params": [],
     "returns": "void"
   },

--- a/tests/widgetCounter.spec.ts
+++ b/tests/widgetCounter.spec.ts
@@ -24,7 +24,7 @@ test.describe('Widget counters', () => {
     await page.click('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')
     await page.locator('.widget-wrapper').first().waitFor()
 
-    await expect(page.locator('#widget-count')).toHaveText('Active: 1 / Used: 1 / Max: 1')
+    await expect(page.locator('#widget-count')).toHaveText('Running: 1/1 / Widgets: 1')
 
     await page.click('#widget-dropdown-toggle')
     const row = page.locator('#widget-selector-panel .widget-option:has-text("ASD-toolbox")')


### PR DESCRIPTION
## Summary
- update widget selector panel counter to show `Running: active/max / Widgets: total`
- adjust widget counter test for new text format

## Testing
- `just format`
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_689a819f7bb0832591ca55bbc8e75cdc