### PR TITLE
chore(url): add fragment chunking + schema-aware minimizer (built-ins only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ ASD Dashboard also supports sharing full configuration and service state using t
 ### Practical Limits
 
 * Works reliably up to \~60KB total URL length (more than enough for hundreds of services)
-* Shows a warning if the link becomes too large for some browsers
+* Very long `cfg`/`svc` parameters are automatically chunked (`cfg0,cfg1,...`) when exceeding 12KB each. A `chunks` manifest (e.g. `chunks=cfg:3;svc:2`) plus a whole-payload checksum `ccw` guard reassembly.
+* Shows a warning if the link becomes too large even after chunking
 * Fails gracefully if compression is unsupported (e.g., older Safari versions)
 
 ### Use Case Example

--- a/src/component/modal/fragmentDecisionModal.js
+++ b/src/component/modal/fragmentDecisionModal.js
@@ -90,7 +90,7 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam, algo
          */
         async function applyFragment (overwrite) {
           try {
-            const algo = algoParam || new URLSearchParams(location.hash.slice(1)).get('algo') || 'gzip'
+            const algo = /** @type {'gzip'|'deflate'} */ (algoParam || new URLSearchParams(location.hash.slice(1)).get('algo') || 'gzip')
             const cc = ccParam || new URLSearchParams(location.hash.slice(1)).get('cc')
             const checks = cc ? cc.split(',') : []
             const cfgChecksum = checks[0] || null

--- a/src/utils/chunker.js
+++ b/src/utils/chunker.js
@@ -1,0 +1,86 @@
+// @ts-check
+/**
+ * Deterministic splitter/joiner for long fragment parameters.
+ *
+ * @module chunker
+ */
+
+/**
+ * Split a string into URL fragment parameters, adding numeric suffixes when needed.
+ *
+ * @function splitIntoParams
+ * @param {string} name
+ * @param {string} data
+ * @param {number} maxLen
+ * @returns {Array<[string,string]>}
+ */
+export function splitIntoParams (name, data, maxLen) {
+  if (data.length <= maxLen) return [[name, data]]
+  /** @type {Array<[string,string]>} */
+  const out = []
+  let i = 0
+  for (let off = 0; off < data.length; off += maxLen) {
+    const part = data.slice(off, off + maxLen)
+    out.push([`${name}${i}`, part])
+    i++
+  }
+  return out
+}
+
+/**
+ * Join numbered fragment parameters back into a single string.
+ *
+ * @function joinFromParams
+ * @param {string} name
+ * @param {URLSearchParams} params
+ * @returns {string|null}
+ */
+export function joinFromParams (name, params) {
+  const single = params.get(name)
+  if (single) return single
+
+  /** @type {Array<[number,string]>} */
+  const parts = []
+  for (const [k, v] of params.entries()) {
+    if (k.startsWith(name)) {
+      const idx = Number(k.slice(name.length))
+      if (Number.isInteger(idx)) parts.push([idx, v])
+    }
+  }
+  if (parts.length === 0) return null
+  parts.sort((a, b) => a[0] - b[0])
+  return parts.map(([, v]) => v).join('')
+}
+
+/**
+ * Parse a chunk manifest string like "cfg:3;svc:2".
+ *
+ * @function parseChunksManifest
+ * @param {string} s
+ * @returns {Record<string,number>}
+ */
+export function parseChunksManifest (s) {
+  /** @type {Record<string, number>} */ const out = {}
+  if (!s) return out
+  for (const seg of s.split(';')) {
+    const [k, v] = seg.split(':')
+    if (!k) continue
+    const n = Number(v)
+    if (Number.isFinite(n) && n >= 0) out[k] = n
+  }
+  return out
+}
+
+/**
+ * Format a chunk manifest object to a string.
+ *
+ * @function formatChunksManifest
+ * @param {Record<string,number>} m
+ * @returns {string}
+ */
+export function formatChunksManifest (m) {
+  return Object.entries(m)
+    .filter(([, n]) => Number.isFinite(n) && n > 0)
+    .map(([k, n]) => `${k}:${n}`)
+    .join(';')
+}

--- a/src/utils/minimizer.js
+++ b/src/utils/minimizer.js
@@ -1,0 +1,84 @@
+// @ts-check
+/**
+ * Schema-aware, reversible minimizer for dashboard payloads.
+ * Drops fields equal to provided defaults and optionally prunes empty values.
+ *
+ * @module minimizer
+ */
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v)
+
+/**
+ * Recursively prune defaults and empties from a value.
+ *
+ * @function minimizeDeep
+ * @param {any} value
+ * @param {any} defaults
+ * @param {{ dropEmpties?: boolean }} [opts]
+ * @returns {any}
+ */
+export function minimizeDeep (value, defaults, opts = {}) {
+  const dropEmpties = !!opts.dropEmpties
+
+  if (!isObj(value)) {
+    if (value === defaults) return undefined
+    if (dropEmpties && (value === '' || value === null)) return undefined
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    const out = value
+      .map((el, i) => minimizeDeep(el, Array.isArray(defaults) ? defaults[i] : undefined, opts))
+      .filter((el) => !(dropEmpties && (el === undefined || el === null || (Array.isArray(el) && el.length === 0))))
+    return (dropEmpties && out.length === 0) ? undefined : out
+  }
+
+  /** @type {Record<string, any>} */
+  const out = {}
+  let kept = 0
+  for (const [k, v] of Object.entries(value)) {
+    const def = isObj(defaults) ? defaults[k] : undefined
+    if (def === undefined && !(k in (defaults || {}))) {
+      out[k] = v
+      kept++
+      continue
+    }
+    const pruned = minimizeDeep(v, def, opts)
+    if (pruned !== undefined) {
+      out[k] = pruned
+      kept++
+    }
+  }
+  if (kept === 0 && dropEmpties) return undefined
+  return out
+}
+
+/**
+ * Restore pruned values by filling defaults for missing keys.
+ *
+ * @function restoreDeep
+ * @param {any} minimized
+ * @param {any} defaults
+ * @returns {any}
+ */
+export function restoreDeep (minimized, defaults) {
+  if (!isObj(defaults)) return minimized ?? defaults
+
+  if (Array.isArray(defaults)) {
+    if (!Array.isArray(minimized)) return defaults
+    const maxLen = Math.max(minimized.length, defaults.length)
+    const out = new Array(maxLen)
+    for (let i = 0; i < maxLen; i++) {
+      out[i] = restoreDeep(minimized[i], defaults[i])
+    }
+    return out
+  }
+
+  /** @type {Record<string, any>} */
+  const out = {}
+  const keys = new Set([...Object.keys(defaults || {}), ...Object.keys(minimized || {})])
+  for (const k of keys) {
+    out[k] = restoreDeep(minimized?.[k], defaults?.[k])
+  }
+  return out
+}

--- a/symbols.json
+++ b/symbols.json
@@ -711,6 +711,20 @@
     "returns": "HTMLElement|undefined"
   },
   {
+    "name": "formatChunksManifest",
+    "kind": "function",
+    "file": "src/utils/chunker.js",
+    "description": "",
+    "params": [
+      {
+        "name": "m",
+        "type": "Record<string,number>",
+        "desc": ""
+      }
+    ],
+    "returns": "string"
+  },
+  {
     "name": "get",
     "kind": "function",
     "file": "src/component/widget/widgetStore.js",
@@ -1283,6 +1297,25 @@
     "returns": "boolean"
   },
   {
+    "name": "joinFromParams",
+    "kind": "function",
+    "file": "src/utils/chunker.js",
+    "description": "Join numbered fragment parameters back into a single string.",
+    "params": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "params",
+        "type": "URLSearchParams",
+        "desc": ""
+      }
+    ],
+    "returns": "string|null"
+  },
+  {
     "name": "jsonGet",
     "kind": "function",
     "file": "src/storage/StorageManager.js",
@@ -1444,6 +1477,30 @@
       }
     ],
     "returns": "Array<Service>"
