### PR TITLE
feat(url): harden fragment pipeline (deflate, checksums, flags, tests, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ ASD Dashboard also supports sharing full configuration and service state using t
   https://your-dashboard.app/#cfg=<compressed>&svc=<compressed>
   ```
 
+### Fragment Parameters
+
+The fragment follows standard `URLSearchParams` semantics and may include:
+
+* `name` – human-readable snapshot name
+* `cfg` / `svc` – compressed config and service payloads
+* `algo` – compression algorithm (`deflate` by default, `gzip` for legacy links)
+* `cc` – per-payload CRC32 checksums (`cfg,svc`)
+* `ccw` – whole-payload checksum over both payloads
+* `chunks` – optional manifest when `cfg` or `svc` are split (`cfg:3;svc:2`)
+
 * Config and services are:
 
   * Compressed with built-in **deflate** (or legacy **gzip**) and base64url-encoded for compactness

--- a/src/component/modal/fragmentDecisionModal.js
+++ b/src/component/modal/fragmentDecisionModal.js
@@ -11,6 +11,9 @@ import { mergeBoards, mergeServices } from '../../utils/merge.js'
 import { Logger } from '../../utils/Logger.js'
 import { showNotification } from '../dialog/notification.js'
 import StorageManager from '../../storage/StorageManager.js'
+import { restoreDeep } from '../../utils/minimizer.js'
+import { DEFAULT_CONFIG_TEMPLATE } from '../../storage/defaultConfig.js'
+import { FRAG_MINIMIZE_ENABLED } from '../../utils/fragmentConstants.js'
 
 /** @typedef {import('../../types.js').DashboardConfig} DashboardConfig */
 /** @typedef {import('../../types.js').Service} Service */
@@ -107,12 +110,15 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam, algo
                   expectChecksum: cfgChecksum
                 })
               )
+              const cfgFull = FRAG_MINIMIZE_ENABLED
+                ? restoreDeep(decoded, DEFAULT_CONFIG_TEMPLATE)
+                : decoded
               if (overwrite) {
-                cfgObj = decoded
+                cfgObj = cfgFull
               } else {
                 const currentBoards = StorageManager.getBoards()
-                const mergedBoards = mergeBoards(currentBoards, decoded.boards || [])
-                cfgObj = { ...cfgObj, ...decoded, boards: mergedBoards }
+                const mergedBoards = mergeBoards(currentBoards, cfgFull.boards || [])
+                cfgObj = { ...cfgObj, ...cfgFull, boards: mergedBoards }
               }
             }
 
@@ -124,10 +130,13 @@ export function openFragmentDecisionModal ({ cfgParam, svcParam, nameParam, algo
                   expectChecksum: svcChecksum
                 })
               )
+              const svcFull = FRAG_MINIMIZE_ENABLED
+                ? restoreDeep(decodedSvc, [])
+                : decodedSvc
               if (overwrite) {
-                svcArr = decodedSvc
+                svcArr = svcFull
               } else {
-                svcArr = mergeServices(svcArr, decodedSvc)
+                svcArr = mergeServices(svcArr, svcFull)
               }
             }
 

--- a/src/utils/fragmentConstants.js
+++ b/src/utils/fragmentConstants.js
@@ -1,0 +1,45 @@
+// @ts-check
+/**
+ * Shared constants and feature flags for URL fragment handling.
+ * Values can be overridden via environment variables at build time.
+ *
+ * @module fragmentConstants
+ */
+
+const env = typeof process !== 'undefined' && process && process.env ? process.env : {}
+
+/**
+ * Default compression algorithm for fragment exports.
+ *
+ * @type {'deflate'|'gzip'}
+ */
+export const FRAG_DEFAULT_ALGO = env.FRAG_DEFAULT_ALGO === 'gzip' ? 'gzip' : 'deflate'
+
+/**
+ * Toggle minimization of config/services during export/import.
+ * Set `FRAG_MINIMIZE_ENABLED=false` to disable.
+ *
+ * @type {boolean}
+ */
+export const FRAG_MINIMIZE_ENABLED = env.FRAG_MINIMIZE_ENABLED !== 'false'
+
+/**
+ * Maximum length per fragment parameter before chunking is applied.
+ * Set `FRAG_CHUNK_MAX_LEN=0` to disable chunking.
+ *
+ * @type {number}
+ */
+export const FRAG_CHUNK_MAX_LEN = (() => {
+  const n = Number(env.FRAG_CHUNK_MAX_LEN)
+  return Number.isFinite(n) && n > 0 ? n : Infinity
+})()
+
+/**
+ * URL length threshold after which a warning is shown.
+ *
+ * @type {number}
+ */
+export const FRAG_WARN_URL_LEN = (() => {
+  const n = Number(env.FRAG_WARN_URL_LEN)
+  return Number.isFinite(n) && n > 0 ? n : 60000
+})()

--- a/tests/compression.spec.ts
+++ b/tests/compression.spec.ts
@@ -33,6 +33,13 @@ test('deflate round-trip with key map and checksum', async () => {
   expect(decoded).toEqual(obj)
 })
 
+test('checksum detects tampered data', async () => {
+  const obj = { name: 'test', url: 'http://example.com' }
+  const { data, checksum } = await encodeConfig(obj, { algo: 'deflate', withChecksum: true })
+  const wrongChecksum = checksum ? checksum.slice(1) + checksum[0] : '00000000'
+  await expect(decodeConfig(data, { algo: 'deflate', expectChecksum: wrongChecksum })).rejects.toThrow(/Checksum mismatch/)
+})
+
 test('deflate with key map produces shorter URL than gzip', async () => {
   const gzipCfg = await gzipJsonToBase64url(ciConfig)
   const gzipSvc = await gzipJsonToBase64url(ciServices)


### PR DESCRIPTION
## Summary
- centralize fragment settings with env-overridable constants and default deflate algo
- export/share links use built-in deflate, optional minimization, chunking manifest and warn on large URLs
- loader restores minimized payloads, validates checksums, logs reasons and counts successful imports
- document fragment parameters and add checksum tamper test

## Testing
- `just format`
- `just check`
- `just test`

------
https://chatgpt.com/codex/tasks/task_b_689b64bf38f08325a54c7757bc42305f