### PR TITLE
feat(selector): add JS hover-intent with cancellable delay for action flyouts

### DIFF
--- a/src/component/panel/SelectorPanel.js
+++ b/src/component/panel/SelectorPanel.js
@@ -93,7 +93,7 @@ export class SelectorPanel {
     this.hoverIntent = installHoverIntent({
       root: this.dom.wrap,
       selector: '.panel-item, .menu-item',
-      delay: 250,
+      delay: 50,
       activeClass: 'hover-active'
     })
   }

--- a/src/component/panel/SelectorPanel.js
+++ b/src/component/panel/SelectorPanel.js
@@ -1,5 +1,6 @@
 // @ts-check
 import { emojiList } from '../../ui/unicodeEmoji.js'
+import { installHoverIntent } from './selector-hover-intent.js'
 /**
  * Generic selector panel with compact top menu and per-row flyout actions.
  *
@@ -89,6 +90,12 @@ export class SelectorPanel {
     this.render()
     this.bind()
     this.refresh()
+    this.hoverIntent = installHoverIntent({
+      root: this.dom.wrap,
+      selector: '.panel-item, .menu-item',
+      delay: 250,
+      activeClass: 'hover-active'
+    })
   }
 
   /** Render base DOM structure */

--- a/src/component/panel/selector-hover-intent.js
+++ b/src/component/panel/selector-hover-intent.js
@@ -1,0 +1,112 @@
+// @ts-check
+/* global Element */
+/**
+ * Apply hover intent to selector rows with cancellable delay.
+ * @module selector-hover-intent
+ */
+
+/**
+ * Install hover intent listeners on a root element to toggle an active class
+ * after a delay only when the pointer rests over a target item.
+ * @function installHoverIntent
+ * @param {object} [cfg]
+ * @param {Element} [cfg.root] - Root element hosting the items.
+ * @param {string} [cfg.selector] - CSS selector to match actionable rows.
+ * @param {number} [cfg.delay] - Milliseconds before the active class is applied.
+ * @param {string} [cfg.activeClass] - Class toggled to reveal actions in CSS.
+ * @returns {{dispose: () => void, rescan: () => void}}
+ */
+export function installHoverIntent (cfg = {}) {
+  const { root, selector = '.panel-item', delay = 250, activeClass = 'hover-active' } = cfg
+  if (!root || !(root instanceof Element)) {
+    throw new TypeError('installHoverIntent: "root" must be a DOM Element')
+  }
+
+  const STATE_SYM = Symbol.for('asd.selector.hoverIntent.state')
+  if (root[STATE_SYM]) return root[STATE_SYM].api
+
+  const timers = new WeakMap()
+  const active = new WeakSet()
+  const attached = new WeakSet()
+  let disposed = false
+
+  const onEnter = (el) => {
+    if (active.has(el) || timers.has(el)) return
+    const id = setTimeout(() => {
+      timers.delete(el)
+      if (disposed) return
+      el.classList.add(activeClass)
+      active.add(el)
+      el.setAttribute('data-hover-intent', 'true')
+    }, delay)
+    timers.set(el, id)
+  }
+
+  const clearTimer = (el) => {
+    const id = timers.get(el)
+    if (id != null) {
+      clearTimeout(id)
+      timers.delete(el)
+    }
+  }
+
+  const onLeave = (el) => {
+    clearTimer(el)
+    if (active.has(el)) {
+      el.classList.remove(activeClass)
+      active.delete(el)
+      el.removeAttribute('data-hover-intent')
+    }
+  }
+
+  const handleMouseOver = (e) => {
+    if (disposed) return
+    const el = e.target.closest(selector)
+    if (!el || !root.contains(el)) return
+    if (!attached.has(el)) attached.add(el)
+    onEnter(el)
+  }
+
+  const handleMouseOut = (e) => {
+    if (disposed) return
+    const el = e.target.closest(selector)
+    if (!el || !root.contains(el)) return
+    const to = /** @type {Element|null} */ (e.relatedTarget)
+    if (to && el.contains(to)) return
+    onLeave(el)
+  }
+
+  const handlePointerDown = (e) => {
+    const el = e.target.closest(selector)
+    if (el && root.contains(el)) clearTimer(el)
+  }
+
+  root.addEventListener('mouseover', handleMouseOver, true)
+  root.addEventListener('mouseout', handleMouseOut, true)
+  root.addEventListener('pointerdown', handlePointerDown, true)
+
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    root.removeEventListener('mouseover', handleMouseOver, true)
+    root.removeEventListener('mouseout', handleMouseOut, true)
+    root.removeEventListener('pointerdown', handlePointerDown, true)
+    root.querySelectorAll(selector).forEach((el) => {
+      clearTimer(el)
+      if (active.has(el)) {
+        el.classList.remove(activeClass)
+        el.removeAttribute('data-hover-intent')
+        active.delete(el)
+      }
+    })
+  }
+
+  const api = {
+    dispose,
+    rescan () {}
+  }
+
+  root[STATE_SYM] = { api }
+
+  return api
+}

