### PR TITLE
Reduce default expect timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   // Faster feedback and less spend minutes in Githun Actions
   timeout: 10000, // Timeout for each test (in milliseconds) default is 30000
   expect: {
-      timeout: 4000, // Timeout for `expect` assertions
+      timeout: 500, // Timeout for `expect` assertions
   },
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/symbols.json
+++ b/symbols.json
@@ -2026,7 +2026,7 @@
     "name": "setServices",
     "kind": "function",
     "file": "src/storage/StorageManager.js",
-    "description": "Persist the provided services array after normalizing each object.",
+    "description": "Persist the provided services array after resolving templates and normalizing.",
     "params": [
       {
         "name": "services",


### PR DESCRIPTION
## Summary
- Tighten Playwright `expect` timeout to 500 ms for faster feedback
- Regenerate symbol index to keep metadata in sync