### PR TITLE
fix: safeguard StorageManager before init

### DIFF
--- a/src/storage/driver.js
+++ b/src/storage/driver.js
@@ -13,6 +13,7 @@ import { lsKV } from './adapters/lsKV.js'
  * @property {(store:string,key:string,val:any)=>Promise<void>} set
  * @property {(store:string,key:string)=>Promise<void>} del
  * @property {(store:string)=>Promise<void>} clear
+ * @property {(store:string)=>Promise<Array<any>>} keys
  */
 
 /**


### PR DESCRIPTION
## Summary
- initialize StorageManager with a safe localStorage-backed driver
- ensure key-value API supports `keys` lookup for cache warming

## Testing
- `npm run test -- tests/addManageWidgets.spec.ts`
- `npm run test -- tests/dynamicConfig.spec.ts` *(fails: Dashboard Config tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a9ef807b688325bacf4e29c8287c93