### PR TITLE
feat(selectors): obvious create + label-click affordance; swap delete to ❌

### DIFF
--- a/src/component/board/BoardControl.js
+++ b/src/component/board/BoardControl.js
@@ -69,11 +69,9 @@ export function mountBoardControl () {
       updateBoardSelector()
     },
     actions: [
-      { label: 'New Board', action: 'create' },
-      { label: 'Reset Board', action: 'reset' }
+      { key: 'create', label: 'New Board' },
+      { key: 'reset', label: 'Reset Board' }
     ],
-    primaryAction: { label: 'New Board', action: 'create' },
-    quickAddAction: { title: 'New Board', action: 'create', icon: emojiList.plus.unicode },
     selectVerb: () => 'Switch',
     itemActionsFor: () => [
       { action: 'rename', title: 'Rename board', icon: emojiList.edit.unicode },

--- a/src/component/board/BoardControl.js
+++ b/src/component/board/BoardControl.js
@@ -72,9 +72,12 @@ export function mountBoardControl () {
       { label: 'New Board', action: 'create' },
       { label: 'Reset Board', action: 'reset' }
     ],
+    primaryAction: { label: 'New Board', action: 'create' },
+    quickAddAction: { title: 'New Board', action: 'create', icon: emojiList.plus.unicode },
+    selectVerb: () => 'Switch',
     itemActionsFor: () => [
       { action: 'rename', title: 'Rename board', icon: emojiList.edit.unicode },
-      { action: 'delete', title: 'Delete board', icon: emojiList.noEntry.unicode }
+      { action: 'delete', title: 'Delete board', icon: emojiList.cross.unicode }
     ]
   })
 

--- a/src/component/panel/SelectorPanel.js
+++ b/src/component/panel/SelectorPanel.js
@@ -1,12 +1,7 @@
 // @ts-check
 import { emojiList } from '../../ui/unicodeEmoji.js'
 /**
- * Generic Service-style selector panel:
- * - Hover/keyboard open/close
- * - Search filter (case/diacritic/whitespace normalized)
- * - OPTIONAL right-side count (hidden when not configured)
- * - FIRST ROW = "Actions ▸" → opens side dropdown with action buttons
- * - OPTIONAL per-item icon actions (e.g., rename ✏️, delete ⛔) rendered on each row
+ * Generic selector panel with compact top menu and per-row flyout actions.
  *
  * Emits DOM events (CustomEvent with `{ bubbles:true, composed:true }`):
  *   'selector:select'      { id }
@@ -35,11 +30,9 @@ import { emojiList } from '../../ui/unicodeEmoji.js'
  * @property {(action:string, ctx:any)=>void} [onAction]
  * @property {(action:string, id:string, ctx:any)=>void} [onItemAction]
  * @property {() => any} [context]
- * @property {{label:string,action:string}[]} [actions]
+ * @property {{key:string,label:string}[]} [actions]
  * @property {{action:string,title:string,icon?:string}[]} [itemActions]
  * @property {(item:SelectorItem)=>{action:string,title:string,icon?:string}[]} [itemActionsFor]
- * @property {{label:string,action:string}} [primaryAction]
- * @property {{title:string,action:string,icon:string}} [quickAddAction]
  * @property {(item:SelectorItem)=>string} [selectVerb]
 */
 
