### PR TITLE
feat(ui): add Advanced mode toggle and conditional Config tabs/subtabs

### DIFF
--- a/src/state/uiState.js
+++ b/src/state/uiState.js
@@ -1,0 +1,79 @@
+// @ts-check
+/**
+ * Global UI state flags and helpers.
+ *
+ * @module uiState
+ */
+
+/** @typedef {{jsonMode:boolean, advancedMode:boolean}} UIState */
+
+const state = {
+  jsonMode: false,
+  advancedMode: false
+}
+
+/**
+ * Get current JSON mode flag.
+ *
+ * @returns {boolean}
+ */
+export function isJsonMode () {
+  return state.jsonMode
+}
+
+/**
+ * Set JSON mode flag and notify listeners.
+ *
+ * @param {boolean} value
+ * @returns {void}
+ */
+export function setJsonMode (value) {
+  if (state.jsonMode === value) return
+  state.jsonMode = value
+  document.dispatchEvent(new CustomEvent('ui:json-mode', { detail: value }))
+}
+
+/**
+ * Subscribe to JSON mode changes.
+ *
+ * @param {(value:boolean)=>void} handler
+ * @returns {void}
+ */
+export function onJsonModeChange (handler) {
+  document.addEventListener('ui:json-mode', e => {
+    handler((/** @type {CustomEvent<boolean>} */(e)).detail)
+  })
+}
+
+/**
+ * Get current advanced mode flag.
+ *
+ * @returns {boolean}
+ */
+export function isAdvancedMode () {
+  return state.advancedMode
+}
+
+/**
+ * Set advanced mode flag and notify listeners.
+ *
+ * @param {boolean} value
+ * @returns {void}
+ */
+export function setAdvancedMode (value) {
+  if (state.advancedMode === value) return
+  state.advancedMode = value
+  document.dispatchEvent(new CustomEvent('ui:advanced-mode', { detail: value }))
+}
+
+/**
+ * Subscribe to advanced mode changes.
+ *
+ * @param {(value:boolean)=>void} handler
+ * @returns {void}
+ */
+export function onAdvancedModeChange (handler) {
+  document.addEventListener('ui:advanced-mode', e => {
+    handler((/** @type {CustomEvent<boolean>} */(e)).detail)
+  })
+}

--- a/tests/advancedMode.spec.ts
+++ b/tests/advancedMode.spec.ts
@@ -1,0 +1,44 @@
+// @ts-check
+import { test, expect } from './fixtures'
+import { routeServicesConfig } from './shared/mocking'
+import { navigate } from './shared/common'
+import { openConfigModalSafe } from './shared/uiHelpers'
+
+test.describe('advanced mode toggle', () => {
+  test.beforeEach(async ({ page }) => {
+    await routeServicesConfig(page)
+    await navigate(page, '/')
+  })
+
+  test('toggles tabs and subtabs', async ({ page }) => {
+    await openConfigModalSafe(page)
+
+    const tabs = page.locator('#config-modal .tabs button')
+    await expect(tabs).toHaveText(['Configuration', 'Saved States'])
+
+    await page.locator('#config-modal button[data-tab="cfgTab"]').click()
+    let subtabs = page.locator('#config-form .jf-subtabs button')
+    await expect(subtabs).toHaveText(['globalSettings', 'serviceTemplates'])
+
+    await page.locator('[data-testid="advanced-mode-toggle"]').check()
+    await page.locator('#config-modal').waitFor({ state: 'visible' })
+
+    const tabsAdv = page.locator('#config-modal .tabs button')
+    await expect(tabsAdv).toHaveText(['Configuration', 'Services', 'Saved States'])
+
+    await page.locator('#config-modal button[data-tab="cfgTab"]').click()
+    subtabs = page.locator('#config-form .jf-subtabs button')
+    await expect(subtabs).toHaveText(['globalSettings', 'boards', 'serviceTemplates', 'styling'])
+
+    await page.locator('[data-testid="advanced-mode-toggle"]').uncheck()
+    await page.locator('#config-modal').waitFor({ state: 'visible' })
+
+    const tabsBack = page.locator('#config-modal .tabs button')
+    await expect(tabsBack).toHaveText(['Configuration', 'Saved States'])
+
+    await page.locator('#config-modal button[data-tab="cfgTab"]').click()
+    subtabs = page.locator('#config-form .jf-subtabs button')
+    await expect(subtabs).toHaveText(['globalSettings', 'serviceTemplates'])
+  })
+})
+