+  },
+  {
+    "name": "minimizeDeep",
+    "kind": "function",
+    "file": "src/utils/minimizer.js",
+    "description": "Recursively prune defaults and empties from a value.",
+    "params": [
+      {
+        "name": "value",
+        "type": "any",
+        "desc": ""
+      },
+      {
+        "name": "defaults",
+        "type": "any",
+        "desc": ""
+      },
+      {
+        "name": "opts",
+        "type": "{ dropEmpties?: boolean }",
+        "desc": ""
+      }
+    ],
+    "returns": "any"
   },
   {
     "name": "mountBoardControl",
@@ -1610,6 +1667,20 @@
       }
     ],
     "returns": "object|null"
+  },
+  {
+    "name": "parseChunksManifest",
+    "kind": "function",
+    "file": "src/utils/chunker.js",
+    "description": "Parse a chunk manifest string like \"cfg:3;svc:2\".",
+    "params": [
+      {
+        "name": "s",
+        "type": "string",
+        "desc": ""
+      }
+    ],
+    "returns": "Record<string,number>"
   },
   {
     "name": "populateWidgetSelectorPanel",
@@ -1784,6 +1855,25 @@
       }
     ],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "restoreDeep",
+    "kind": "function",
+    "file": "src/utils/minimizer.js",
+    "description": "Restore pruned values by filling defaults for missing keys.",
+    "params": [
+      {
+        "name": "minimized",
+        "type": "any",
+        "desc": ""
+      },
+      {
+        "name": "defaults",
+        "type": "any",
+        "desc": ""
+      }
+    ],
+    "returns": "any"
   },
   {
     "name": "runSilentImportFlowIfRequested",
@@ -2059,6 +2149,30 @@
       }
     ],
     "returns": "Promise<void>"