@@ -58,7 +51,18 @@ function normalize (s) {
 }
 
 /**
- * Generic service-style selector panel with optional side dropdown and per-item actions.
+ * Detect if an action is a create-like action.
+ * @param {{key?:string,label?:string}} a
+ * @returns {boolean}
+ */
+function hasCreate (a) {
+  const k = (a.key || '').toLowerCase()
+  const l = (a.label || '').toLowerCase()
+  return /create|new|add/.test(k) || /create|new|add/.test(l)
+}
+
+/**
+ * Generic selector panel with compact menu.
  * @class
  */
 export class SelectorPanel {
@@ -68,9 +72,8 @@ export class SelectorPanel {
   constructor (cfg) {
     this.cfg = { showCount: true, labelText: null, ...cfg }
     this.timers = { openClose: /** @type {any} */ (null) }
-    this.state = { sideOpen: false, wasFocused: false }
+    this.state = { wasFocused: false }
     this.dom = /** @type {any} */ ({})
-    this.hoverFns = /** @type {any} */ ({})
     this.handlers = /** @type {any} */ ({})
     this.render()
     this.bind()
@@ -99,6 +102,7 @@ export class SelectorPanel {
     const input = document.createElement('input')
     input.className = 'panel-search'
     input.placeholder = placeholder
+
     const spacer = document.createElement('span')
     spacer.className = 'panel-spacer'
 
@@ -108,35 +112,21 @@ export class SelectorPanel {
       count.className = 'panel-count'
     }
 
-    const cta = document.createElement('button')
-    cta.type = 'button'
-    cta.className = 'panel-cta'
-    cta.style.display = 'none'
-
-    const quickAdd = document.createElement('button')
-    quickAdd.type = 'button'
-    quickAdd.className = 'panel-quick-add'
-    quickAdd.style.display = 'none'
-
     const content = document.createElement('div')
     content.className = 'dropdown-content'
 
-    // right-side submenu content (hidden by default)
-    const side = document.createElement('div')
-    side.className = 'side-content'
-    content.appendChild(side)
-
+    const menu = document.createElement('div')
+    menu.className = 'menu'
     const list = document.createElement('div')
     list.className = 'panel-list'
-    content.appendChild(list)
+    content.append(menu, list)
 
     wrap.append(arrow, label, input, spacer)
     if (count) wrap.append(count)
-    wrap.append(cta, quickAdd)
-    wrap.appendChild(content)
+    wrap.append(content)
     root.appendChild(wrap)
 
-    this.dom = { root, wrap, input, arrow, label, count, cta, quickAdd, spacer, content, list, side }
+    this.dom = { root, wrap, input, arrow, label, count, spacer, content, menu, list }
   }
 
   /** Bind DOM events */
@@ -146,28 +136,16 @@ export class SelectorPanel {
     const onEnter = () => schedule(() => this.open(), 0)
     const onLeave = () => schedule(() => this.close(), 200)
 
-    this.hoverFns = {
-      enter: () => schedule(() => this.toggleSide(true), 0),
-      leave: () => schedule(() => this.toggleSide(false), 200)
-    }
-
     for (const el of [this.dom.wrap, this.dom.content]) {
       el.addEventListener('mouseenter', onEnter)
       el.addEventListener('mouseleave', onLeave)
     }
 
-    this.dom.side.addEventListener('mouseenter', this.hoverFns.enter)
-    this.dom.side.addEventListener('mouseleave', this.hoverFns.leave)
-
     const onKeydown = (e) => {
       if (e.key === 'Escape') {
-        if (this.state.sideOpen) this.closeSide()
-        else this.close()
+        this.close()
       } else if (e.key === 'Enter' || e.key === ' ') {
         this.open()
-      } else if (e.key === 'ArrowLeft') {
-        if (this.state.sideOpen) this.closeSide()
-        else this.close()
       }
     }
     this.dom.wrap.addEventListener('keydown', onKeydown)
@@ -184,14 +162,7 @@ export class SelectorPanel {
         const action = /** @type {HTMLElement} */ (itemBtn).dataset.itemAction || ''
         const row = target.closest('[data-id]')
         const id = row ? /** @type {HTMLElement} */ (row).dataset.id || '' : ''
-        this.close()
         this.dispatchItemAction(action, id)
-        return
-      }
-      const actionsTrigger = target.closest('[data-testid="panel-actions-trigger"]')
-      if (actionsTrigger) {
-        e.preventDefault()
-        this.toggleSide(true, { focusFirst: true })
         return
       }
       const row = target.closest('[data-id]')
@@ -204,60 +175,62 @@ export class SelectorPanel {
     }
     this.dom.list.addEventListener('click', onListClick)
 
-    const onSideClick = (e) => {
-      const btn = /** @type {HTMLElement|null} */ (e.target instanceof HTMLElement ? e.target.closest('[data-action]') : null)
-      if (!btn) return
-      e.preventDefault()
-      this.close()
-      this.dispatchAction(btn.dataset.action || '')
-    }
-    this.dom.side.addEventListener('click', onSideClick)
-
     const onListKeydown = (e) => {
-      const onFirstRow = /** @type {HTMLElement|null} */ (
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement.closest('[data-testid="panel-actions-trigger"]')
-          : null
+      const row = /** @type {HTMLElement|null} */ (
+        e.target instanceof HTMLElement ? e.target.closest('[data-id]') : null
       )
-      if (onFirstRow && e.key === 'ArrowRight') {
+      if (row && (e.key === 'Enter' || e.key === ' ')) {
         e.preventDefault()
-        this.toggleSide(true, { focusFirst: true })
+        const id = row.dataset.id || ''
+        this.close()
+        this.dispatchSelect(id)
       }
     }
     this.dom.list.addEventListener('keydown', onListKeydown)
 
-    // close on modal open/close
-    this.handlers.onModalOpen = () => {
+    const onMenuClick = (e) => {
+      const target = /** @type {HTMLElement} */ (e.target)
+      const item = target.closest('[data-menu-action]')
+      if (item) {
+        e.preventDefault()
+        const action = /** @type {HTMLElement} */ (item).dataset.menuAction || ''
+        this.close()
+        this.dispatchAction(action)
+      }
+    }
+    this.dom.menu.addEventListener('click', onMenuClick)
+
+    const onMenuKeydown = (e) => {
+      const el = /** @type {HTMLElement|null} */ (
+        e.target instanceof HTMLElement ? e.target.closest('[data-menu-action]') : null
+      )
+      if (el && (e.key === 'Enter' || e.key === ' ')) {
+        e.preventDefault()
+        const action = el.dataset.menuAction || ''
+        this.close()
+        this.dispatchAction(action)
+      }
+    }
+    this.dom.menu.addEventListener('keydown', onMenuKeydown)
+
+    const onModalOpen = () => {
       const active = document.activeElement
       this.state.wasFocused = !!(active && this.dom.wrap.contains(active))
       this.close()
     }
-    this.handlers.onModalClose = () => {
+    const onModalClose = () => {
       if (this.state.wasFocused) this.dom.wrap.focus()
       this.state.wasFocused = false
     }
-    document.addEventListener('modal:open', this.handlers.onModalOpen)
-    document.addEventListener('modal:close', this.handlers.onModalClose)
+    document.addEventListener('modal:open', onModalOpen)
+    document.addEventListener('modal:close', onModalClose)
 
-    this.handlers.onEnter = onEnter
-    this.handlers.onLeave = onLeave
-    this.handlers.onKeydown = onKeydown
-    this.handlers.onInput = onInput
-    this.handlers.onListClick = onListClick
-    this.handlers.onSideClick = onSideClick
-    this.handlers.onListKeydown = onListKeydown
-
-    this.dom.cta.addEventListener('click', () => {
-      if (this.cfg.primaryAction) this.dispatchAction(this.cfg.primaryAction.action)
-    })
-    this.dom.quickAdd.addEventListener('click', () => {
-      if (this.cfg.quickAddAction) this.dispatchAction(this.cfg.quickAddAction.action)
-    })
+    this.handlers = { onEnter, onLeave, onKeydown, onInput, onListClick, onListKeydown, onMenuClick, onMenuKeydown, onModalOpen, onModalClose }
   }
 
-  /** Refresh list and counts */
+  /** Refresh list and menu */
   refresh () {
-    const { getItems, showCount, countText, labelText, actions: topActions = [], itemActions = [], itemActionsFor, primaryAction, quickAddAction, selectVerb } = this.cfg
+    const { getItems, showCount, countText, labelText, actions = [], itemActions = [], itemActionsFor, selectVerb } = this.cfg
 
     if (this.dom.label) {
       if (typeof labelText === 'function') {
@@ -284,61 +257,60 @@ export class SelectorPanel {
       }
     }
 
-    // header actions
-    const hasCreate = topActions.some(a => (primaryAction && a.action === primaryAction.action) || (quickAddAction && a.action === quickAddAction.action))
-    const singleCreate = topActions.length === 1 && hasCreate
-
-    if (primaryAction && singleCreate) {
-      this.dom.cta.textContent = primaryAction.label
-      this.dom.cta.title = primaryAction.label
-      this.dom.cta.setAttribute('aria-label', primaryAction.label)
-      this.dom.cta.style.display = ''
-      this.dom.cta.style.marginLeft = this.dom.count ? '6px' : 'auto'
-    } else {
-      this.dom.cta.style.display = 'none'
-    }
-
-    if (quickAddAction && hasCreate && topActions.length > 1) {
-      this.dom.quickAdd.textContent = quickAddAction.icon
-      this.dom.quickAdd.title = quickAddAction.title
-      this.dom.quickAdd.setAttribute('aria-label', quickAddAction.title)
-      this.dom.quickAdd.style.display = ''
-      this.dom.quickAdd.style.marginLeft = this.dom.count ? '6px' : 'auto'
-    } else {
-      this.dom.quickAdd.style.display = 'none'
-    }
-
+    this.dom.menu.innerHTML = ''
     this.dom.list.innerHTML = ''
-    this.dom.side.innerHTML = ''
-    if (this.dom.empty) {
-      this.dom.empty.remove()
-      this.dom.empty = null
+    if (this.dom.empty) { this.dom.empty.remove(); this.dom.empty = null }
+
+    // build top menu
+    if (actions.length === 1 && hasCreate(actions[0])) {
+      const a = actions[0]
+      const item = document.createElement('div')
+      item.className = 'menu-item'
+      item.dataset.menuAction = a.key
+      item.tabIndex = 0
+      item.setAttribute('role', 'menuitem')
+      item.textContent = `${emojiList.plus.unicode} ${a.label}`
+      item.title = a.label
+      item.setAttribute('aria-label', a.label)
+      this.dom.menu.appendChild(item)
+    } else if (actions.length > 0) {
+      const row = document.createElement('div')
+      row.className = 'menu-item'
+      row.tabIndex = 0
+      row.setAttribute('role', 'menuitem')
+      row.textContent = 'Actions ▸'
+      const fly = document.createElement('div')
+      fly.className = 'panel-item-actions-flyout'
+      fly.setAttribute('role', 'menu')
+      const sorted = [...actions].sort((a, b) => Number(hasCreate(b)) - Number(hasCreate(a)))
+      for (const a of sorted) {
+        const b = document.createElement('button')
+        b.type = 'button'
+        b.className = 'panel-action'
+        b.dataset.menuAction = a.key
+        const lbl = hasCreate(a) ? `${emojiList.plus.unicode} ${a.label}` : a.label
+        b.textContent = lbl
+        b.title = a.label
+        b.setAttribute('aria-label', a.label)
+        fly.appendChild(b)
+      }
+      row.appendChild(fly)
+      this.dom.menu.appendChild(row)
     }
 
     const items = getItems()
     if (items.length === 0) {
       this.dom.list.style.display = 'none'
-      this.dom.side.style.display = 'none'
       const empty = document.createElement('div')
       empty.className = 'panel-empty'
-      const src = primaryAction || quickAddAction
-      if (src) {
-        const base = ('label' in src ? src.label : src.title).replace(/^New\s+/i, '').trim()
+      const createA = actions.find(hasCreate)
+      if (createA) {
+        const base = createA.label.replace(/^New\s+/i, '').trim()
         const plural = base.endsWith('s') ? base + 'es' : base + 's'
         const titleEl = document.createElement('div')
-        titleEl.className = 'panel-empty-title'
+        titleEl.className = 'empty-title panel-empty-title'
         titleEl.textContent = `No ${plural} yet`
         empty.appendChild(titleEl)
-        if (primaryAction) {
-          const btn = document.createElement('button')
-          btn.type = 'button'
-          btn.className = 'panel-empty-cta'
-          btn.textContent = `+ ${primaryAction.label}`
-          btn.title = primaryAction.label
-          btn.setAttribute('aria-label', primaryAction.label)
-          btn.addEventListener('click', () => this.dispatchAction(primaryAction.action))
-          empty.appendChild(btn)
-        }
       }
       this.dom.content.appendChild(empty)
       this.dom.empty = empty
@@ -346,29 +318,6 @@ export class SelectorPanel {
     }
 
     this.dom.list.style.display = ''
-    this.dom.side.style.display = ''
-
-    const showActionsTrigger = topActions.length > 1 || (topActions.length === 1 && !singleCreate)
-    if (showActionsTrigger) {
-      const trigger = document.createElement('div')
-      trigger.className = 'panel-item panel-actions-trigger'
-      trigger.dataset.testid = 'panel-actions-trigger'
-      trigger.tabIndex = 0
-      trigger.innerHTML = '<span class="panel-item-label">Actions ▸</span>'
-      this.dom.list.appendChild(trigger)
-
-      trigger.addEventListener('mouseenter', this.hoverFns.enter)
-      trigger.addEventListener('mouseleave', this.hoverFns.leave)
-
-      for (const a of topActions) {
-        const b = document.createElement('button')
-        b.type = 'button'
-        b.className = 'panel-action'
-        b.dataset.action = a.action
-        b.textContent = a.label
-        this.dom.side.appendChild(b)
-      }
-    }
 
     for (const it of items) {
       const row = document.createElement('div')
@@ -390,29 +339,36 @@ export class SelectorPanel {
       left.textContent = it.label
       row.appendChild(left)
 
-      const hint = document.createElement('span')
-      hint.className = 'panel-item-hint'
-      hint.setAttribute('aria-hidden', 'true')
-      if (typeof selectVerb === 'function') hint.textContent = `Click to ${selectVerb(it).toLowerCase()}`
-      row.appendChild(hint)
-
       const meta = document.createElement('span')
       meta.className = 'panel-item-meta'
       meta.textContent = it.meta ? ` ${it.meta}` : ''
       row.appendChild(meta)
 
-      const acts = document.createElement('span')
-      acts.className = 'panel-item-actions'
-      const actions = typeof itemActionsFor === 'function' ? itemActionsFor(it) : itemActions
-      const iconMap = { rename: emojiList.edit.unicode, delete: emojiList.cross.unicode }
-      for (const a of actions) {
+      const placeholder = document.createElement('span')
+      placeholder.className = 'panel-item-actions-placeholder'
+      row.appendChild(placeholder)
+
+      const hint = document.createElement('span')
+      hint.className = 'panel-item-hint'
+      hint.setAttribute('aria-hidden', 'true')
+      if (typeof selectVerb === 'function') {
+        const verb = selectVerb(it) === 'Add' ? 'add' : 'switch'
+        hint.textContent = `Click to ${verb}`
+      }
+      row.appendChild(hint)
+
+      const acts = document.createElement('div')
+      acts.className = 'panel-item-actions-flyout'
+      acts.setAttribute('role', 'menu')
+      const actionsArr = typeof itemActionsFor === 'function' ? itemActionsFor(it) : itemActions
+      for (const a of actionsArr) {
         const b = document.createElement('button')
         b.type = 'button'
         b.className = 'panel-item-icon'
         b.dataset.itemAction = a.action
         b.title = a.title
         b.setAttribute('aria-label', a.title)
-        b.textContent = a.icon || iconMap[a.action] || ''
+        b.textContent = a.icon || ''
         acts.appendChild(b)
       }
       row.appendChild(acts)
@@ -428,7 +384,6 @@ export class SelectorPanel {
   filter (q) {
     const needle = normalize(q)
     this.dom.list.querySelectorAll('.panel-item').forEach(el => {
-      if (el.classList.contains('panel-actions-trigger')) return
       const txt = el.getAttribute('data-filterable') || ''
       el.toggleAttribute('hidden', !txt.includes(needle))
     })
@@ -446,25 +401,9 @@ export class SelectorPanel {
   close () {
     if (this.dom.wrap.classList.contains('open')) {
       this.dom.wrap.classList.remove('open')
-      this.closeSide()
       this.dom.wrap.dispatchEvent(new CustomEvent('selector:closed', { bubbles: true, composed: true }))
     }
   }
-
-  /** Toggle side panel */
-  toggleSide (open, opts = /** @type {{focusFirst?:boolean}} */({})) {
-    if (open) {
-      this.dom.content.classList.add('side-open')
-      this.state.sideOpen = true
-      if (opts.focusFirst) this.dom.side.querySelector('button')?.focus()
-    } else {
-      this.dom.content.classList.remove('side-open')
-      this.state.sideOpen = false
-    }
-  }
-
-  /** Close side panel */
-  closeSide () { this.toggleSide(false) }
 
   /** Dispatch selection */
   dispatchSelect (id) {
@@ -488,18 +427,17 @@ export class SelectorPanel {
 
   /** Unbind all event listeners */
   destroy () {
-    const { wrap, content, side, list, input } = this.dom
+    const { wrap, content, list, input, menu } = this.dom
     wrap.removeEventListener('mouseenter', this.handlers.onEnter)
     wrap.removeEventListener('mouseleave', this.handlers.onLeave)
     content.removeEventListener('mouseenter', this.handlers.onEnter)
     content.removeEventListener('mouseleave', this.handlers.onLeave)
-    side.removeEventListener('mouseenter', this.hoverFns.enter)
-    side.removeEventListener('mouseleave', this.hoverFns.leave)
     wrap.removeEventListener('keydown', this.handlers.onKeydown)
     input.removeEventListener('input', this.handlers.onInput)
     list.removeEventListener('click', this.handlers.onListClick)
-    side.removeEventListener('click', this.handlers.onSideClick)
     list.removeEventListener('keydown', this.handlers.onListKeydown)
+    menu.removeEventListener('click', this.handlers.onMenuClick)
+    menu.removeEventListener('keydown', this.handlers.onMenuKeydown)
     document.removeEventListener('modal:open', this.handlers.onModalOpen)
     document.removeEventListener('modal:close', this.handlers.onModalClose)
   }

--- a/src/component/panel/selector-panel.css
+++ b/src/component/panel/selector-panel.css
@@ -23,29 +23,52 @@
 .dropdown.panel .dropdown-content { position: absolute; top: 100%; left: 0; min-width: 340px; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 8px; display: none; box-shadow: 0 6px 24px rgba(0,0,0,.12); z-index: 20; }
 .dropdown.panel.open .dropdown-content { display: block; }
 
+.menu { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
+.menu-item { position: relative; padding: 6px 8px; border-radius: 4px; cursor: pointer; }
+.menu-item:hover { background: #f6f8fa; }
+.menu-item:focus { outline: 2px solid #2684ff; outline-offset: 2px; }
+
 .panel-list { display: flex; flex-direction: column; gap: 6px; }
-.panel-item { display: grid; grid-template-columns: 1fr auto var(--actions-width, 72px); gap: 6px; align-items: center; padding: 6px 8px; border-radius: 4px; cursor: pointer; }
+.panel-item { position: relative; display: grid; grid-template-columns: 1fr auto var(--actions-width,72px); gap: 6px; align-items: center; padding: 6px 8px; border-radius: 4px; cursor: pointer; }
 .panel-item[hidden] { display: none !important; }
 .panel-item:hover { background: #f6f8fa; }
 .panel-item-label { font-weight: 400; text-decoration: none; }
 .panel-item-meta { opacity: .7; font-size: 12px; }
-.panel-item-actions {
-  display: inline-flex;
-  gap: 6px;
-  justify-content: flex-end;
+.panel-item-actions-placeholder { width: var(--actions-width,72px); height: 1px; }
+.panel-item-hint {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: calc(var(--actions-width,72px) + 6px);
   opacity: 0;
-  pointer-events: none;
-  visibility: visible;
-  width: var(--actions-width, 72px);
+  font-size: 12px;
+  color: #6b7280;
   transition: opacity .15s ease;
+  pointer-events: none;
 }
-.panel-item:hover .panel-item-actions,
-.panel-item:focus-within .panel-item-actions {
-  opacity: 1;
-  pointer-events: auto;
+.panel-item:hover .panel-item-hint,
+.panel-item:focus-within .panel-item-hint { opacity: 1; }
+
+.panel-item-actions-flyout {
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translateY(-50%);
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 4px;
+  display: none;
+  gap: 6px;
+  box-shadow: 0 6px 24px rgba(0,0,0,.12);
 }
-#controls .panel-item-actions .panel-item-icon,
-.panel-item-actions .panel-item-icon {
+.panel-item:hover .panel-item-actions-flyout,
+.panel-item:focus-within .panel-item-actions-flyout,
+.menu-item:hover .panel-item-actions-flyout,
+.menu-item:focus-within .panel-item-actions-flyout { display: flex; }
+
+.panel-item-actions-flyout button,
+.panel-item-icon {
   background: none;
   border: none;
   padding: 0.2rem;
@@ -54,88 +77,13 @@
   cursor: pointer;
   transition: transform 0.2s ease, background-color 0.2s ease;
 }
-
-#controls .panel-item-actions .panel-item-icon:hover,
-.panel-item-actions .panel-item-icon:hover {
-  background-color: rgba(0,0,0,0.06);
-  transform: translateY(-1px);
-}
-
-.panel-actions-trigger {
-  font-weight: 400;
-  background: transparent;
-  grid-template-columns: 1fr;
-}
-.panel-actions-trigger:hover { background: #f6f8fa; }
-.panel-actions-trigger:focus {
-  outline: 2px solid #2684ff;
-  outline-offset: 2px;
-}
-.dropdown.panel .side-content { display: none; position: absolute; top: 0; left: 100%; min-width: 220px; background: #fff; border: 1px solid #ddd; border-radius: 4px; padding: 8px; box-shadow: 0 6px 24px rgba(0,0,0,.12); }
-.dropdown.panel .dropdown-content.side-open .side-content { display: block; }
-.side-content .panel-action {
-  padding: 6px 8px;
-  width: 100%;
-  text-align: left;
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
-  border-radius: 6px;
-  margin-bottom: 6px;
-  transition: background-color .15s ease, transform .15s ease;
-}
-.side-content .panel-action:hover {
-  background: #f6f8fa;
-  transform: translateY(-1px);
-}
-.side-content .panel-action:last-child { margin-bottom: 0; }
-
-.panel-spacer { flex: 1; }
-.panel-cta,
-.panel-quick-add {
-  background: none;
-  border: 1px solid #e5e7eb;
-  border-radius: 4px;
-  padding: 2px 6px;
-  cursor: pointer;
-  transition: background-color .15s ease, transform .15s ease;
-}
-.panel-quick-add { font-size: 1rem; }
-.panel-cta:hover,
-.panel-quick-add:hover {
-  background: #f6f8fa;
-  transform: translateY(-1px);
-}
+.panel-item-actions-flyout button:hover,
+.panel-item-icon:hover { background-color: rgba(0,0,0,0.06); transform: translateY(-1px); }
 
 .panel-item:hover .panel-item-label,
-.panel-item:focus-within .panel-item-label {
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.panel-item-hint {
-  opacity: 0;
-  margin-left: 6px;
-  font-size: 12px;
-  color: #6b7280;
-  transition: opacity .15s ease;
-}
-.panel-item:hover .panel-item-hint,
-.panel-item:focus-within .panel-item-hint {
-  opacity: 1;
-}
+.panel-item:focus-within .panel-item-label { text-decoration: underline; text-underline-offset: 2px; }
 
 .panel-empty { text-align: center; padding: 20px 0; }
 .panel-empty-title { margin-bottom: 12px; }
-.panel-empty-cta {
-  padding: 8px 12px;
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background-color .15s ease, transform .15s ease;
-}
-.panel-empty-cta:hover {
-  background: #f6f8fa;
-  transform: translateY(-1px);
-}
-
+.panel-empty-cta { padding: 8px 12px; border: 1px solid #e5e7eb; background: #ffffff; border-radius: 6px; cursor: pointer; transition: background-color .15s ease, transform .15s ease; }
+.panel-empty-cta:hover { background: #f6f8fa; transform: translateY(-1px); }

--- a/src/component/panel/selector-panel.css
+++ b/src/component/panel/selector-panel.css
@@ -24,16 +24,19 @@
 .dropdown.panel.open .dropdown-content { display: block; }
 
 .panel-list { display: flex; flex-direction: column; gap: 6px; }
-.panel-item { display: grid; grid-template-columns: 1fr auto auto; gap: 6px; align-items: center; padding: 6px 8px; border-radius: 4px; cursor: pointer; }
+.panel-item { display: grid; grid-template-columns: 1fr auto var(--actions-width, 72px); gap: 6px; align-items: center; padding: 6px 8px; border-radius: 4px; cursor: pointer; }
 .panel-item[hidden] { display: none !important; }
 .panel-item:hover { background: #f6f8fa; }
-.panel-item-label { font-weight: 400; }
+.panel-item-label { font-weight: 400; text-decoration: none; }
 .panel-item-meta { opacity: .7; font-size: 12px; }
 .panel-item-actions {
   display: inline-flex;
   gap: 6px;
+  justify-content: flex-end;
   opacity: 0;
   pointer-events: none;
+  visibility: visible;
+  width: var(--actions-width, 72px);
   transition: opacity .15s ease;
 }
 .panel-item:hover .panel-item-actions,
@@ -85,4 +88,54 @@
   transform: translateY(-1px);
 }
 .side-content .panel-action:last-child { margin-bottom: 0; }
+
+.panel-spacer { flex: 1; }
+.panel-cta,
+.panel-quick-add {
+  background: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: background-color .15s ease, transform .15s ease;
+}
+.panel-quick-add { font-size: 1rem; }
+.panel-cta:hover,
+.panel-quick-add:hover {
+  background: #f6f8fa;
+  transform: translateY(-1px);
+}
+
+.panel-item:hover .panel-item-label,
+.panel-item:focus-within .panel-item-label {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.panel-item-hint {
+  opacity: 0;
+  margin-left: 6px;
+  font-size: 12px;
+  color: #6b7280;
+  transition: opacity .15s ease;
+}
+.panel-item:hover .panel-item-hint,
+.panel-item:focus-within .panel-item-hint {
+  opacity: 1;
+}
+
+.panel-empty { text-align: center; padding: 20px 0; }
+.panel-empty-title { margin-bottom: 12px; }
+.panel-empty-cta {
+  padding: 8px 12px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color .15s ease, transform .15s ease;
+}
+.panel-empty-cta:hover {
+  background: #f6f8fa;
+  transform: translateY(-1px);
+}
 

--- a/src/component/service/ServiceControl.js
+++ b/src/component/service/ServiceControl.js
@@ -157,9 +157,8 @@ export function mountServiceControl () {
       panel.refresh()
     },
     actions: [
-      { label: 'New Service', action: 'create' }
+      { key: 'create', label: 'New Service' }
     ],
-    primaryAction: { label: 'New Service', action: 'create' },
     selectVerb: () => 'Add',
     itemActionsFor: (item) => {
       /** @type {{action:string,title:string,icon:string}[]} */

--- a/src/component/service/ServiceControl.js
+++ b/src/component/service/ServiceControl.js
@@ -122,10 +122,10 @@ export function mountServiceControl () {
       const svc = (StorageManager.getServices() || []).find(s => s.id === id)
       if (!svc) return
       const resolved = resolveServiceConfig(svc)
-      if (action === 'edit') {
+      if (action === 'rename') {
         const mod = await import('../modal/saveServiceModal.js')
         mod.openSaveServiceModal({ mode: 'edit', service: svc })
-      } else if (action === 'remove') {
+      } else if (action === 'delete') {
         // eslint-disable-next-line no-alert
         if (confirm('Remove this service and all its widgets?')) {
           document.querySelectorAll('.widget-wrapper').forEach(async el => {
@@ -159,14 +159,16 @@ export function mountServiceControl () {
     actions: [
       { label: 'New Service', action: 'create' }
     ],
+    primaryAction: { label: 'New Service', action: 'create' },
+    selectVerb: () => 'Add',
     itemActionsFor: (item) => {
       /** @type {{action:string,title:string,icon:string}[]} */
       const acts = []
       if (item.canNavigate) {
         acts.push({ action: 'navigate', title: 'Locate widget', icon: emojiList.magnifyingGlass.unicode })
       }
-      acts.push({ action: 'edit', title: 'Edit widget', icon: emojiList.edit.unicode })
-      acts.push({ action: 'remove', title: 'Delete widget type', icon: emojiList.noEntry.unicode })
+      acts.push({ action: 'rename', title: 'Rename service', icon: emojiList.edit.unicode })
+      acts.push({ action: 'delete', title: 'Delete service', icon: emojiList.cross.unicode })
       return acts
     }
   })

--- a/src/component/view/ViewControl.js
+++ b/src/component/view/ViewControl.js
@@ -77,11 +77,9 @@ export function mountViewControl () {
       if (bId) updateViewSelector(bId)
     },
     actions: [
-      { label: 'New View', action: 'create' },
-      { label: 'Reset View', action: 'reset' }
+      { key: 'create', label: 'New View' },
+      { key: 'reset', label: 'Reset View' }
     ],
-    primaryAction: { label: 'New View', action: 'create' },
-    quickAddAction: { title: 'New View', action: 'create', icon: emojiList.plus.unicode },
     selectVerb: () => 'Switch',
     itemActionsFor: () => [
       { action: 'rename', title: 'Rename view', icon: emojiList.edit.unicode },

--- a/src/component/view/ViewControl.js
+++ b/src/component/view/ViewControl.js
@@ -80,9 +80,12 @@ export function mountViewControl () {
       { label: 'New View', action: 'create' },
       { label: 'Reset View', action: 'reset' }
     ],
+    primaryAction: { label: 'New View', action: 'create' },
+    quickAddAction: { title: 'New View', action: 'create', icon: emojiList.plus.unicode },
+    selectVerb: () => 'Switch',
     itemActionsFor: () => [
       { action: 'rename', title: 'Rename view', icon: emojiList.edit.unicode },
-      { action: 'delete', title: 'Delete view', icon: emojiList.noEntry.unicode }
+      { action: 'delete', title: 'Delete view', icon: emojiList.cross.unicode }
     ]
   })
 

--- a/src/ui/unicodeEmoji.js
+++ b/src/ui/unicodeEmoji.js
@@ -3,6 +3,7 @@ export const emojiList = {
   puzzle: { icon: '🧩', unicode: '\u{1F9E9}', description: 'Widget to grid' },
   satellite: { icon: '📡', unicode: '\u{1F4E1}', description: 'Serviceworker' },
   cross: { icon: '❌', unicode: '\u{274C}', description: 'Delete widget' },
+  plus: { icon: '➕', unicode: '\u{2795}', description: 'Add' },
   noEntry: { icon: '⛔', unicode: '\u{26D4}', description: 'Delete' },
   crossCycle: { icon: '🔄', unicode: '\u{1F504}', description: 'Reset or refresh' },
   arrowDown: { icon: '⬇️', unicode: '\u{2B07}\u{FE0F}', description: 'Increase height' },

--- a/tests/boardPanel.spec.ts
+++ b/tests/boardPanel.spec.ts
@@ -31,6 +31,30 @@ test.describe('Board panel', () => {
     await row.focus()
     await expect(acts).toHaveCSS('opacity', '1')
     await expect(panel.locator('[data-item-action="navigate"]')).toHaveCount(0)
+    await row.hover()
+    await expect(row.locator('[data-item-action="delete"]')).toHaveText('❌')
+  })
+
+  test('header quick-add button visible and creates board', async ({ page }) => {
+    const panel = page.locator('[data-testid="board-panel"]')
+    await panel.hover()
+    await expect(panel.locator('.panel-quick-add')).toHaveText('➕')
+    await panel.locator('.panel-quick-add').focus()
+    const newName = 'Quick Board'
+    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(newName) })
+    await page.keyboard.press('Enter')
+    await expect(panel.locator('.side-content')).toHaveCount(0)
+    await panel.hover()
+    await expect(panel.locator('.panel-item', { hasText: newName })).toBeVisible()
+  })
+
+  test('label hint and aria for switch', async ({ page }) => {
+    const panel = page.locator('[data-testid="board-panel"]')
+    await panel.hover()
+    const first = panel.locator('.panel-item').nth(1)
+    await expect(first).toHaveAttribute('aria-label', /^Switch:/)
+    await first.hover()
+    await expect(first.locator('.panel-item-hint')).toHaveText('Click to switch')
   })
 
   test('opens dropdown and shows Actions ▸', async ({ page }) => {
@@ -95,7 +119,7 @@ test.describe('Board panel', () => {
 
     await rowRenamed.hover()
     const deleteBtn = rowRenamed.locator('[data-item-action="delete"]').first()
-    await expect(deleteBtn).toHaveText('⛔')
+    await expect(deleteBtn).toHaveText('❌')
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })
     await deleteBtn.click()
     await expect(panel.locator('.panel-item', { hasText: renamed })).toHaveCount(0)

--- a/tests/boardPanel.spec.ts
+++ b/tests/boardPanel.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking'
 import { navigate, addServices } from './shared/common'
+import { openCreateFromTopMenu, ensurePanelOpen } from './shared/panels'
 
-// Tests for board selector panel with item icons and side actions
 test.describe('Board panel', () => {
   test.beforeEach(async ({ page }) => {
     await routeServicesConfig(page)
@@ -14,100 +14,43 @@ test.describe('Board panel', () => {
     const panel = page.locator('[data-testid="board-panel"]')
     await expect(panel.locator('.panel-arrow')).toHaveText('▼')
     await expect(panel.locator('.panel-label')).toHaveText(/Board:\s+/)
-    await expect(panel.locator('.panel-label')).not.toContainText('▼')
     await expect(panel.locator('.panel-count')).toHaveCount(0)
   })
 
-  test('icons hidden at rest, shown on hover/focus, no magnifier', async ({ page }) => {
+  test('flyout actions on hover', async ({ page }) => {
     const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-    const row = panel.locator('.panel-item').nth(1)
-    const acts = row.locator('.panel-item-actions')
-    await expect(acts).toHaveCSS('opacity', '0')
+    await ensurePanelOpen(page, 'board-panel')
+    const row = panel.locator('.panel-item').first()
     await row.hover()
-    await expect(acts).toHaveCSS('opacity', '1')
-    await panel.locator('.panel-search').hover()
-    await expect(acts).toHaveCSS('opacity', '0')
-    await row.focus()
-    await expect(acts).toHaveCSS('opacity', '1')
-    await expect(panel.locator('[data-item-action="navigate"]')).toHaveCount(0)
-    await row.hover()
+    await expect(row.locator('.panel-item-actions-flyout')).toBeVisible()
+    await expect(row.locator('[data-item-action="navigate"]')).toHaveCount(0)
     await expect(row.locator('[data-item-action="delete"]')).toHaveText('❌')
-  })
-
-  test('header quick-add button visible and creates board', async ({ page }) => {
-    const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-    await expect(panel.locator('.panel-quick-add')).toHaveText('➕')
-    await panel.locator('.panel-quick-add').focus()
-    const newName = 'Quick Board'
-    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(newName) })
-    await page.keyboard.press('Enter')
-    await expect(panel.locator('.side-content')).toHaveCount(0)
-    await panel.hover()
-    await expect(panel.locator('.panel-item', { hasText: newName })).toBeVisible()
   })
 
   test('label hint and aria for switch', async ({ page }) => {
     const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-    const first = panel.locator('.panel-item').nth(1)
+    await ensurePanelOpen(page, 'board-panel')
+    const first = panel.locator('.panel-item').first()
     await expect(first).toHaveAttribute('aria-label', /^Switch:/)
     await first.hover()
     await expect(first.locator('.panel-item-hint')).toHaveText('Click to switch')
   })
 
-  test('opens dropdown and shows Actions ▸', async ({ page }) => {
-    const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-    await expect(panel.locator('.dropdown-content')).toBeVisible()
-    await expect(panel.locator('[data-testid="panel-actions-trigger"]')).toBeVisible()
-  })
-
-  test('side opens on hover', async ({ page }) => {
-    const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
-    await trigger.hover()
-    await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
-  })
-
-  test('Actions ▸ focus ring visible via keyboard', async ({ page }) => {
-    const panel = page.locator('[data-testid="board-panel"]')
-    await panel.focus()
-    await page.keyboard.press('Enter')
-    await page.keyboard.press('Tab') // focus search
-    await page.keyboard.press('Tab') // focus Actions ▸
-    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
-    await expect(trigger).toBeFocused()
-    await expect(trigger).toHaveCSS('outline-style', 'solid')
-  })
-
-  test('Actions ▸ → New Board creates a board', async ({ page }) => {
-    const panel = page.locator('[data-testid="board-panel"]')
+  test('top-menu create board', async ({ page }) => {
     const newName = 'Playwright Board'
     page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(newName) })
-    await panel.hover()
-    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
-    await trigger.hover()
-    await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
-    await panel.locator('.side-content .panel-action', { hasText: 'New Board' }).click()
-    await panel.hover()
-    await expect(panel.locator('.panel-item', { hasText: newName })).toBeVisible()
+    await openCreateFromTopMenu(page, 'board-panel', 'New Board')
+    await ensurePanelOpen(page, 'board-panel')
+    await expect(page.locator('[data-testid="board-panel"] .panel-item', { hasText: newName })).toBeVisible()
   })
 
-  test('per-item rename and delete icons', async ({ page }) => {
+  test('per-item rename and delete', async ({ page }) => {
     const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-
     const initial = 'Temp Board'
     page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(initial) })
-    await panel.locator('[data-testid="panel-actions-trigger"]').click()
-    await panel.locator('.side-content .panel-action', { hasText: 'New Board' }).click()
-    await panel.hover()
+    await openCreateFromTopMenu(page, 'board-panel', 'New Board')
+    await ensurePanelOpen(page, 'board-panel')
     const row = panel.locator('.panel-item', { hasText: initial })
-    await expect(row).toBeVisible()
-
     await row.hover()
     const renameBtn = row.locator('[data-item-action="rename"]').first()
     await expect(renameBtn).toHaveText('✏️')
@@ -115,61 +58,23 @@ test.describe('Board panel', () => {
     page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(renamed) })
     await renameBtn.click()
     const rowRenamed = panel.locator('.panel-item', { hasText: renamed })
-    await expect(rowRenamed).toBeVisible()
-
     await rowRenamed.hover()
     const deleteBtn = rowRenamed.locator('[data-item-action="delete"]').first()
-    await expect(deleteBtn).toHaveText('❌')
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })
     await deleteBtn.click()
     await expect(panel.locator('.panel-item', { hasText: renamed })).toHaveCount(0)
   })
 
-  test('keyboard interactions', async ({ page }) => {
+  test('keyboard focus reveals flyout', async ({ page }) => {
     const panel = page.locator('[data-testid="board-panel"]')
     await panel.focus()
     await page.keyboard.press('Enter')
-    await expect(panel.locator('.dropdown-content')).toBeVisible()
-    await page.keyboard.press('Tab')
-    await page.keyboard.press('Tab')
+    await page.keyboard.press('Tab') // search
+    await page.keyboard.press('Tab') // first row
     await page.keyboard.press('ArrowRight')
-    await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
-    await page.keyboard.press('ArrowLeft')
-    await expect(panel.locator('.dropdown-content.side-open .side-content')).toHaveCount(0)
-    await panel.focus()
+    const fly = panel.locator('.panel-item').first().locator('.panel-item-actions-flyout')
+    await expect(fly).toBeVisible()
     await page.keyboard.press('Escape')
-    await expect(panel.locator('.dropdown-content')).toBeHidden()
-  })
-
-  test('item icons hover styling', async ({ page }) => {
-    const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-    const row = panel.locator('.panel-item').nth(1)
-    await row.hover()
-    const icon = row.locator('[data-item-action="rename"]').first()
-    await expect(icon).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
-    await icon.hover()
-    await expect(icon).toHaveCSS('background-color', 'rgba(0, 0, 0, 0.06)')
-  })
-
-  test('search filters boards but keeps Actions ▸', async ({ page }) => {
-    const panel = page.locator('[data-testid="board-panel"]')
-    await panel.hover()
-
-    const names = ['Alpha Board', 'Beta Board']
-    for (const name of names) {
-      page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(name) })
-      await panel.locator('[data-testid="panel-actions-trigger"]').click()
-      await panel.locator('.side-content .panel-action', { hasText: 'New Board' }).click()
-      await panel.hover()
-    }
-    await expect(panel.locator('.panel-item', { hasText: names[0] })).toBeVisible()
-    await expect(panel.locator('.panel-item', { hasText: names[1] })).toBeVisible()
-
-    await panel.locator('.panel-search').fill('alpha')
-    await expect(panel.locator('.panel-item', { hasText: names[0] })).toBeVisible()
-    await expect(panel.locator('.panel-item', { hasText: names[1] })).toHaveAttribute('hidden', '')
-    await expect(panel.locator('[data-testid="panel-actions-trigger"]')).toBeVisible()
+    await expect(fly).toBeHidden()
   })
 })
-

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -7,8 +7,8 @@ import {
   getConfigBoards,
   b64,
   navigate,
-  ensurePanelOpen,
 } from "./shared/common";
+import { ensurePanelOpen } from './shared/panels'
 import { decodeConfig } from "../src/utils/compression.js";
 import { restoreDeep } from "../src/utils/minimizer.js";
 import { DEFAULT_CONFIG_TEMPLATE } from "../src/storage/defaultConfig.js";
@@ -23,10 +23,10 @@ test.describe("Dashboard Config - Base64 via URL Params", () => {
 
     await navigate(page, `/?config_base64=${config}&services_base64=${services}`);
 
-    // Service panel should render with all services (actions row + items)
-    await ensurePanelOpen(page);
+    // Service panel should render with all services
+    await ensurePanelOpen(page, 'service-panel');
     await expect(page.locator('[data-testid="service-panel"] .panel-item')).toHaveCount(
-      ciServices.length + 1
+      ciServices.length
     );
 
     // Boards are available in the UI
@@ -217,7 +217,7 @@ test.describe("Dashboard Functionality - Building from Services", () => {
       `/?config_base64=${b64(cfg)}&services_base64=${b64(ciServices)}`
     );
 
-    await ensurePanelOpen(page);
+    await ensurePanelOpen(page, 'service-panel');
     // Click first available service option (index 1 skips the placeholder/search row if present)
     await page.locator('[data-testid="service-panel"] .panel-item').nth(1).click();
 

--- a/tests/persistence.spec.ts
+++ b/tests/persistence.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking'
 import { handleDialog, getConfigBoards, navigate } from './shared/common'
+import { openCreateFromTopMenu, ensurePanelOpen } from './shared/panels'
 
 const boardName = 'Persist Board'
 
@@ -13,10 +14,8 @@ test.describe('Board persistence', () => {
 
   test('new board persists after reload', async ({ page }) => {
     await handleDialog(page, 'prompt', boardName)
-    await page.locator('[data-testid="board-panel"]').hover()
-    await page.locator('[data-testid="board-panel"] [data-testid="panel-actions-trigger"]').click()
-    await page.locator('[data-testid="board-panel"] .side-content .panel-action', { hasText: 'New Board' }).click()
-    await page.locator('[data-testid="board-panel"]').hover()
+    await openCreateFromTopMenu(page, 'board-panel', 'New Board')
+    await ensurePanelOpen(page, 'board-panel')
     await expect(page.locator('#board-selector')).toContainText(boardName)
 
     await page.reload()
@@ -27,10 +26,8 @@ test.describe('Board persistence', () => {
 
   test('last view persists after reload', async ({ page }) => {
     await handleDialog(page, 'prompt', 'Second View')
-    await page.locator('[data-testid="view-panel"]').hover()
-    await page.locator('[data-testid="view-panel"] [data-testid="panel-actions-trigger"]').click()
-    await page.locator('[data-testid="view-panel"] .side-content .panel-action', { hasText: 'New View' }).click()
-    await page.locator('[data-testid="view-panel"]').hover()
+    await openCreateFromTopMenu(page, 'view-panel', 'New View')
+    await ensurePanelOpen(page, 'view-panel')
     await expect(page.locator('#view-selector option:checked')).toHaveText('Second View')
 
     await page.reload()

--- a/tests/saveServiceModal.spec.ts
+++ b/tests/saveServiceModal.spec.ts
@@ -1,19 +1,17 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking.js'
-import { ensurePanelOpen } from './shared/common'
+import { ensurePanelOpen, openCreateFromTopMenu } from './shared/panels'
 
 test.describe('Save Service Modal', () => {
   test.beforeEach(async ({ page }) => {
     await routeServicesConfig(page)
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
-    await ensurePanelOpen(page)
+    await ensurePanelOpen(page, 'service-panel')
   })
 
   test('opens when adding widget with manual URL', async ({ page }) => {
-    const trigger = page.locator('[data-testid="service-panel"] [data-testid="panel-actions-trigger"]')
-    await trigger.hover()
-    await page.locator('.side-content .panel-action', { hasText: 'New Service' }).click()
+    await openCreateFromTopMenu(page, 'service-panel', 'New Service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
     await expect(modal.locator('input#service-name')).toBeVisible()
@@ -21,9 +19,7 @@ test.describe('Save Service Modal', () => {
 
   test('saves manual service when confirmed', async ({ page }) => {
     const url = 'http://localhost/manual-save'
-    const trigger2 = page.locator('[data-testid="service-panel"] [data-testid="panel-actions-trigger"]')
-    await trigger2.hover()
-    await page.locator('.side-content .panel-action', { hasText: 'New Service' }).click()
+    await openCreateFromTopMenu(page, 'service-panel', 'New Service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
 
@@ -50,9 +46,7 @@ test.describe('Save Service Modal', () => {
 
   test('skipping manual service does not store it', async ({ page }) => {
     const url = 'http://localhost/manual-skip'
-    const trigger3 = page.locator('[data-testid="service-panel"] [data-testid="panel-actions-trigger"]')
-    await trigger3.hover()
-    await page.locator('.side-content .panel-action', { hasText: 'New Service' }).click()
+    await openCreateFromTopMenu(page, 'service-panel', 'New Service')
     const modal = page.locator('#save-service-modal')
     await expect(modal).toBeVisible()
     await page.fill('#service-url', url) // Fill URL to be certain

--- a/tests/serviceEditDelete.spec.ts
+++ b/tests/serviceEditDelete.spec.ts
@@ -17,7 +17,7 @@ test.describe('Service Edit/Delete', () => {
     // *** FIX: Hover over the row first to make action buttons appear ***
     await serviceRow.hover();
     
-    await serviceRow.locator('[data-item-action="edit"]').click();
+    await serviceRow.locator('[data-item-action="rename"]').click();
 
     const modal = page.locator('#save-service-modal') // The modal ID is now save-service-modal
     await expect(modal).toBeVisible()
@@ -36,7 +36,7 @@ test.describe('Service Edit/Delete', () => {
     await expect(page.locator('.widget-wrapper')).toHaveCount(1)
 
     page.on('dialog', d => d.accept())
-    await page.click('[data-testid="service-panel"] .panel-item:has-text("ASD-terminal") [data-item-action="remove"]')
+    await page.click('[data-testid="service-panel"] .panel-item:has-text("ASD-terminal") [data-item-action="delete"]')
     await page.waitForSelector('.widget-wrapper', { state: 'detached' })
 
     const services = await page.evaluate(() => JSON.parse(localStorage.getItem('services')))

--- a/tests/servicePanel.spec.ts
+++ b/tests/servicePanel.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking'
 import { addServices, clearStorage } from './shared/common'
+import { openCreateFromTopMenu, ensurePanelOpen } from './shared/panels'
 
 // Basic structure tests for service selector panel
 
@@ -19,33 +20,29 @@ test.describe('Service panel', () => {
     await expect(panel.locator('.panel-count')).toBeVisible()
 
     const order = await panel.evaluate((el) => Array.from(el.children).map(c => c.className))
-    expect(order.slice(0,7)).toEqual(['panel-arrow','panel-label','panel-search','panel-spacer','panel-count','panel-cta','panel-quick-add'])
+    expect(order.slice(0,5)).toEqual(['panel-arrow','panel-label','panel-search','panel-spacer','panel-count'])
   })
 
-  test('icons toggle visibility and magnifier conditional', async ({ page }) => {
+  test('flyout visibility and magnifier conditional', async ({ page }) => {
     await addServices(page, 1)
     const panel = page.locator('[data-testid="service-panel"]')
-    await panel.hover()
+    await ensurePanelOpen(page, 'service-panel')
     const first = panel.locator('.panel-item').nth(1)
     const second = panel.locator('.panel-item').nth(2)
-    const firstActs = first.locator('.panel-item-actions')
-    await expect(firstActs).toHaveCSS('opacity', '0')
     await first.hover()
-    await expect(firstActs).toHaveCSS('opacity', '1')
-    await second.hover()
-    await expect(firstActs).toHaveCSS('opacity', '0')
+    await expect(first.locator('.panel-item-actions-flyout')).toBeVisible()
     await expect(first.locator('[data-item-action="navigate"]')).toHaveCount(1)
+    await second.hover()
+    await expect(first.locator('.panel-item-actions-flyout')).toBeHidden()
     await expect(second.locator('[data-item-action="navigate"]')).toHaveCount(0)
     await first.hover()
     await expect(first.locator('[data-item-action="delete"]')).toHaveText('❌')
   })
 
-  test('header shows primary CTA without Actions row', async ({ page }) => {
-    const panel = page.locator('[data-testid="service-panel"]')
-    await panel.hover()
-    await expect(panel.locator('.panel-cta')).toHaveText('New Service')
-    await expect(panel.locator('.panel-quick-add')).toHaveCount(0)
-    await expect(panel.locator('[data-testid="panel-actions-trigger"]')).toHaveCount(0)
+  test('top menu shows single create action', async ({ page }) => {
+    await ensurePanelOpen(page, 'service-panel')
+    const first = page.locator('[data-testid="service-panel"] .menu .menu-item').first()
+    await expect(first).toHaveText(/New Service/)
   })
 
   test('empty state renders CTA and hides Actions', async ({ page }) => {
@@ -54,30 +51,34 @@ test.describe('Service panel', () => {
     const panel = page.locator('[data-testid="service-panel"]')
     await panel.hover()
     await expect(panel.locator('.panel-empty-title')).toHaveText('No Services yet')
-    await expect(panel.locator('.panel-empty-cta')).toHaveText('+ New Service')
+    await expect(panel.locator('.panel-empty-cta')).toHaveCount(0)
     await expect(panel.locator('.panel-search')).toBeVisible()
-    await expect(panel.locator('[data-testid="panel-actions-trigger"]')).toHaveCount(0)
   })
 
   test('meta column aligned regardless of navigate icon', async ({ page }) => {
     await addServices(page, 1)
     const panel = page.locator('[data-testid="service-panel"]')
-    await panel.hover()
-    const firstMeta = await panel.locator('.panel-item').nth(1).locator('.panel-item-meta').boundingBox()
-    const secondMeta = await panel.locator('.panel-item').nth(2).locator('.panel-item-meta').boundingBox()
-    const dx = Math.abs((firstMeta?.x || 0) - (secondMeta?.x || 0))
+    await ensurePanelOpen(page, 'service-panel')
+    const firstRow = panel.locator('.panel-item').nth(1)
+    const meta = firstRow.locator('.panel-item-meta')
+    const before = await meta.boundingBox()
+    await firstRow.hover()
+    const after = await meta.boundingBox()
+    const dx = Math.abs((after?.x || 0) - (before?.x || 0))
     expect(dx).toBeLessThanOrEqual(1)
   })
 
   test('label affordance and keyboard create', async ({ page }) => {
     const panel = page.locator('[data-testid="service-panel"]')
-    await panel.hover()
+    await ensurePanelOpen(page, 'service-panel')
     const first = panel.locator('.panel-item').nth(1)
     await expect(first).toHaveAttribute('aria-label', /^Add:/)
+    const before = await first.boundingBox()
     await first.hover()
     await expect(first.locator('.panel-item-hint')).toHaveText('Click to add')
-    await panel.locator('.panel-cta').focus()
+    const after = await first.boundingBox()
+    expect(Math.abs((after?.height || 0) - (before?.height || 0))).toBeLessThanOrEqual(1)
     page.once('dialog', d => d.dismiss())
-    await page.keyboard.press('Enter')
+    await openCreateFromTopMenu(page, 'service-panel', 'New Service')
   })
 })

--- a/tests/shared/panels.ts
+++ b/tests/shared/panels.ts
@@ -1,0 +1,20 @@
+import { expect, Page } from '@playwright/test'
+
+export async function ensurePanelOpen (page: Page, panelTestId: string) {
+  const panel = page.locator(`[data-testid="${panelTestId}"]`)
+  await panel.hover()
+  await expect(panel.locator('.dropdown-content')).toBeVisible()
+}
+
+export async function openCreateFromTopMenu (page: Page, panelTestId: 'service-panel' | 'board-panel' | 'view-panel', label: string) {
+  await ensurePanelOpen(page, panelTestId)
+  const menu = page.locator(`[data-testid="${panelTestId}"] .menu`)
+  const direct = menu.locator('.menu-item', { hasText: label }).first()
+  if (await direct.count()) {
+    await direct.click()
+    return
+  }
+  const submenu = menu.locator('.menu-item').first()
+  await submenu.hover()
+  await submenu.locator('.panel-item-actions-flyout button', { hasText: label }).first().click()
+}

--- a/tests/viewPanel.spec.ts
+++ b/tests/viewPanel.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking'
 import { navigate, addServices } from './shared/common'
+import { openCreateFromTopMenu, ensurePanelOpen } from './shared/panels'
 
 test.describe('View panel', () => {
   test.beforeEach(async ({ page }) => {
@@ -13,131 +14,67 @@ test.describe('View panel', () => {
     const panel = page.locator('[data-testid="view-panel"]')
     await expect(panel.locator('.panel-arrow')).toHaveText('▼')
     await expect(panel.locator('.panel-label')).toHaveText(/View:\s+/)
-    await expect(panel.locator('.panel-label')).not.toContainText('▼')
     await expect(panel.locator('.panel-count')).toHaveCount(0)
   })
 
-  test('shows widget counts and icon visibility on hover/focus', async ({ page }) => {
+  test('shows widget counts and flyout on hover', async ({ page }) => {
     const panel = page.locator('[data-testid="view-panel"]')
-    await panel.hover()
-    const first = panel.locator('.panel-item').nth(1)
+    await ensurePanelOpen(page, 'view-panel')
+    const first = panel.locator('.panel-item').first()
     await expect(first.locator('.panel-item-meta')).toContainText('widgets')
-    const acts = first.locator('.panel-item-actions')
-    await expect(acts).toHaveCSS('opacity', '0')
     await first.hover()
-    await expect(acts).toHaveCSS('opacity', '1')
-    await panel.locator('.panel-search').hover()
-    await expect(acts).toHaveCSS('opacity', '0')
-    await first.focus()
-    await expect(acts).toHaveCSS('opacity', '1')
-    await first.hover()
+    await expect(first.locator('.panel-item-actions-flyout')).toBeVisible()
     await expect(first.locator('[data-item-action="delete"]')).toHaveText('❌')
-  })
-
-  test('opens dropdown and side Actions ▸', async ({ page }) => {
-    const panel = page.locator('[data-testid="view-panel"]')
-    await panel.hover()
-    await expect(panel.locator('.dropdown-content')).toBeVisible()
-    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
-    await trigger.hover()
-    await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
-    await expect(panel.locator('.side-content .panel-action', { hasText: 'New View' })).toBeVisible()
-    await expect(panel.locator('.side-content .panel-action', { hasText: 'Reset View' })).toBeVisible()
-  })
-
-  test('header quick-add creates view', async ({ page }) => {
-    const panel = page.locator('[data-testid="view-panel"]')
-    await panel.hover()
-    await expect(panel.locator('.panel-quick-add')).toHaveText('➕')
-    await panel.locator('.panel-quick-add').focus()
-    const name = 'Quick View'
-    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(name) })
-    await page.keyboard.press('Enter')
-    await expect(panel.locator('.side-content')).toHaveCount(0)
-    await panel.hover()
-    await expect(panel.locator('.panel-item', { hasText: name })).toBeVisible()
   })
 
   test('label hint and aria for switch', async ({ page }) => {
     const panel = page.locator('[data-testid="view-panel"]')
-    await panel.hover()
-    const first = panel.locator('.panel-item').nth(1)
+    await ensurePanelOpen(page, 'view-panel')
+    const first = panel.locator('.panel-item').first()
     await expect(first).toHaveAttribute('aria-label', /^Switch:/)
     await first.hover()
     await expect(first.locator('.panel-item-hint')).toHaveText('Click to switch')
   })
 
-  test('per-item rename/delete and Reset View', async ({ page }) => {
+  test('top-menu create view', async ({ page }) => {
+    const name = 'Playwright View'
+    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(name) })
+    await openCreateFromTopMenu(page, 'view-panel', 'New View')
+    await ensurePanelOpen(page, 'view-panel')
+    await expect(page.locator('[data-testid="view-panel"] .panel-item', { hasText: name })).toBeVisible()
+  })
+
+  test('per-item rename and delete', async ({ page }) => {
     const panel = page.locator('[data-testid="view-panel"]')
-    await panel.hover()
-
-    const v1 = 'Playwright View'
-    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(v1) })
-    const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
-    await trigger.hover()
-    await panel.locator('.side-content .panel-action', { hasText: 'New View' }).click()
-    await panel.hover()
-    await expect(panel.locator('.panel-item', { hasText: v1 })).toBeVisible()
-
-    const row = panel.locator('.panel-item', { hasText: v1 })
+    const initial = 'Temp View'
+    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(initial) })
+    await openCreateFromTopMenu(page, 'view-panel', 'New View')
+    await ensurePanelOpen(page, 'view-panel')
+    const row = panel.locator('.panel-item', { hasText: initial })
     await row.hover()
     const renameBtn = row.locator('[data-item-action="rename"]').first()
     await expect(renameBtn).toHaveText('✏️')
-    const v2 = 'Renamed View'
-    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(v2) })
+    const renamed = 'Renamed View'
+    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(renamed) })
     await renameBtn.click()
-    const row2 = panel.locator('.panel-item', { hasText: v2 })
-    await expect(row2).toBeVisible()
-
-    await trigger.hover()
-    page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })
-    await panel.locator('.side-content .panel-action', { hasText: 'Reset View' }).click()
-    await panel.hover()
-
-    await row2.hover()
-    const deleteBtn = row2.locator('[data-item-action="delete"]').first()
-    await expect(deleteBtn).toHaveText('❌')
+    const rowRenamed = panel.locator('.panel-item', { hasText: renamed })
+    await rowRenamed.hover()
+    const deleteBtn = rowRenamed.locator('[data-item-action="delete"]').first()
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })
     await deleteBtn.click()
-    await panel.hover()
-    await expect(panel.locator('.panel-item', { hasText: v2 })).toHaveCount(0)
+    await expect(panel.locator('.panel-item', { hasText: renamed })).toHaveCount(0)
   })
 
-  test('keyboard interactions', async ({ page }) => {
+  test('keyboard focus reveals flyout', async ({ page }) => {
     const panel = page.locator('[data-testid="view-panel"]')
     await panel.focus()
     await page.keyboard.press('Enter')
-    await expect(panel.locator('.dropdown-content')).toBeVisible()
     await page.keyboard.press('Tab')
     await page.keyboard.press('Tab')
     await page.keyboard.press('ArrowRight')
-    await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
+    const fly = panel.locator('.panel-item').first().locator('.panel-item-actions-flyout')
+    await expect(fly).toBeVisible()
     await page.keyboard.press('Escape')
-    await expect(panel.locator('.dropdown-content.side-open .side-content')).toHaveCount(0)
-    await panel.focus()
-    await page.keyboard.press('Escape')
-    await expect(panel.locator('.dropdown-content')).toBeHidden()
-  })
-
-  test('search filters view list', async ({ page }) => {
-    const panel = page.locator('[data-testid="view-panel"]')
-    await panel.hover()
-
-    const names = ['Alpha View', 'Beta View']
-    for (const name of names) {
-      page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(name) })
-      const trigger = panel.locator('[data-testid="panel-actions-trigger"]')
-      await trigger.hover()
-      await panel.locator('.side-content .panel-action', { hasText: 'New View' }).click()
-      await panel.hover()
-    }
-    await expect(panel.locator('.panel-item', { hasText: names[0] })).toBeVisible()
-    await expect(panel.locator('.panel-item', { hasText: names[1] })).toBeVisible()
-
-    await panel.locator('.panel-search').fill('alpha')
-    await expect(panel.locator('.panel-item', { hasText: names[0] })).toBeVisible()
-    await expect(panel.locator('.panel-item', { hasText: names[1] })).toHaveAttribute('hidden', '')
-    await expect(panel.locator('[data-testid="panel-actions-trigger"]')).toBeVisible()
+    await expect(fly).toBeHidden()
   })
 })
-

--- a/tests/viewPanel.spec.ts
+++ b/tests/viewPanel.spec.ts
@@ -30,6 +30,8 @@ test.describe('View panel', () => {
     await expect(acts).toHaveCSS('opacity', '0')
     await first.focus()
     await expect(acts).toHaveCSS('opacity', '1')
+    await first.hover()
+    await expect(first.locator('[data-item-action="delete"]')).toHaveText('❌')
   })
 
   test('opens dropdown and side Actions ▸', async ({ page }) => {
@@ -41,6 +43,28 @@ test.describe('View panel', () => {
     await expect(panel.locator('.dropdown-content.side-open .side-content')).toBeVisible()
     await expect(panel.locator('.side-content .panel-action', { hasText: 'New View' })).toBeVisible()
     await expect(panel.locator('.side-content .panel-action', { hasText: 'Reset View' })).toBeVisible()
+  })
+
+  test('header quick-add creates view', async ({ page }) => {
+    const panel = page.locator('[data-testid="view-panel"]')
+    await panel.hover()
+    await expect(panel.locator('.panel-quick-add')).toHaveText('➕')
+    await panel.locator('.panel-quick-add').focus()
+    const name = 'Quick View'
+    page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(name) })
+    await page.keyboard.press('Enter')
+    await expect(panel.locator('.side-content')).toHaveCount(0)
+    await panel.hover()
+    await expect(panel.locator('.panel-item', { hasText: name })).toBeVisible()
+  })
+
+  test('label hint and aria for switch', async ({ page }) => {
+    const panel = page.locator('[data-testid="view-panel"]')
+    await panel.hover()
+    const first = panel.locator('.panel-item').nth(1)
+    await expect(first).toHaveAttribute('aria-label', /^Switch:/)
+    await first.hover()
+    await expect(first.locator('.panel-item-hint')).toHaveText('Click to switch')
   })
 
   test('per-item rename/delete and Reset View', async ({ page }) => {
@@ -72,7 +96,7 @@ test.describe('View panel', () => {
 
     await row2.hover()
     const deleteBtn = row2.locator('[data-item-action="delete"]').first()
-    await expect(deleteBtn).toHaveText('⛔')
+    await expect(deleteBtn).toHaveText('❌')
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })
     await deleteBtn.click()
     await panel.hover()

--- a/tests/widgetSearch.spec.ts
+++ b/tests/widgetSearch.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures'
 import { routeServicesConfig } from './shared/mocking.js'
+import { ensurePanelOpen } from './shared/panels'
 
 
 test.describe('Widget search filter', () => {
@@ -11,19 +12,18 @@ test.describe('Widget search filter', () => {
 
   test('typing filters widget options', async ({ page }) => {
     const panel = page.locator('[data-testid="service-panel"]')
-    await panel.hover()
+    await ensurePanelOpen(page, 'service-panel')
     const options = panel.locator('.panel-item')
-    await expect(options).toHaveCount(5)
+    await expect(options).toHaveCount(4)
 
     await panel.locator('.panel-search').fill('terminal')
     await expect(panel.locator('.panel-item', { hasText: 'ASD-terminal' })).toBeVisible()
     await expect(panel.locator('.panel-item', { hasText: 'ASD-toolbox' })).toBeHidden()
-    await expect(page.locator('[data-testid="service-panel"] [data-testid="panel-actions-trigger"]').first()).toBeVisible()
   })
 
   test('search normalization handles case/diacritics/whitespace', async ({ page }) => {
     const panel = page.locator('[data-testid="service-panel"]')
-    await panel.hover()
+    await ensurePanelOpen(page, 'service-panel')
     const input = panel.locator('.panel-search')
     await input.fill('  TÉRMINAL  ')
     await expect(panel.locator('.panel-item', { hasText: 'ASD-terminal' })).toBeVisible()


### PR DESCRIPTION
## Summary
- add primary header CTA and quick-add (+) options to SelectorPanel
- show empty-state "No X yet" blocks with + CTA
- replace delete icon with ❌ and expose "Click to add/switch" label hints

- streamline SelectorPanel with compact top menu and per-row flyout actions
- update Service/Board/View controls for new menu semantics and emoji-based actions
- refresh Playwright tests with shared panel helpers and updated interactions