### PR TITLE
feat(storage): add metrics and migration guards

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,6 +32,7 @@ format:
 # Run static type checking
 check:
     bash -c "! rg 'import\\s+StorageManager\\s+from' -n src tests || (echo 'Default StorageManager import found'; exit 1)"
+    bash -c "! rg \"localStorage\\.getItem\\(['\\\"]asd\\.\" -n src | rg -v 'migration|adapters' || (echo 'Direct asd.* localStorage access found'; exit 1)"
     npm run check
 
 [private]


### PR DESCRIPTION
## Summary
- record persistent store metrics and quota on init
- add idempotent localStorage migration and cleanup
- guard CI against legacy localStorage access

## Testing
- `just symbols-extract` *(fails: Cannot find module '/workspace/asd-dashboard/scripts/just/scripts/extract-symbol-index.mjs')*
- `node scripts/extract-symbol-index.mjs`
- `just format check`
- `npm run test` *(fails: page.waitForSelector timeout for #widget-selector-panel.open)*

------
https://chatgpt.com/codex/tasks/task_b_68a78502a7e08325a833899a789a8206