### PR TITLE
Stabilize V4 config Form: subtabs data integrity, default-adding, placeholders, and compact layout

### DIFF
--- a/src/component/modal/configModal.js
+++ b/src/component/modal/configModal.js
@@ -13,7 +13,7 @@ import { DEFAULT_CONFIG_TEMPLATE } from '../../storage/defaultConfig.js'
 import { exportConfig } from '../configModal/exportConfig.js'
 import { openFragmentDecisionModal } from './fragmentDecisionModal.js'
 import { JsonForm } from '../utils/json-form.js'
-import { JSON_FORM_ARRAY_DEFAULTS, JSON_FORM_TEMPLATES, JSON_FORM_PLACEHOLDERS } from '../utils/json-form-defaults.js'
+import { DEFAULT_TEMPLATES, DEFAULT_PLACEHOLDERS } from '../utils/json-form-defaults.js'
 
 /** @typedef {import('../../types.js').DashboardConfig} DashboardConfig */
 
@@ -45,16 +45,15 @@ export async function openConfigModal () {
 
             const toggle = document.createElement('button')
             toggle.textContent = 'JSON mode'
-            toggle.classList.add('modal__btn', 'modal__btn--toggle')
+            toggle.classList.add('modal__btn', 'modal__btn--toggle', 'modal__toggle')
 
             const formDiv = document.createElement('div')
             formDiv.id = 'config-form'
             formDiv.classList.add('modal__jsonform')
             cfgForm = new JsonForm(formDiv, configData, {
               topLevelTabs: { enabled: true, order: ['globalSettings', 'boards', 'serviceTemplates', 'styling'] },
-              templates: JSON_FORM_TEMPLATES,
-              placeholders: JSON_FORM_PLACEHOLDERS,
-              defaultResolver: (_parent, key) => JSON_FORM_ARRAY_DEFAULTS[key]
+              templates: DEFAULT_TEMPLATES,
+              placeholders: DEFAULT_PLACEHOLDERS
             })
 
             const textarea = document.createElement('textarea')
@@ -95,13 +94,15 @@ export async function openConfigModal () {
 
             const toggle = document.createElement('button')
             toggle.textContent = 'JSON mode'
-            toggle.classList.add('modal__btn', 'modal__btn--toggle')
+            toggle.classList.add('modal__btn', 'modal__btn--toggle', 'modal__toggle')
 
             const formDiv = document.createElement('div')
             formDiv.id = 'services-form'
             formDiv.classList.add('modal__jsonform', 'modal__textarea--grow')
             svcForm = new JsonForm(formDiv, StorageManager.getServices(), {
-              defaultResolver: (_parent, key) => JSON_FORM_ARRAY_DEFAULTS[key || 'services']
+              templates: DEFAULT_TEMPLATES,
+              placeholders: DEFAULT_PLACEHOLDERS,
+              rootPath: 'services'
             })
 
             const textarea = document.createElement('textarea')

--- a/src/component/utils/json-form-defaults.js
+++ b/src/component/utils/json-form-defaults.js
@@ -1,44 +1,15 @@
 // @ts-check
 /**
- * Default templates for arrays handled by JsonForm.
+ * Central defaults and placeholders for JsonForm.
  *
  * @module json-form-defaults
  */
 
-export const JSON_FORM_ARRAY_DEFAULTS = {
-  boards: { id: '', name: '', views: [] },
-  views: { id: '', name: '', widgetState: [] },
-  widgetState: {
-    dataid: '',
-    serviceId: '',
-    url: '',
-    columns: 1,
-    rows: 1,
-    type: '',
-    order: '',
-    metadata: {},
-    settings: {}
-  },
-  tags: '',
-  services: {
-    id: '',
-    name: 'Unnamed Service',
-    url: '',
-    type: 'iframe',
-    category: '',
-    subcategory: '',
-    tags: [],
-    config: {},
-    maxInstances: null,
-    template: undefined,
-    fallback: undefined
-  }
-}
-
 /**
- * Default templates for nested config arrays keyed by path patterns.
+ * Templates mapped by dotted path patterns. Patterns may use `[]` to match
+ * any array index.
  */
-export const JSON_FORM_TEMPLATES = {
+export const DEFAULT_TEMPLATES = {
   'boards[]': { id: '', name: '', order: 0, views: [] },
   'boards[].views[]': { id: '', name: '', widgetState: [] },
   'boards[].views[].widgetState[]': {
@@ -52,7 +23,20 @@ export const JSON_FORM_TEMPLATES = {
     metadata: {},
     settings: {}
   },
-  serviceTemplates: {},
+  'services[]': {
+    id: '',
+    name: 'Unnamed Service',
+    url: '',
+    type: 'iframe',
+    category: '',
+    subcategory: '',
+    tags: [],
+    config: {},
+    maxInstances: null,
+    template: undefined,
+    fallback: undefined
+  },
+  'services[].tags[]': '',
   'serviceTemplates.default': {
     type: 'iframe',
     maxInstances: 10,
@@ -63,7 +47,7 @@ export const JSON_FORM_TEMPLATES = {
 /**
  * Placeholder texts mapped by path patterns.
  */
-export const JSON_FORM_PLACEHOLDERS = {
+export const DEFAULT_PLACEHOLDERS = {
   'globalSettings.widgetStoreUrl[]': 'https://…',
   'boards[].views[].widgetState[].url': 'https://…',
   'boards[].views[].widgetState[].type': 'iframe'

--- a/src/component/utils/match-pattern.js
+++ b/src/component/utils/match-pattern.js
@@ -1,0 +1,32 @@
+// @ts-check
+/**
+ * Resolve dotted/array paths against pattern maps.
+ *
+ * @module match-pattern
+ */
+
+/**
+ * Find the most specific match for a path in a pattern object.
+ *
+ * Patterns may include `[]` to match any array index.
+ *
+ * @param {string} path
+ * @param {Record<string, any>} patterns
+ * @returns {{kind:'template'|'placeholder', value:any}|undefined}
+ */
+export function matchPattern (path, patterns) {
+  if (!patterns) return undefined
+  let best
+  for (const [pattern, value] of Object.entries(patterns)) {
+    const regex = new RegExp('^' + pattern.replace(/\[\]/g, '\\[\\d+\\]').replace(/\./g, '\\.') + '$')
+    if (regex.test(path)) {
+      if (!best || pattern.length > best.pattern.length) {
+        best = { pattern, value }
+      }
+    }
+  }
+  if (!best) return undefined
+  const val = best.value
+  const kind = typeof val === 'string' ? 'placeholder' : 'template'
+  return { kind, value: typeof val === 'object' ? structuredClone(val) : val }
+}

--- a/src/ui/modalJsonUI.css
+++ b/src/ui/modalJsonUI.css
@@ -143,17 +143,21 @@
 }
 
 /* Subtabs inside JsonForm */
-.jf-subtabs {
+.modal .jf-subtabs {
   display: flex;
   gap: 0.25rem;
   margin: 0.25rem 0 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #fff;
 }
-.jf-subtabs button {
+.modal .jf-subtabs button {
   padding: 0.35rem 0.5rem;
   border: 1px solid #d0d0d0;
   background: #f2f2f2;
 }
-.jf-subtabs button.active {
+.modal .jf-subtabs button.active {
   background: #e7e7e7;
   font-weight: 600;
 }

--- a/tests/configArrayDefaults.spec.ts
+++ b/tests/configArrayDefaults.spec.ts
@@ -20,7 +20,6 @@ test.describe('config array defaults', () => {
     await page.click('#cfgTab .modal__btn--toggle')
 
     // add board, view and widget
-    await page.click('#config-form .jf-subtabs button:has-text("boards")')
     await page.click('#config-form .jf-array > button:has-text("+")')
     await page.click('#config-form label:has-text("views") + .jf-array > button:has-text("+")')
     await page.click('#config-form label:has-text("widgetState") + .jf-array > button:has-text("+")')

--- a/tests/configConsistency.spec.ts
+++ b/tests/configConsistency.spec.ts
@@ -30,6 +30,7 @@ test.describe('config consistency', () => {
     await page.click('#config-modal .modal__btn--cancel')
     const stored = await getUnwrappedConfig(page)
     expect(stored.boards).toEqual(cfg.boards)
+    expect(typeof stored.boards[0].order).toBe('number')
   })
 
   test('saving config without boards removes boards storage', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Centralize JsonForm templates and placeholders and add matchPattern helper
- Rework JsonForm for path-aware updates, type coercion, default-only array adds, and legacy selector aliases
- Wire config modal to new defaults, tighten subtab CSS, and adjust tests for new behavior

## Testing
- `just test`