### PR TITLE
fix: stabilize panel creation interactions

### DIFF
--- a/tests/boardPanel.spec.ts
+++ b/tests/boardPanel.spec.ts
@@ -60,6 +60,7 @@ test.describe('Board panel', () => {
     page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(renamed) })
     await renameBtn.click()
     const rowRenamed = panel.locator('.panel-item', { hasText: renamed })
+    await expect(rowRenamed).toBeVisible()
     await rowRenamed.hover()
     const deleteBtn = rowRenamed.locator('[data-item-action="delete"]').first()
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })

--- a/tests/shared/panels.ts
+++ b/tests/shared/panels.ts
@@ -9,16 +9,15 @@ export async function ensurePanelOpen (page: Page, panelTestId: string) {
 export async function openCreateFromTopMenu (page: Page, panelTestId: 'service-panel' | 'board-panel' | 'view-panel', label: string) {
   await ensurePanelOpen(page, panelTestId)
   const menu = page.locator(`[data-testid="${panelTestId}"] .menu`)
-  const direct = menu.locator('.menu-item', { hasText: label }).first()
-  if (await direct.count()) {
-    await direct.click()
+  // Target specific action buttons to avoid misfiring on wrapper rows
+  const directBtn = menu.locator('[data-menu-action]', { hasText: label }).first()
+  if (await directBtn.count() && await directBtn.isVisible()) {
+    await directBtn.click()
     return
   }
   const submenu = menu.locator('.menu-item').first()
   await submenu.hover()
-  const actionBtn = submenu
-    .locator('.panel-item-actions-flyout button', { hasText: label })
-    .first()
+  const actionBtn = submenu.locator('[data-menu-action]', { hasText: label }).first()
   await expect(actionBtn).toBeVisible()
   await actionBtn.click()
 }

--- a/tests/viewPanel.spec.ts
+++ b/tests/viewPanel.spec.ts
@@ -60,6 +60,7 @@ test.describe('View panel', () => {
     page.once('dialog', async d => { expect(d.type()).toBe('prompt'); await d.accept(renamed) })
     await renameBtn.click()
     const rowRenamed = panel.locator('.panel-item', { hasText: renamed })
+    await expect(rowRenamed).toBeVisible()
     await rowRenamed.hover()
     const deleteBtn = rowRenamed.locator('[data-item-action="delete"]').first()
     page.once('dialog', async d => { expect(d.type()).toBe('confirm'); await d.accept() })


### PR DESCRIPTION
## Summary
- target action buttons directly in test helper to avoid misfiring clicks
- wait for renamed panel rows before subsequent actions

## Testing
- `just format`
- `just check`
- `just test` *(fails: boardPanel.spec.ts:49, viewPanel.spec.ts:49, viewStateIsolation.spec.ts:44)*

------
https://chatgpt.com/codex/tasks/task_b_68aa42bfefc483259df681c364d14ffa