### PR TITLE
fix hover-to-open actions, unify icon styling with ServiceSelector, and tidy Board/View headers

### DIFF
--- a/src/component/board/BoardControl.js
+++ b/src/component/board/BoardControl.js
@@ -33,7 +33,7 @@ export function mountBoardControl () {
     labelText: () => {
       const id = StorageManager.misc.getLastBoardId()
       const b = (StorageManager.getBoards() || []).find(x => x.id === id)
-      return '▼ Board: ' + (b?.name ?? '—')
+      return 'Board: ' + (b?.name ?? '—')
     },
     getItems: () => {
       const boards = StorageManager.getBoards() || []
@@ -72,8 +72,8 @@ export function mountBoardControl () {
       { label: 'Reset Board', action: 'reset' }
     ],
     itemActions: [
-      { action: 'rename', title: 'Rename board', icon: '✏️' },
-      { action: 'delete', title: 'Delete board', icon: '🗑' }
+      { action: 'rename', title: 'Rename board' },
+      { action: 'delete', title: 'Delete board' }
     ]
   })
 

--- a/src/component/panel/selector-panel.css
+++ b/src/component/panel/selector-panel.css
@@ -11,7 +11,8 @@
 }
 .panel-arrow { margin-left: 4px; }
 .panel-label {
-  font-weight: 600;
+  font-weight: 500;
+  color: #111;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -28,13 +29,45 @@
 .panel-item-label { font-weight: 500; }
 .panel-item-meta { opacity: .7; font-size: 12px; }
 .panel-item-actions { display: inline-flex; gap: 6px; }
-.panel-item-icon { border: 1px solid transparent; background: transparent; cursor: pointer; padding: 2px 6px; border-radius: 4px; }
-.panel-item-icon:hover { border-color: #e5e5e5; background: #fff; }
+#controls .panel-item-actions .panel-item-icon {
+  background: none;
+  border: none;
+  padding: 0.2rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+#controls .panel-item-actions .panel-item-icon:hover {
+  background-color: rgba(0,0,0,0.06);
+  transform: translateY(-1px);
+}
 
-.panel-actions-trigger { font-weight: 600; grid-template-columns: 1fr; }
-.panel-actions-trigger:focus { outline: 2px solid #2684ff; outline-offset: 2px; }
+.panel-actions-trigger {
+  font-weight: 500;
+  background: transparent;
+  grid-template-columns: 1fr;
+}
+.panel-actions-trigger:hover { background: #f6f8fa; }
+.panel-actions-trigger:focus {
+  outline: 2px solid #2684ff;
+  outline-offset: 2px;
+}
 .dropdown.panel .side-content { display: none; position: absolute; top: 0; left: 100%; min-width: 220px; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 8px; box-shadow: 0 6px 24px rgba(0,0,0,.12); }
 .dropdown.panel .dropdown-content.side-open .side-content { display: block; }
-.panel-action { padding: 6px 8px; width: 100%; text-align: left; border: 1px solid #cde; background: #eef9ff; border-radius: 4px; margin-bottom: 6px; cursor: pointer; }
-.panel-action:last-child { margin-bottom: 0; }
+.side-content .panel-action {
+  padding: 6px 8px;
+  width: 100%;
+  text-align: left;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  border-radius: 6px;
+  margin-bottom: 6px;
+  transition: background-color .15s ease, transform .15s ease;
+}
+.side-content .panel-action:hover {
+  background: #f6f8fa;
+  transform: translateY(-1px);
+}
+.side-content .panel-action:last-child { margin-bottom: 0; }
 

--- a/src/component/view/ViewControl.js
+++ b/src/component/view/ViewControl.js
@@ -36,7 +36,7 @@ export function mountViewControl () {
       const vId = StorageManager.misc.getLastViewId()
       const b = (StorageManager.getBoards() || []).find(x => x.id === bId)
       const v = b?.views.find(v => v.id === vId)
-      return '▼ View: ' + (v?.name ?? '—')
+      return 'View: ' + (v?.name ?? '—')
     },
     getItems: () => {
       const bId = getCurrentBoardId() || StorageManager.misc.getLastBoardId()
@@ -77,8 +77,8 @@ export function mountViewControl () {
       { label: 'Reset View', action: 'reset' }
     ],
     itemActions: [
-      { action: 'rename', title: 'Rename view', icon: '✏️' },
-      { action: 'delete', title: 'Delete view', icon: '🗑' }
+      { action: 'rename', title: 'Rename view' },
+      { action: 'delete', title: 'Delete view' }
     ]
   })
 

--- a/src/ui/unicodeEmoji.js
+++ b/src/ui/unicodeEmoji.js
@@ -1,5 +1,5 @@
 // @ts-check
-const emojiList = {
+export const emojiList = {
   puzzle: { icon: '🧩', unicode: '\u{1F9E9}', description: 'Widget to grid' },
   satellite: { icon: '📡', unicode: '\u{1F4E1}', description: 'Serviceworker' },
   cross: { icon: '❌', unicode: '\u{274C}', description: 'Delete widget' },

--- a/tests/boardPanel.spec.ts
+++ b/tests/boardPanel.spec.ts
@@ -12,7 +12,9 @@ test.describe('Board panel', () => {
 
   test('renders header label and hides count', async ({ page }) => {
     const panel = page.locator('[data-testid="board-panel"]')
-    await expect(panel.locator('.panel-label')).toHaveText(/▼ Board:\s+/)
+    await expect(panel.locator('.panel-arrow')).toHaveText('▼')
+    await expect(panel.locator('.panel-label')).toHaveText(/Board:\s+/)
+    await expect(panel.locator('.panel-label')).not.toContainText('▼')
     await expect(panel.locator('.panel-count')).toHaveCount(0)
   })
 
@@ -21,6 +23,14 @@ test.describe('Board panel', () => {
     await panel.hover()
     await expect(panel.locator('.dropdown-content')).toBeVisible()
     await expect(panel.locator('[data-testid="panel-actions-trigger"]')).toBeVisible()
+  })
+
+  test('side opens on hover', async ({ page }) => {
+    const panel = page.locator('[data-testid="board-panel"]')
+    await panel.hover()
+    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
+    await trigger.hover()
+    await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
   })
 
   test('Actions ▸ focus ring visible via keyboard', async ({ page }) => {
@@ -39,7 +49,8 @@ test.describe('Board panel', () => {
     const newName = 'Playwright Board'
     page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(newName) })
     await panel.hover()
-    await panel.locator('[data-testid="panel-actions-trigger"]').click()
+    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
+    await trigger.hover()
     await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
     await panel.locator('.side-content .panel-action', { hasText: 'New Board' }).click()
     await panel.hover()
@@ -67,6 +78,15 @@ test.describe('Board panel', () => {
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })
     await deleteBtn.click()
     await expect(panel.locator('.panel-item', { hasText: renamed })).toHaveCount(0)
+  })
+
+  test('item icons hover styling', async ({ page }) => {
+    const panel = page.locator('[data-testid="board-panel"]')
+    await panel.hover()
+    const icon = panel.locator('[data-item-action="rename"]').first()
+    await expect(icon).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+    await icon.hover()
+    await expect(icon).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.06)')
   })
 
   test('search filters boards but keeps Actions ▸', async ({ page }) => {

--- a/tests/viewPanel.spec.ts
+++ b/tests/viewPanel.spec.ts
@@ -11,7 +11,9 @@ test.describe('View panel', () => {
 
   test('renders header label and hides count', async ({ page }) => {
     const panel = page.locator('[data-testid="view-panel"]')
-    await expect(panel.locator('.panel-label')).toHaveText(/▼ View:\s+/)
+    await expect(panel.locator('.panel-arrow')).toHaveText('▼')
+    await expect(panel.locator('.panel-label')).toHaveText(/View:\s+/)
+    await expect(panel.locator('.panel-label')).not.toContainText('▼')
     await expect(panel.locator('.panel-count')).toHaveCount(0)
   })
 
@@ -19,7 +21,8 @@ test.describe('View panel', () => {
     const panel = page.locator('[data-testid="view-panel"]')
     await panel.hover()
     await expect(panel.locator('.dropdown-content')).toBeVisible()
-    await panel.locator('[data-testid="panel-actions-trigger"]').click()
+    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
+    await trigger.hover()
     await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
     await expect(panel.locator('.side-content .panel-action', { hasText: 'New View' })).toBeVisible()
     await expect(panel.locator('.side-content .panel-action', { hasText: 'Reset View' })).toBeVisible()
@@ -31,7 +34,8 @@ test.describe('View panel', () => {
 
     const v1 = 'Playwright View'
     page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(v1) })
-    await panel.locator('[data-testid="panel-actions-trigger"]').click()
+    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
+    await trigger.hover()
     await panel.locator('.side-content .panel-action', { hasText: 'New View' }).click()
     await panel.hover()
     await expect(panel.locator('.panel-item', { hasText: v1 })).toBeVisible()
@@ -42,7 +46,7 @@ test.describe('View panel', () => {
     await renameBtn.click()
     await expect(panel.locator('.panel-item', { hasText: v2 })).toBeVisible()
 
-    await panel.locator('[data-testid="panel-actions-trigger"]').click()
+    await trigger.hover()
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })
     await panel.locator('.side-content .panel-action', { hasText: 'Reset View' }).click()
     await panel.hover()
@@ -77,7 +81,8 @@ test.describe('View panel', () => {
     const names = ['Alpha View', 'Beta View']
     for (const name of names) {
       page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(name) })
-      await panel.locator('[data-testid="panel-actions-trigger"]').click()
+      const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
+      await trigger.hover()
       await panel.locator('.side-content .panel-action', { hasText: 'New View' }).click()
       await panel.hover()
     }


### PR DESCRIPTION
## Summary
- Open selector side menu on hover with shared delay to match ServiceSelector behavior
- Replace green item-icon buttons with subtle emoji-based icons and refined header styling
- Clean Board/View panel labels and rely on shared emoji icon set

## Testing
- `just format check`
- `just test`