### PR TITLE
Handle StorageManager init failure

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -51,7 +51,12 @@ window.addEventListener('hashchange', () => loadFromFragment(false))
 async function main () {
   logger.log('Application initialization started')
 
-  await StorageManager.init({ persist: true })
+  try {
+    await StorageManager.init({ persist: true })
+  } catch (err) {
+    console.error('Failed to initialize StorageManager', err)
+    throw err
+  }
 
   // 1. Handle configuration from URL fragment first
   const params = new URLSearchParams(location.search)


### PR DESCRIPTION
## Summary
- guard StorageManager initialization in main entrypoint with try/catch
- log StorageManager init failures to console.error and rethrow to surface

## Testing
- `just format check`
- `npm run test` *(fails: TypeError: Cannot read properties of undefined (reading 'set'))*