+  },
+  {
+    "name": "splitIntoParams",
+    "kind": "function",
+    "file": "src/utils/chunker.js",
+    "description": "Split a string into URL fragment parameters, adding numeric suffixes when needed.",
+    "params": [
+      {
+        "name": "name",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "data",
+        "type": "string",
+        "desc": ""
+      },
+      {
+        "name": "maxLen",
+        "type": "number",
+        "desc": ""
+      }
+    ],
+    "returns": "Array<[string,string]>"
   },
   {
     "name": "stopResize",

--- a/tests/fragmentChunking.spec.ts
+++ b/tests/fragmentChunking.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '@playwright/test'
+import { encodeConfig, decodeConfig } from '../src/utils/compression.js'
+import { splitIntoParams, joinFromParams, formatChunksManifest } from '../src/utils/chunker.js'
+import { minimizeDeep, restoreDeep } from '../src/utils/minimizer.js'
+import { computeCRC32Hex } from '../src/utils/checksum.js'
+import { applyKeyMap } from '../src/utils/keymap.js'
+
+const KEY_MAP = { foo: 'f', bar: 'b', name: 'n', url: 'u' }
+const CFG_DEFAULTS = { foo: 1, bar: 0, arr: [] }
+const CFG_SAMPLE = { foo: 1, bar: 2, arr: [] }
+const SVC_SAMPLE = [{ name: 'svc', url: 'http://x' }]
+
+async function roundTrip (algo: 'gzip'|'deflate', maxLen: number) {
+  const cfgMapped = applyKeyMap(CFG_SAMPLE, KEY_MAP, 'encode')
+  const svcMapped = applyKeyMap(SVC_SAMPLE, KEY_MAP, 'encode')
+  const cfgDefMapped = applyKeyMap(CFG_DEFAULTS, KEY_MAP, 'encode')
+  const svcDefMapped: any = []
+
+  const cfgMin = minimizeDeep(cfgMapped, cfgDefMapped, { dropEmpties: true }) ?? {}
+  const svcMin = minimizeDeep(svcMapped, svcDefMapped, { dropEmpties: true }) ?? []
+
+  const [cfgRes, svcRes] = await Promise.all([
+    encodeConfig(cfgMin, { algo, withChecksum: true }),
+    encodeConfig(svcMin, { algo, withChecksum: true })
+  ])
+  const ccw = computeCRC32Hex(JSON.stringify({ c: cfgMin, s: svcMin }))
+
+  const params = new URLSearchParams()
+  params.set('algo', algo)
+  params.set('cc', `${cfgRes.checksum},${svcRes.checksum}`)
+  params.set('ccw', ccw)
+  const cfgPairs = splitIntoParams('cfg', cfgRes.data, maxLen)
+  const svcPairs = splitIntoParams('svc', svcRes.data, maxLen)
+  for (const [k, v] of [...cfgPairs, ...svcPairs]) params.set(k, v)
+  const manifest = formatChunksManifest({
+    cfg: cfgPairs.length > 1 ? cfgPairs.length : 0,
+    svc: svcPairs.length > 1 ? svcPairs.length : 0
+  })
+  if (manifest) params.set('chunks', manifest)
+
+  const cfgJoined = joinFromParams('cfg', params)!
+  const svcJoined = joinFromParams('svc', params)!
+  const cfgDec = await decodeConfig(cfgJoined, { algo, expectChecksum: cfgRes.checksum })
+  const svcDec = await decodeConfig(svcJoined, { algo, expectChecksum: svcRes.checksum })
+  const calc = computeCRC32Hex(JSON.stringify({ c: cfgDec, s: svcDec }))
+  expect(calc).toBe(ccw)
+  const cfgRestored = restoreDeep(cfgDec, cfgDefMapped)
+  const svcRestored = restoreDeep(svcDec, svcDefMapped)
+  const cfgOut = applyKeyMap(cfgRestored, KEY_MAP, 'decode')
+  const svcOut = applyKeyMap(svcRestored, KEY_MAP, 'decode')
+  expect(cfgOut).toEqual(CFG_SAMPLE)
+  expect(svcOut).toEqual(SVC_SAMPLE)
+}
+
+test('single export round-trip (deflate + gzip)', async () => {
+  await roundTrip('deflate', 1000)
+  await roundTrip('gzip', 1000)
+})
+
+test('chunked export round-trip (deflate + gzip)', async () => {
+  await roundTrip('deflate', 10)
+  await roundTrip('gzip', 10)
+})
+
+test('permuted chunk order fails until sorted', async () => {
+  const algo: 'deflate' = 'deflate'
+  const cfgMapped = applyKeyMap(CFG_SAMPLE, KEY_MAP, 'encode')
+  const cfgDefMapped = applyKeyMap(CFG_DEFAULTS, KEY_MAP, 'encode')
+  const cfgMin = minimizeDeep(cfgMapped, cfgDefMapped, { dropEmpties: true }) ?? {}
+  const { data, checksum } = await encodeConfig(cfgMin, { algo, withChecksum: true })
+  const parts = splitIntoParams('cfg', data, 5)
+  const rev = parts.slice().reverse()
+  const wrong = rev.map(([, v]) => v).join('')
+  await expect(decodeConfig(wrong, { algo, expectChecksum: checksum })).rejects.toThrow()
+  const params = new URLSearchParams()
+  for (const [k, v] of rev) params.set(k, v)
+  const joined = joinFromParams('cfg', params)!
+  const decoded = await decodeConfig(joined, { algo, expectChecksum: checksum })
+  const restored = restoreDeep(decoded, cfgDefMapped)
+  const cfgOut = applyKeyMap(restored, KEY_MAP, 'decode')
+  expect(cfgOut).toEqual(CFG_SAMPLE)
+})
+
+test('legacy single-param links still import', async () => {
+  const algo: 'gzip' = 'gzip'
+  const cfgMapped = applyKeyMap(CFG_SAMPLE, KEY_MAP, 'encode')
+  const svcMapped = applyKeyMap(SVC_SAMPLE, KEY_MAP, 'encode')
+  const cfgDefMapped = applyKeyMap(CFG_DEFAULTS, KEY_MAP, 'encode')
+  const svcDefMapped: any = []
+  const cfgMin = minimizeDeep(cfgMapped, cfgDefMapped, { dropEmpties: true }) ?? {}
+  const svcMin = minimizeDeep(svcMapped, svcDefMapped, { dropEmpties: true }) ?? []
+  const [cfgRes, svcRes] = await Promise.all([
+    encodeConfig(cfgMin, { algo, withChecksum: true }),
+    encodeConfig(svcMin, { algo, withChecksum: true })
+  ])
+  const params = new URLSearchParams()
+  params.set('cfg', cfgRes.data)
+  params.set('svc', svcRes.data)
+  params.set('cc', `${cfgRes.checksum},${svcRes.checksum}`)
+  const cfgJoined = joinFromParams('cfg', params)!
+  const svcJoined = joinFromParams('svc', params)!
+  const cfgDec = await decodeConfig(cfgJoined, { algo, expectChecksum: cfgRes.checksum })
+  const svcDec = await decodeConfig(svcJoined, { algo, expectChecksum: svcRes.checksum })
+  const cfgRestored = restoreDeep(cfgDec, cfgDefMapped)
+  const svcRestored = restoreDeep(svcDec, svcDefMapped)
+  const cfgOut = applyKeyMap(cfgRestored, KEY_MAP, 'decode')
+  const svcOut = applyKeyMap(svcRestored, KEY_MAP, 'decode')
+  expect(cfgOut).toEqual(CFG_SAMPLE)
+  expect(svcOut).toEqual(SVC_SAMPLE)
+})


### PR DESCRIPTION
## Summary
- add reversible minimizer and chunker utilities for fragment payloads
- apply minimization, chunk manifest, and whole-payload checksum to export/import
- document automatic chunking and extend fragment tests

## Testing
- `just format check`
- `just test`