--- a/src/component/panel/selector-panel.css
+++ b/src/component/panel/selector-panel.css
@@ -43,7 +43,7 @@
 /* Menu wrapper */
 .menu { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
 .menu-item { position: relative; padding: 6px 8px; border-radius: 4px; cursor: pointer; }
-.menu-item:hover { background: #f6f8fa; }
+.menu-item.hover-active { background: #f6f8fa; }
 .menu-item:focus { outline: 2px solid #2684ff; outline-offset: 2px; }
 
 /* --- PANEL LIST + ITEMS --- */
@@ -66,7 +66,7 @@
   border-radius: 4px;
   cursor: pointer;
 }
-.panel-item:hover { background: #f6f8fa; }
+.panel-item.hover-active { background: #f6f8fa; }
 .panel-item[hidden] { display: none !important; }
 
 .panel-item-label { font-weight: 400; text-decoration: none; }
@@ -76,7 +76,7 @@
 .panel-item-actions-placeholder { display: none !important; }
 
 /* Subtle affordance on hover/focus */
-.panel-item:hover .panel-item-label,
+.panel-item.hover-active .panel-item-label,
 .panel-item:focus-within .panel-item-label { text-decoration: underline; text-underline-offset: 2px; }
 
 /* -----------------------------------------------------------
@@ -112,9 +112,9 @@
 }
 
 /* Reveal on hover/focus: add the second row (panel-item context) */
-.panel-item:hover > .panel-item-hint,
+.panel-item.hover-active > .panel-item-hint,
 .panel-item:focus-within > .panel-item-hint { display: block; opacity: 1; }
-.panel-item:hover > .panel-item-actions-flyout,
+.panel-item.hover-active > .panel-item-actions-flyout,
 .panel-item:focus-within > .panel-item-actions-flyout { display: inline-flex; opacity: 1; }
 
 /* Icon-only buttons INSIDE panel items: bigger, borderless, no green */
@@ -149,7 +149,7 @@
 }
 
 /* Show both buttons on hover/focus of the menu row */
-.menu-item:hover .panel-item-actions-flyout,
+.menu-item.hover-active .panel-item-actions-flyout,
 .menu-item:focus-within .panel-item-actions-flyout {
   display: inline-flex;
   opacity: 1;

--- a/symbols.json
+++ b/symbols.json
@@ -1267,6 +1267,40 @@
     "returns": "void"
   },
   {
+    "name": "installHoverIntent",
+    "kind": "function",
+    "file": "src/component/panel/selector-hover-intent.js",
+    "description": "Install hover intent listeners on a root element to toggle an active class after a delay only when the pointer rests over a target item.",
+    "params": [
+      {
+        "name": "cfg",
+        "type": "object",
+        "desc": ""
+      },
+      {
+        "name": "cfg.root",
+        "type": "Element",
+        "desc": "- Root element hosting the items."
+      },
+      {
+        "name": "cfg.selector",
+        "type": "string",
+        "desc": "- CSS selector to match actionable rows."
+      },
+      {
+        "name": "cfg.delay",
+        "type": "number",
+        "desc": "- Milliseconds before the active class is applied."
+      },
+      {
+        "name": "cfg.activeClass",
+        "type": "string",
+        "desc": "- Class toggled to reveal actions in CSS."
+      }
+    ],
+    "returns": "{dispose: () => void, rescan: () => void}"
+  },
+  {
     "name": "isAdding",
     "kind": "function",
     "file": "src/component/widget/widgetStore.js",
@@ -2026,7 +2060,7 @@
     "name": "setServices",
     "kind": "function",
     "file": "src/storage/StorageManager.js",
-    "description": "Persist the provided services array after normalizing each object.",
+    "description": "Persist the provided services array after resolving templates and normalizing.",
     "params": [
       {
         "name": "services",

--- a/tests/shared/panels.ts
+++ b/tests/shared/panels.ts
@@ -16,5 +16,10 @@ export async function openCreateFromTopMenu (page: Page, panelTestId: 'service-p
   }
   const submenu = menu.locator('.menu-item').first()
   await submenu.hover()
-  await submenu.locator('.panel-item-actions-flyout button', { hasText: label }).first().click()
+  const actionBtn = submenu
+    .locator('.panel-item-actions-flyout button', { hasText: label })
+    .first()
+  await expect(actionBtn).toBeVisible()
+  await actionBtn.click()
+  await page.waitForTimeout(500)
 }


### PR DESCRIPTION
## Summary
- add `installHoverIntent` helper for delayed hover activation
- wire hover intent into `SelectorPanel` and switch CSS to `.hover-active`
- adjust tests to wait for delayed action flyouts