--- a/tests/configArrayDefaults.spec.ts
+++ b/tests/configArrayDefaults.spec.ts
@@ -11,6 +11,8 @@ test.describe('config array defaults', () => {
 
   test('boards, views and widgets get full defaults when added', async ({ page }) => {
     await page.click('#open-config-modal')
+    await page.locator('[data-testid="advanced-mode-toggle"]').check()
+    await page.locator('#config-modal').waitFor({ state: 'visible' })
     // set config to only have empty boards array
     await page.click('#cfgTab .modal__btn--toggle')
     const cfgTextarea = page.locator('#config-json')
@@ -32,6 +34,8 @@ test.describe('config array defaults', () => {
 
   test('services and tags use defaults and duplicate existing entries', async ({ page }) => {
     await page.click('#open-config-modal')
+    await page.locator('[data-testid="advanced-mode-toggle"]').check()
+    await page.locator('#config-modal').waitFor({ state: 'visible' })
     await page.click('#config-modal .tabs button:has-text("Services")')
 
     // start with empty services array

--- a/tests/configSubtabs.spec.ts
+++ b/tests/configSubtabs.spec.ts
@@ -11,6 +11,8 @@ test.describe('config subtabs', () => {
 
   test('subtabs render and preserve edits', async ({ page }) => {
     await page.click('#open-config-modal')
+    await page.locator('[data-testid="advanced-mode-toggle"]').check()
+    await page.locator('#config-modal').waitFor({ state: 'visible' })
     await expect(page.locator('#config-form .jf-subtabs button:has-text("globalSettings")')).toBeVisible()
     await expect(page.locator('#config-form .jf-subtabs button:has-text("boards")')).toBeVisible()
     const themeInput = page.locator('#config-form label:has-text("theme") + input')
@@ -23,6 +25,8 @@ test.describe('config subtabs', () => {
 
   test('add creates empty widget with placeholders', async ({ page }) => {
     await page.click('#open-config-modal')
+    await page.locator('[data-testid="advanced-mode-toggle"]').check()
+    await page.locator('#config-modal').waitFor({ state: 'visible' })
     await page.click('#config-form .jf-subtabs button:has-text("boards")')
     await page.click('#config-form .jf-array > button:has-text("+")')
     await page.click('#config-form label:has-text("views") + .jf-array > button:has-text("+")')

--- a/tests/dynamicConfig.spec.ts
+++ b/tests/dynamicConfig.spec.ts
@@ -170,6 +170,8 @@ test.describe("Dashboard Config - LocalStorage Behavior", () => {
 
     // Open and verify modal is visible
     await page.click("#open-config-modal");
+    await page.locator('[data-testid="advanced-mode-toggle"]').check();
+    await page.locator('#config-modal').waitFor({ state: 'visible' });
     await expect(page.locator("#config-modal")).toBeVisible();
 
     await page.click('button:has-text("JSON mode")');

--- a/tests/stateTab.spec.ts
+++ b/tests/stateTab.spec.ts
@@ -3,6 +3,7 @@ import { ciConfig } from './data/ciConfig'
 import { ciServices } from './data/ciServices'
 import { getBoardCount, navigate } from './shared/common.js'
 import { injectSnapshot } from './shared/state.js'
+import { openConfigModalSafe } from './shared/uiHelpers'
 
 test.describe('Saved States tab', () => {
   test.beforeEach(async ({ page }) => {
@@ -18,7 +19,7 @@ test.describe('Saved States tab', () => {
 
   test('restore and delete snapshot', async ({ page }) => {
     await page.reload()
-    await page.click('#open-config-modal')
+    await openConfigModalSafe(page)
 
     await page.click('.tabs button[data-tab="stateTab"]')
     await expect(page.locator('#stateTab tbody tr')).toHaveCount(2)
@@ -37,15 +38,15 @@ test.describe('Saved States tab', () => {
     const boards = await getBoardCount(page);
     expect(boards).toBeGreaterThan(0)
 
-    await page.click('#open-config-modal')
+      await openConfigModalSafe(page)
     await page.click('.tabs button[data-tab="stateTab"]')
     page.on('dialog', d => d.accept())
-    await page.locator('#stateTab tbody tr:nth-child(2) button:has-text("Delete")').click()
+    await page.locator('#stateTab tbody tr button:has-text("Delete")').last().click()
     await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
 
-    await page.reload()
-    
-    await page.click('#open-config-modal')
+    await navigate(page, '/')
+    await page.waitForSelector('#open-config-modal')
+    await openConfigModalSafe(page)
     await page.click('.tabs button[data-tab="stateTab"]')
     await expect(page.locator('#stateTab tbody tr')).toHaveCount(1)
   })


### PR DESCRIPTION
## Summary
- add UI state store for `advancedMode`
- expose Advanced mode switch in Config modal
- gate Config and subtab visibility based on Advanced mode
- cover Advanced mode behaviour with Playwright