### PR TITLE
Persist service template defaults and apply widget sizing

### DIFF
--- a/src/component/service/ServiceControl.js
+++ b/src/component/service/ServiceControl.js
@@ -126,7 +126,7 @@ export function mountServiceControl () {
       }
 
       // This code will now only run if the instance limit has not been reached
-      await addWidget(resolved.url, 1, 1, 'iframe', getCurrentBoardId(), getCurrentViewId())
+      await addWidget(resolved.url, undefined, undefined, 'iframe', getCurrentBoardId(), getCurrentViewId())
       emitStateChange('services')
       panel.refresh()
     },

--- a/src/types.js
+++ b/src/types.js
@@ -38,6 +38,8 @@
  * @property {number} [maxColumns]
  * @property {number} [minRows]
  * @property {number} [maxRows]
+ * @property {number} [columns]
+ * @property {number} [rows]
  */
 
 /**

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -135,6 +135,11 @@ export async function getConfig () {
   }
 
   StorageManager.setConfig(config)
+  // Re-resolve services against the newly loaded templates
+  const existingServices = StorageManager.getServices()
+  if (Array.isArray(existingServices) && existingServices.length) {
+    StorageManager.setServices(existingServices)
+  }
   logger.log('Config loaded successfully')
   return config
 }

--- a/tests/data/ciConfig.ts
+++ b/tests/data/ciConfig.ts
@@ -22,6 +22,17 @@ export const ciConfig = {
             "minRows": 1,
             "maxRows": 4
         }
+    },
+    "serviceTemplates": {
+        "default": {
+            "type": "iframe",
+            "maxInstances": 1,
+            "config": {}
+        },
+        "twoByTwo": {
+            "type": "iframe",
+            "config": { "columns": 2, "rows": 2 }
+        }
     }
 }
 

--- a/tests/data/ciServices.ts
+++ b/tests/data/ciServices.ts
@@ -1,4 +1,6 @@
-export const ciServices = [
+import type { Service } from '../../src/types.js'
+
+export const ciServices: Service[] = [
   {
     id: "toolbox",
     name: "ASD-toolbox",
@@ -50,5 +52,14 @@ export const ciServices = [
       minRows: 2,
       maxRows: 6,
     },
+  },
+  {
+    id: "templated",
+    name: "ASD-templated",
+    url: "http://localhost:8000/asd/templated",
+    type: "web",
+    template: "twoByTwo",
+    maxInstances: 20,
+    config: {},
   },
 ];

--- a/tests/shared/mocking.ts
+++ b/tests/shared/mocking.ts
@@ -43,5 +43,12 @@ export async function routeServicesConfig(page: Page) {
         body: JSON.stringify({ "name": "ASD-containers" })
     });
     });
+
+    await page.route('**/asd/templated', route => {
+    route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ "name": "ASD-templated" })
+    });
+    });
 }
 

--- a/tests/storage.spec.ts
+++ b/tests/storage.spec.ts
@@ -151,7 +151,7 @@ test.describe('StorageManager', () => {
       subcategory: '',
       tags: [],
       config: {},
-      maxInstances: null
+      maxInstances: 1
     })
     expect(services[1]).toEqual({
       id: 'srv-fixed',
@@ -161,7 +161,7 @@ test.describe('StorageManager', () => {
       category: 'c',
       subcategory: 'sc',
       tags: ['t'],
-      config: { x: 1 },
+      config: { minColumns: 1, maxColumns: 8, minRows: 1, maxRows: 6, x: 1 },
       maxInstances: 5
     })
   })

--- a/tests/widgetLimits.spec.ts
+++ b/tests/widgetLimits.spec.ts
@@ -31,7 +31,19 @@ test.describe("Widget limits", () => {
       {
         id: "b1",
         name: "B1",
-        views: [{ id: "v1", name: "V1", widgetState: [{ /* ... widget ... */ }] }],
+        views: [{
+          id: "v1",
+          name: "V1",
+          widgetState: [
+            {
+              order: "0",
+              url: "http://localhost:8000/asd/toolbox",
+              type: "web",
+              dataid: "W1",
+              serviceId: "toolbox"
+            }
+          ]
+        }],
       },
       {
         id: "b2",

--- a/tests/widgetSearch.spec.ts
+++ b/tests/widgetSearch.spec.ts
@@ -14,7 +14,7 @@ test.describe('Widget search filter', () => {
     const panel = page.locator('[data-testid="service-panel"]')
     await ensurePanelOpen(page, 'service-panel')
     const options = panel.locator('.panel-item')
-    await expect(options).toHaveCount(4)
+    await expect(options).toHaveCount(5)
 
     await panel.locator('.panel-search').fill('terminal')
     await expect(panel.locator('.panel-item', { hasText: 'ASD-terminal' })).toBeVisible()

--- a/tests/widgetSizing.spec.ts
+++ b/tests/widgetSizing.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+import { ensurePanelOpen } from './shared/panels'
+
+// Verify that widgets respect size defaults from their service template
+
+test.describe('Widget Sizing', () => {
+  test('should apply default dimensions from service template on creation', async ({ page }) => {
+    await routeServicesConfig(page)
+    await page.goto('/')
+    // Wait until service templates have been applied
+    await page.waitForFunction(async () => {
+      const StorageManager = (await import('/storage/StorageManager.js')).default
+      const svc = StorageManager.getServices().find(s => s.name === 'ASD-templated')
+      return svc?.config?.columns === 2 && svc?.config?.rows === 2
+    })
+    await ensurePanelOpen(page, 'service-panel')
+
+    await page.click('[data-testid="service-panel"] .panel-item:has-text("ASD-templated")')
+    const widget = page.locator('.widget-wrapper[data-service="ASD-templated"]')
+    await widget.waitFor()
+    await expect(widget).toHaveAttribute('data-columns', '2')
+    await expect(widget).toHaveAttribute('data-rows', '2')
+  })
+})


### PR DESCRIPTION
## Summary
- resolve service templates before persisting to storage
- default widget dimensions from service templates
- regression tests for service limits and template sizing

## Testing
- `just check`
- `just test`


------
https://chatgpt.com/codex/tasks/task_b_68a8c0afda448325a56eedecadef69ba