### PR TITLE
Use serviceId for Locate widget navigation

### DIFF
--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -5,7 +5,7 @@
  *
  * @module widgetSelectorPanel
  */
-import { addWidget, removeWidget, findFirstLocationByServiceName } from '../widget/widgetManagement.js'
+import { addWidget, removeWidget, findFirstLocationByServiceId } from '../widget/widgetManagement.js'
 import { widgetStore } from '../widget/widgetStore.js'
 import { switchBoard } from '../board/boardManagement.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
@@ -150,6 +150,7 @@ export function populateWidgetSelectorPanel () {
     const item = document.createElement('div')
     item.className = 'widget-option'
     item.dataset.name = resolved.name
+    item.dataset.serviceId = resolved.id
     if (resolved.category) item.dataset.category = resolved.category
     if (resolved.subcategory) item.dataset.subcategory = resolved.subcategory
     if (Array.isArray(resolved.tags)) item.dataset.tags = resolved.tags.join(',')
@@ -239,6 +240,7 @@ export function initializeWidgetSelectorPanel () {
     const action = target.dataset.action
     const url = item.dataset.url
     const name = item.dataset.name
+    const serviceId = item.dataset.serviceId
 
     // Edit service metadata
     if (action === 'edit' && name) {
@@ -279,8 +281,8 @@ export function initializeWidgetSelectorPanel () {
     }
 
     // Navigate to first matching widget location
-    if (action === 'navigate' && name) {
-      const location = findFirstLocationByServiceName(name)
+    if (action === 'navigate' && serviceId) {
+      const location = findFirstLocationByServiceId(serviceId)
       if (location) {
         await switchBoard(location.boardId, location.viewId)
         showNotification(`Mapped to view containing '${name}' widget.`)

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -377,4 +377,26 @@ function findFirstLocationByServiceName (serviceName) {
   return null
 }
 
-export { addWidget, removeWidget, updateWidgetOrders, createWidget, findWidgetLocation, findFirstLocationByServiceName }
+/**
+ * Finds the board and view IDs for the first widget matching a service ID.
+ * @function findFirstLocationByServiceId
+ * @param {string} serviceId The ID of the service to find.
+ * @returns {{boardId: string, viewId: string} | null} Location or null if not found.
+ */
+function findFirstLocationByServiceId (serviceId) {
+  if (!serviceId) return null
+  const boards = StorageManager.getBoards()
+  if (!Array.isArray(boards)) return null
+
+  for (const board of boards) {
+    if (!board || !Array.isArray(board.views)) continue
+    for (const view of board.views) {
+      const widgets = Array.isArray(view?.widgetState) ? view.widgetState : []
+      const hasMatch = widgets.some(w => w && 'serviceId' in w && w.serviceId === serviceId)
+      if (hasMatch) return { boardId: board.id, viewId: view.id }
+    }
+  }
+  return null
+}
+
+export { addWidget, removeWidget, updateWidgetOrders, createWidget, findWidgetLocation, findFirstLocationByServiceName, findFirstLocationByServiceId }

--- a/symbols.json
+++ b/symbols.json
@@ -635,6 +635,20 @@
     "returns": "Promise<Array<Service>>"
   },
   {
+    "name": "findFirstLocationByServiceId",
+    "kind": "function",
+    "file": "src/component/widget/widgetManagement.js",
+    "description": "Finds the board and view IDs for the first widget matching a service ID.",
+    "params": [
+      {
+        "name": "serviceId",
+        "type": "string",
+        "desc": "The ID of the service to find."
+      }
+    ],
+    "returns": "{boardId: string, viewId: string} | null"
+  },
+  {
     "name": "findFirstLocationByServiceName",
     "kind": "function",
     "file": "src/component/widget/widgetManagement.js",


### PR DESCRIPTION
## Summary
- attach each service's unique id to widget selector entries
- add helper to resolve a widget's location by service id
- navigate to widgets using service ids instead of names

## Testing
- `node scripts/extract-symbol-index.mjs`
- `just format`
- `just check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_b_689a872d40f88325a924013242cb672f