### PR TITLE
Add dual-mode editing to config modal

### DIFF
--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -12,6 +12,7 @@ import StorageManager from '../../storage/StorageManager.js'
 import { DEFAULT_CONFIG_TEMPLATE } from '../../storage/defaultConfig.js'
 import { exportConfig } from '../configModal/exportConfig.js'
 import { openFragmentDecisionModal } from './fragmentDecisionModal.js'
+import { JsonForm } from '../utils/json-form.js'
 
 /** @typedef {import('../../types.js').DashboardConfig} DashboardConfig */
 
@@ -27,6 +28,7 @@ export async function openConfigModal () {
   const storedConfig = StorageManager.getConfig()
   const configData = storedConfig || { ...DEFAULT_CONFIG_TEMPLATE }
   const last = StorageManager.misc.getItem('configModalTab') || 'cfgTab'
+  let cfgForm, svcForm
 
   openModal({
     id: 'config-modal',
@@ -37,22 +39,90 @@ export async function openConfigModal () {
           id: 'cfgTab',
           label: 'Configuration',
           contentFn: () => {
+            const wrap = document.createElement('div')
+            wrap.classList.add('modal__tab--column')
+
+            const toggle = document.createElement('button')
+            toggle.textContent = 'JSON mode'
+            toggle.classList.add('modal__btn', 'modal__btn--toggle')
+
+            const formDiv = document.createElement('div')
+            formDiv.id = 'config-form'
+            formDiv.classList.add('modal__jsonform', 'modal__textarea--grow')
+            cfgForm = new JsonForm(formDiv, configData)
+
             const textarea = document.createElement('textarea')
             textarea.id = 'config-json'
             textarea.classList.add('modal__textarea--grow')
+            textarea.style.display = 'none'
             textarea.value = JSON.stringify(configData, null, 2)
-            return textarea
+
+            toggle.addEventListener('click', () => {
+              if (formDiv.style.display !== 'none') {
+                const val = cfgForm.getValue()
+                textarea.value = JSON.stringify(val, null, 2)
+                formDiv.style.display = 'none'
+                textarea.style.display = 'block'
+                toggle.textContent = 'Form mode'
+              } else {
+                try {
+                  cfgForm.setValue(JSON.parse(textarea.value))
+                  textarea.style.display = 'none'
+                  formDiv.style.display = 'block'
+                  toggle.textContent = 'JSON mode'
+                } catch (e) {
+                  showNotification('Invalid JSON format', 3000, 'error')
+                }
+              }
+            })
+
+            wrap.append(toggle, formDiv, textarea)
+            return wrap
           }
         },
         {
           id: 'svcTab',
           label: 'Services',
           contentFn: () => {
+            const wrap = document.createElement('div')
+            wrap.classList.add('modal__tab--column')
+
+            const toggle = document.createElement('button')
+            toggle.textContent = 'JSON mode'
+            toggle.classList.add('modal__btn', 'modal__btn--toggle')
+
+            const formDiv = document.createElement('div')
+            formDiv.id = 'services-form'
+            formDiv.classList.add('modal__jsonform', 'modal__textarea--grow')
+            svcForm = new JsonForm(formDiv, StorageManager.getServices())
+
             const textarea = document.createElement('textarea')
             textarea.id = 'config-services'
             textarea.classList.add('modal__textarea--grow')
+            textarea.style.display = 'none'
             textarea.value = JSON.stringify(StorageManager.getServices(), null, 2)
-            return textarea
+
+            toggle.addEventListener('click', () => {
+              if (formDiv.style.display !== 'none') {
+                const val = svcForm.getValue()
+                textarea.value = JSON.stringify(val, null, 2)
+                formDiv.style.display = 'none'
+                textarea.style.display = 'block'
+                toggle.textContent = 'Form mode'
+              } else {
+                try {
+                  svcForm.setValue(JSON.parse(textarea.value))
+                  textarea.style.display = 'none'
+                  formDiv.style.display = 'block'
+                  toggle.textContent = 'JSON mode'
+                } catch (e) {
+                  showNotification('Invalid JSON format', 3000, 'error')
+                }
+              }
+            })
+
+            wrap.append(toggle, formDiv, textarea)
+            return wrap
           }
         },
         {
@@ -113,18 +183,26 @@ export async function openConfigModal () {
       saveButton.addEventListener('click', () => {
         /** @type {HTMLTextAreaElement|null} */
         const cfgEl = modal.querySelector('#config-json')
+        /** @type {HTMLDivElement|null} */
+        const cfgFormDiv = modal.querySelector('#config-form')
         /** @type {HTMLTextAreaElement|null} */
         const svcEl = modal.querySelector('#config-services')
+        /** @type {HTMLDivElement|null} */
+        const svcFormDiv = modal.querySelector('#services-form')
         let cfg, svc
         try {
-          cfg = cfgEl ? JSON.parse(cfgEl.value) : {}
+          cfg = cfgFormDiv && cfgFormDiv.style.display !== 'none'
+            ? cfgForm.getValue()
+            : cfgEl ? JSON.parse(cfgEl.value) : {}
         } catch (e) {
           logger.error('Invalid config JSON:', e)
           showNotification('Invalid config JSON format', 3000, 'error')
           return
         }
         try {
-          svc = svcEl ? JSON.parse(svcEl.value) : []
+          svc = svcFormDiv && svcFormDiv.style.display !== 'none'
+            ? svcForm.getValue()
+            : svcEl ? JSON.parse(svcEl.value) : []
         } catch (e) {
           logger.error('Invalid services JSON:', e)
           showNotification('Invalid services JSON format', 3000, 'error')

--- a/src/component/utils/json-form.js
+++ b/src/component/utils/json-form.js
@@ -1,0 +1,161 @@
+// @ts-check
+/**
+ * Lightweight renderer to edit plain objects as HTML inputs.
+ * Supports nested objects and arrays with add/remove controls.
+ *
+ * @module json-form
+ * @class JsonForm
+ */
+export class JsonForm {
+  /**
+   * @constructor
+   * @param {HTMLElement} container element that will host the form
+   * @param {object} [data={}] initial object to render
+   */
+  constructor (container, data = {}) {
+    this.container = container
+    this.setValue(data)
+  }
+
+  /**
+   * Replace current data and re-render the form.
+   *
+   * @param {object} data new object to display
+   */
+  setValue (data) {
+    this.data = structuredClone(data)
+    this.container.innerHTML = ''
+    this.container.appendChild(this.#renderNode(this.data))
+  }
+
+  /**
+   * Get current object value.
+   *
+   * @returns {object}
+   */
+  getValue () {
+    return structuredClone(this.data)
+  }
+
+  /**
+   * Render any value type.
+   *
+   * @param {*} value
+   * @param {object|Array} [parent]
+   * @param {string|number} [key]
+   * @returns {HTMLElement}
+   */
+  #renderNode (value, parent, key) {
+    if (Array.isArray(value)) return this.#renderArray(value, parent, key)
+    if (value && typeof value === 'object') return this.#renderObject(value, parent, key)
+    return this.#renderPrimitive(value, parent, key)
+  }
+
+  /**
+   * Render object properties.
+   *
+   * @param {object} obj
+   * @param {object|Array|undefined} parent
+   * @param {string|number|undefined} key
+   * @returns {HTMLElement}
+   */
+  #renderObject (obj, parent, key) {
+    const wrap = document.createElement('div')
+    Object.keys(obj).forEach(k => {
+      const label = document.createElement('label')
+      label.className = 'modal__label'
+      label.textContent = k
+      wrap.appendChild(label)
+      wrap.appendChild(this.#renderNode(obj[k], obj, k))
+    })
+    return wrap
+  }
+
+  /**
+   * Render array with add/remove controls.
+   *
+   * @param {Array} arr
+   * @param {object|Array|undefined} parent
+   * @param {string|number|undefined} key
+   * @returns {HTMLElement}
+   */
+  #renderArray (arr, parent, key) {
+    const wrap = document.createElement('div')
+    arr.forEach((item, i) => {
+      const row = document.createElement('div')
+      row.style.display = 'flex'
+      row.style.alignItems = 'center'
+      row.style.gap = '0.25rem'
+      row.appendChild(this.#renderNode(item, arr, i))
+      const del = document.createElement('button')
+      del.type = 'button'
+      del.textContent = '−'
+      del.addEventListener('click', () => {
+        arr.splice(i, 1)
+        this.setValue(this.data)
+      })
+      row.appendChild(del)
+      wrap.appendChild(row)
+    })
+    const add = document.createElement('button')
+    add.type = 'button'
+    add.textContent = '+'
+    add.addEventListener('click', () => {
+      arr.push(this.#defaultFor(arr[0]))
+      this.setValue(this.data)
+    })
+    wrap.appendChild(add)
+    return wrap
+  }
+
+  /**
+   * Render a primitive input.
+   *
+   * @param {*} value
+   * @param {object|Array} parent
+   * @param {string|number} key
+   * @returns {HTMLElement}
+   */
+  #renderPrimitive (value, parent, key) {
+    let el
+    const t = typeof value
+    if (t === 'number') {
+      el = document.createElement('input')
+      el.type = 'number'
+      el.value = String(value)
+      el.addEventListener('input', () => {
+        parent[key] = el.value === '' ? 0 : Number(el.value)
+      })
+    } else if (t === 'boolean') {
+      el = document.createElement('input')
+      el.type = 'checkbox'
+      el.checked = Boolean(value)
+      el.addEventListener('change', () => {
+        parent[key] = el.checked
+      })
+    } else {
+      el = document.createElement('input')
+      el.type = 'text'
+      el.value = value == null ? '' : String(value)
+      el.addEventListener('input', () => {
+        parent[key] = el.value
+      })
+    }
+    return el
+  }
+
+  /**
+   * Guess default value for new array items.
+   *
+   * @param {*} sample
+   * @returns {*}
+   */
+  #defaultFor (sample) {
+    const t = typeof sample
+    if (t === 'number') return 0
+    if (t === 'boolean') return false
+    if (Array.isArray(sample)) return []
+    if (sample && t === 'object') return {}
+    return ''
+  }
+}

--- a/src/ui/modal.css
+++ b/src/ui/modal.css
@@ -84,3 +84,17 @@
   flex-direction: column;
   gap: 0.5rem;
 }
+
+.modal__jsonform {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow-y: auto;
+}
+
+.modal__btn--toggle {
+  align-self: flex-end;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}

--- a/symbols.json
+++ b/symbols.json
@@ -1221,6 +1221,14 @@
     "returns": "boolean"
   },
   {
+    "name": "JsonForm",
+    "kind": "class",
+    "file": "src/component/utils/json-form.js",
+    "description": "Lightweight renderer to edit plain objects as HTML inputs. Supports nested objects and arrays with add/remove controls.",
+    "params": [],
+    "returns": ""
+  },
+  {
     "name": "jsonGet",
     "kind": "function",
     "file": "src/storage/StorageManager.js",
@@ -1382,6 +1390,22 @@
       }
     ],
     "returns": "Array<Service>"
+  },
+  {
+    "name": "mountBoardControl",
+    "kind": "function",
+    "file": "src/component/board/BoardControl.js",
+    "description": "Mount board control into #board-control.",
+    "params": [],
+    "returns": "SelectorPanel|null"
+  },
+  {
+    "name": "mountViewControl",
+    "kind": "function",
+    "file": "src/component/view/ViewControl.js",
+    "description": "Mount view control into #view-control.",
+    "params": [],
+    "returns": "SelectorPanel|null"
   },
   {
     "name": "openConfigModal",

--- a/tests/configConsistency.spec.ts
+++ b/tests/configConsistency.spec.ts
@@ -15,6 +15,7 @@ test.describe('config consistency', () => {
 
   test('open-config-modal shows boards after reset', async ({ page }) => {
     await page.click('#open-config-modal')
+    await page.click('#config-modal .modal__btn--toggle')
     const text = await page.locator('#config-json').inputValue()
     const cfg = JSON.parse(text)
     expect(Array.isArray(cfg.boards)).toBeTruthy()
@@ -23,6 +24,7 @@ test.describe('config consistency', () => {
 
   test('config matches localStorage after save', async ({ page }) => {
     await page.click('#open-config-modal')
+    await page.click('#config-modal .modal__btn--toggle')
     const cfgText = await page.locator('#config-json').inputValue()
     const cfg = JSON.parse(cfgText)
     await page.click('#config-modal .modal__btn--cancel')
@@ -32,6 +34,7 @@ test.describe('config consistency', () => {
 
   test('saving config without boards removes boards storage', async ({ page }) => {
     await page.click('#open-config-modal')
+    await page.click('#config-modal .modal__btn--toggle')
     const textarea = page.locator('#config-json')
     const cfg = JSON.parse(await textarea.inputValue())
     delete cfg.boards

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -152,7 +152,7 @@ test.describe("Dashboard Config - Fallback Config Popup", () => {
       import("/component/modal/configModal.js").then((m) => m.openConfigModal())
     );
 
-    await page.waitForSelector("#config-json");
+    await page.click('button:has-text("JSON mode")');
     await page.fill("#config-json", JSON.stringify(ciConfig));
     await page.click("#config-modal .modal__btn--save");
 
@@ -177,8 +177,10 @@ test.describe("Dashboard Config - LocalStorage Behavior", () => {
     await navigate(page, `/?config_base64=${b64(ciConfig)}`);
 
     await page.click("#open-config-modal");
+    await page.click('button:has-text("JSON mode")');
     await page.fill("#config-json", JSON.stringify({ ...ciConfig, boards: [] }));
     await page.click('button:has-text("Services")');
+    await page.click('button:has-text("JSON mode")');
     await page.fill('#config-services', JSON.stringify([{ name: 'svc1', url: 'http://svc1' }]));
     await page.click("#config-modal .modal__btn--save");
     await page.reload();


### PR DESCRIPTION
## Summary
- introduce lightweight `JsonForm` class to render nested objects/arrays with native inputs and +/- controls
- enable configuration modal to toggle between form and raw JSON for configuration and services
- add styling and tests for form/JSON mode switch

## Testing
- `just format check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_689aa734ddc48325ad49adf0e7e33bc6