### PR TITLE
refactor: navigate to widgets via persisted config

### DIFF
--- a/src/component/menu/widgetSelectorPanel.js
+++ b/src/component/menu/widgetSelectorPanel.js
@@ -5,13 +5,21 @@
  *
  * @module widgetSelectorPanel
  */
-import { addWidget, removeWidget, findWidgetLocation } from '../widget/widgetManagement.js'
+import {
+  addWidget,
+  removeWidget,
+  findServiceLocation
+} from '../widget/widgetManagement.js'
 import { widgetStore } from '../widget/widgetStore.js'
 import { switchBoard } from '../board/boardManagement.js'
 import { getCurrentBoardId, getCurrentViewId } from '../../utils/elements.js'
 import StorageManager from '../../storage/StorageManager.js'
 import emojiList from '../../ui/unicodeEmoji.js'
 import { resolveServiceConfig } from '../../utils/serviceUtils.js'
+import { showNotification } from '../dialog/notification.js'
+import { Logger } from '../../utils/Logger.js'
+
+const logger = new Logger('widgetSelectorPanel.js')
 
 /**
  * Emit a standardized state change event.
@@ -283,15 +291,40 @@ export function initializeWidgetSelectorPanel () {
       return
     }
 
-    // Navigate to first matching widget location
+    // Navigate to first matching widget location by searching the persisted config.
     if (action === 'navigate' && name) {
-      const el = widgetStore.findFirstWidgetByService(name)
-      if (el) {
-        const loc = findWidgetLocation(el.dataset.dataid)
-        if (loc) await switchBoard(loc.boardId, loc.viewId)
+      const service = (StorageManager.getServices() || []).find(
+        s => s.name === name
+      )
+      if (!service || !service.id) {
+        showNotification(
+          `Error: Could not find service definition for "${name}".`,
+          4000,
+          'error'
+        )
+        logger.error(`Service with name "${name}" not found in StorageManager.`)
+        closePanel()
+        return
       }
+
+      const location = findServiceLocation(service.id)
+
+      if (location) {
+        await switchBoard(location.boardId, location.viewId)
+        showNotification(
+          `Navigated to view containing "${name}".`,
+          2500,
+          'success'
+        )
+      } else {
+        showNotification(
+          `No instances of "${name}" found in any board.`,
+          3000,
+          'error'
+        )
+      }
+
       closePanel()
-      // No local refresh; rely on state-change if something actually altered state.
       return
     }
 

--- a/src/component/widget/widgetManagement.js
+++ b/src/component/widget/widgetManagement.js
@@ -358,4 +358,32 @@ function findWidgetLocation (id) {
   return null
 }
 
-export { addWidget, removeWidget, updateWidgetOrders, createWidget, findWidgetLocation }
+/**
+ * Find the board and view containing the first instance of a widget by its serviceId.
+ * This function scans the persisted configuration, not the live widgetStore.
+ * @param {string} serviceId - The unique ID of the service to find.
+ * @returns {{boardId: string, viewId: string} | null} The location or null if not found.
+ */
+function findServiceLocation (serviceId) {
+  const boards = StorageManager.getBoards()
+  if (!boards || !serviceId) return null
+
+  for (const board of boards) {
+    for (const view of board.views || []) {
+      const exists = (view.widgetState || []).some(
+        w => w.serviceId === serviceId
+      )
+      if (exists) return { boardId: board.id, viewId: view.id }
+    }
+  }
+  return null
+}
+
+export {
+  addWidget,
+  removeWidget,
+  updateWidgetOrders,
+  createWidget,
+  findWidgetLocation,
+  findServiceLocation
+}


### PR DESCRIPTION
## Summary
- add `findServiceLocation` to scan stored boards/views for a service ID
- use persisted configuration in widget selector's navigate action
- surface notifications and logging for missing services or instances

## Testing
- `just format`
- `just check`
- `just test` *(fails: fragment.spec.ts:13:7 > Secure fragments loading configuration > import modal pre-fills name and saves snapshot)*

------
https://chatgpt.com/codex/tasks/task_b_689a9068f7cc832585f7c1518779d396