### PR TITLE
feat(ui): labeled headers for Board/View panels + a11y focus on Actions ▸; counts off for non-service

### DIFF
--- a/src/component/board/BoardControl.js
+++ b/src/component/board/BoardControl.js
@@ -30,6 +30,11 @@ export function mountBoardControl () {
     testid: 'board-panel',
     placeholder: 'Search Boards',
     showCount: false,
+    labelText: () => {
+      const id = StorageManager.misc.getLastBoardId()
+      const b = (StorageManager.getBoards() || []).find(x => x.id === id)
+      return '▼ Board: ' + (b?.name ?? '—')
+    },
     getItems: () => {
       const boards = StorageManager.getBoards() || []
       return boards.map(b => ({ id: b.id, label: b.name, meta: `${b.views.length} views` }))

--- a/src/component/panel/SelectorPanel.js
+++ b/src/component/panel/SelectorPanel.js
@@ -26,7 +26,8 @@
  * @property {string} placeholder
  * @property {boolean} [showCount]
  * @property {(() => string) | null} [countText]
- * @property {() => SelectorItem[]} getItems
+ * @property {(() => string) | null} [labelText]
+  * @property {() => SelectorItem[]} getItems
  * @property {(id:string)=>void} [onSelect]
  * @property {(action:string, ctx:any)=>void} [onAction]
  * @property {(action:string, id:string, ctx:any)=>void} [onItemAction]
@@ -44,7 +45,7 @@ export class SelectorPanel {
    * @param {SelectorPanelCfg} cfg
    */
   constructor (cfg) {
-    this.cfg = { showCount: true, ...cfg }
+    this.cfg = { showCount: true, labelText: null, ...cfg }
     this.timers = { openClose: /** @type {any} */ (null) }
     this.state = { sideOpen: false }
     this.dom = /** @type {any} */ ({})
@@ -72,6 +73,10 @@ export class SelectorPanel {
     arrow.className = 'panel-arrow'
     arrow.textContent = '▼'
 
+    const label = document.createElement('span')
+    label.className = 'panel-label'
+    label.style.display = 'none'
+
     let count = null
     if (showCount && typeof countText === 'function') {
       count = document.createElement('span')
@@ -90,12 +95,12 @@ export class SelectorPanel {
     list.className = 'panel-list'
     content.appendChild(list)
 
-    wrap.append(input, arrow)
+    wrap.append(input, arrow, label)
     if (count) wrap.appendChild(count)
     wrap.appendChild(content)
     root.appendChild(wrap)
 
-    this.dom = { root, wrap, input, arrow, count, content, list, side }
+    this.dom = { root, wrap, input, arrow, label, count, content, list, side }
   }
 
   /** Bind DOM events */
@@ -178,7 +183,18 @@ export class SelectorPanel {
 
   /** Refresh list and counts */
   refresh () {
-    const { getItems, showCount, countText, actions = [], itemActions = [] } = this.cfg
+    const { getItems, showCount, countText, labelText, actions = [], itemActions = [] } = this.cfg
+
+    if (this.dom.label) {
+      if (typeof labelText === 'function') {
+        const txt = labelText()
+        this.dom.label.textContent = txt
+        this.dom.label.title = txt
+        this.dom.label.style.display = ''
+      } else {
+        this.dom.label.style.display = 'none'
+      }
+    }
 
     if (this.dom.count && showCount && typeof countText === 'function') {
       this.dom.count.textContent = countText()

--- a/src/component/panel/selector-panel.css
+++ b/src/component/panel/selector-panel.css
@@ -2,6 +2,7 @@
 .dropdown.panel { position: relative; display: inline-flex; align-items: center; gap: 8px; padding: 4px 6px; border: 1px solid #ddd; border-radius: 4px; background: #fff; }
 .dropdown.panel .panel-search { border: none; outline: none; width: 220px; }
 .dropdown.panel .panel-arrow { margin-left: 4px; }
+.panel-label { font-weight: 600; white-space: nowrap; text-overflow: ellipsis; overflow: hidden; width: 32ch; }
 .dropdown.panel .panel-count { margin-left: auto; font-size: 12px; opacity: 0.75; }
 .dropdown.panel .dropdown-content { position: absolute; top: 100%; left: 0; min-width: 340px; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 8px; display: none; box-shadow: 0 6px 24px rgba(0,0,0,.12); z-index: 20; }
 .dropdown.panel.open .dropdown-content { display: block; }
@@ -16,6 +17,7 @@
 .panel-item-icon:hover { border-color: #e5e5e5; background: #fff; }
 
 .panel-actions-trigger { font-weight: 600; grid-template-columns: 1fr; }
+.panel-actions-trigger:focus { outline: 2px solid #2684ff; outline-offset: 2px; }
 .dropdown.panel .side-content { display: none; position: absolute; top: 0; left: 100%; min-width: 220px; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 8px; box-shadow: 0 6px 24px rgba(0,0,0,.12); }
 .dropdown.panel .dropdown-content.side-open .side-content { display: block; }
 .panel-action { padding: 6px 8px; width: 100%; text-align: left; border: 1px solid #cde; background: #eef9ff; border-radius: 4px; margin-bottom: 6px; cursor: pointer; }

--- a/src/component/view/ViewControl.js
+++ b/src/component/view/ViewControl.js
@@ -31,6 +31,13 @@ export function mountViewControl () {
     testid: 'view-panel',
     placeholder: 'Search Views',
     showCount: false,
+    labelText: () => {
+      const bId = getCurrentBoardId() || StorageManager.misc.getLastBoardId()
+      const vId = StorageManager.misc.getLastViewId()
+      const b = (StorageManager.getBoards() || []).find(x => x.id === bId)
+      const v = b?.views.find(v => v.id === vId)
+      return '▼ View: ' + (v?.name ?? '—')
+    },
     getItems: () => {
       const bId = getCurrentBoardId() || StorageManager.misc.getLastBoardId()
       const board = (StorageManager.getBoards() || []).find(b => b.id === bId)

--- a/symbols.json
+++ b/symbols.json
@@ -1389,7 +1389,7 @@
     "file": "src/component/board/BoardControl.js",
     "description": "Mount the board control panel into #board-control.",
     "params": [],
-    "returns": "void"
+    "returns": "SelectorPanel|null"
   },
   {
     "name": "mountViewControl",
@@ -1397,7 +1397,7 @@
     "file": "src/component/view/ViewControl.js",
     "description": "Mount the view control panel into #view-control.",
     "params": [],
-    "returns": "void"
+    "returns": "SelectorPanel|null"
   },
   {
     "name": "openConfigModal",

--- a/tests/boardPanel.spec.ts
+++ b/tests/boardPanel.spec.ts
@@ -10,11 +10,28 @@ test.describe('Board panel', () => {
     await addServices(page, 1)
   })
 
+  test('renders header label and hides count', async ({ page }) => {
+    const panel = page.locator('[data-testid="board-panel"]')
+    await expect(panel.locator('.panel-label')).toHaveText(/▼ Board:\s+/)
+    await expect(panel.locator('.panel-count')).toHaveCount(0)
+  })
+
   test('opens dropdown and shows Actions ▸', async ({ page }) => {
     const panel = page.locator('[data-testid="board-panel"]')
     await panel.hover()
     await expect(panel.locator('.dropdown-content')).toBeVisible()
     await expect(panel.locator('[data-testid="panel-actions-trigger"]')).toBeVisible()
+  })
+
+  test('Actions ▸ focus ring visible via keyboard', async ({ page }) => {
+    const panel = page.locator('[data-testid="board-panel"]')
+    await panel.focus()
+    await page.keyboard.press('Enter')
+    await page.keyboard.press('Tab') // focus search
+    await page.keyboard.press('Tab') // focus Actions ▸
+    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
+    await expect(trigger).toBeFocused()
+    await expect(trigger).toHaveCSS('outline-style', 'solid')
   })
 
   test('Actions ▸ → New Board creates a board', async ({ page }) => {

--- a/tests/viewPanel.spec.ts
+++ b/tests/viewPanel.spec.ts
@@ -9,6 +9,12 @@ test.describe('View panel', () => {
     await addServices(page, 1)
   })
 
+  test('renders header label and hides count', async ({ page }) => {
+    const panel = page.locator('[data-testid="view-panel"]')
+    await expect(panel.locator('.panel-label')).toHaveText(/▼ View:\s+/)
+    await expect(panel.locator('.panel-count')).toHaveCount(0)
+  })
+
   test('opens dropdown and side Actions ▸', async ({ page }) => {
     const panel = page.locator('[data-testid="view-panel"]')
     await panel.hover()


### PR DESCRIPTION
## Summary
- add optional `labelText()` to `SelectorPanel` and render header labels
- improve accessibility for Actions ▸ trigger with focus outline
- wire Board/View controls to pass labels and disable counts
- add Playwright tests for labels, counts-off, keyboard focus

## Testing
- `node scripts/extract-symbol-index.mjs`
- `just format`
- `just check`
- `just test` *(fails: Resize Handler Functionality – unexpected data-columns "1")*


------
https://chatgpt.com/codex/tasks/task_b_689b6fdd7808832587d1ced5d59ca8e2