### PR TITLE
fix(eviction): ensure cancel doesn't navigate; evictions runtime-only

### DIFF
--- a/src/component/board/boardManagement.js
+++ b/src/component/board/boardManagement.js
@@ -130,31 +130,38 @@ export async function switchView (boardId = getCurrentBoardId(), viewId) {
   }
 
   const board = StorageManager.getBoards().find(b => b.id === boardId)
-  const view = board?.views.find(v => v.id === viewId)
-  if (!view) return logger.warn(`Invalid view ${viewId} on board ${boardId}`)
+  if (!board) return
+  const view = board.views.find(v => v.id === viewId)
+  if (!view) return
 
-  document.querySelector('.board-view').id = viewId
+  logger.log('switchView', { boardId, viewId })
 
+  // CAPACITY CHECK *BEFORE* instantiating any missing widgets or hiding current ones.
+  const missing = view.widgetState.filter(w => !widgetStore.has(w.dataid))
+  const proceed = await widgetStore.confirmCapacity(missing.length)
+  if (!proceed) return // user cancelled eviction; do not navigate or mutate storage
+
+  // Now safe to switch the DOM id for the view
+  const boardViewEl = document.querySelector('.board-view')
+  if (boardViewEl) boardViewEl.id = viewId
+
+  // Hide widgets not in target view (runtime only)
   const activeIds = new Set(view.widgetState.map(w => w.dataid))
-
   for (const id of widgetStore.widgets.keys()) {
     if (!activeIds.has(id)) {
       widgetStore.hide(id)
     }
   }
 
-  const missing = view.widgetState.filter(w => !widgetStore.has(w.dataid))
-  const proceed = await widgetStore.confirmCapacity(missing.length)
-  if (!proceed) return
-
+  // Show existing and create missing (skip capacity inside addWidget since we already confirmed)
   for (const widget of view.widgetState) {
     if (widgetStore.has(widget.dataid)) {
       widgetStore.show(widget.dataid)
     } else {
       await addWidget(
         widget.url,
-        Number(widget.columns),
-        Number(widget.rows),
+        widget.columns != null ? Number(widget.columns) : undefined,
+        widget.rows != null ? Number(widget.rows) : undefined,
         widget.type,
         boardId,
         viewId,
@@ -164,6 +171,7 @@ export async function switchView (boardId = getCurrentBoardId(), viewId) {
     }
   }
 
+  // Persist current view selection (metadata-only)
   StorageManager.misc.setLastViewId(viewId)
 }
 

--- a/symbols.json
+++ b/symbols.json
@@ -103,6 +103,11 @@
         "name": "dataid",
         "type": "string|null",
         "desc": "- An optional persistent identifier for the widget."
+      },
+      {
+        "name": "opts",
+        "type": "{skipCapacity?:boolean}",
+        "desc": "- Optional flags."
       }
     ],
     "returns": "Promise<void>"

--- a/tests/eviction-cancel-and-runtime-only.spec.ts
+++ b/tests/eviction-cancel-and-runtime-only.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from './fixtures';
+import { ciConfig } from './data/ciConfig';
+import { ciServices } from './data/ciServices';
+
+async function routeLimits(page, boards, services, maxSize = 2, configOverrides = {}) {
+  await page.route('**/services.json', (route) => route.fulfill({ json: services }));
+  await page.route('**/config.json', (route) =>
+    route.fulfill({ json: { ...ciConfig, ...configOverrides, boards } }),
+  );
+  await page.addInitScript((size) => {
+    const apply = () => {
+      if (window.asd?.widgetStore) {
+        window.asd.widgetStore.maxSize = size;
+      } else {
+        setTimeout(apply, 0);
+      }
+    };
+    apply();
+  }, maxSize);
+}
+
+test.describe('Eviction cancel & runtime-only behavior', () => {
+  test('Cancel: stays on current view and storage is unchanged', async ({ page }) => {
+    const boards = [
+      {
+        id: 'b',
+        name: 'B',
+        order: 0,
+        views: [
+          {
+            id: 'v1',
+            name: 'V1',
+            widgetState: [
+              { order: '0', url: 'http://localhost:8000/asd/toolbox',   type: 'web', dataid: 'W1', serviceId: 'toolbox' },
+              { order: '1', url: 'http://localhost:8000/asd/terminal',  type: 'web', dataid: 'W2', serviceId: 'terminal' },
+              { order: '2', url: 'http://localhost:8000/asd/tunnel',    type: 'web', dataid: 'W3', serviceId: 'tunnel' }
+            ]
+          },
+          {
+            id: 'v2',
+            name: 'V2',
+            widgetState: [
+              { order: '0', url: 'http://localhost:8000/asd/toolbox',   type: 'web', dataid: 'W1', serviceId: 'toolbox' },
+              { order: '1', url: 'http://localhost:8000/asd/terminal',  type: 'web', dataid: 'W2', serviceId: 'terminal' },
+              { order: '2', url: 'http://localhost:8000/asd/containers',type: 'web', dataid: 'W4', serviceId: 'containers' }
+            ]
+          }
+        ]
+      }
+    ];
+
+    // Boot with small capacity so switching to v2 would require eviction
+    await routeLimits(page, boards, ciServices, 3, {
+      globalSettings: {
+        ...ciConfig.globalSettings,
+        localStorage: {
+          ...ciConfig.globalSettings.localStorage,
+          defaultBoard: 'b',
+          defaultView: 'v1',
+          loadDashboardFromConfig: 'true'
+        }
+      }
+    });
+
+    await page.goto('/');
+    await page.locator('.widget-wrapper').nth(2).waitFor();
+
+    // Snapshot storage before
+    const before = await page.evaluate(async () => {
+      const StorageManager = (await import('/storage/StorageManager.js')).default;
+      return StorageManager.getBoards();
+    });
+
+    // Attempt to switch; cancel eviction
+    await page.evaluate(async () => {
+      const { switchView } = await import('/component/board/boardManagement.js');
+      // Kick off, then cancel via UI
+      setTimeout(() => {
+        const btn = document.querySelector('#eviction-modal .modal__btn--cancel');
+        if (btn) (btn as HTMLButtonElement).click();
+      }, 50);
+      await switchView('b', 'v2');
+    });
+
+    // We should remain on v1 DOM-wise (all original W1..W3 still present)
+    const currentIds = await page.$$eval('.widget-wrapper', els => els.map(e => e.getAttribute('data-dataid')).filter(Boolean));
+    expect(currentIds.sort()).toEqual(['W1', 'W2', 'W3'].sort());
+
+    // Storage must be unchanged
+    const after = await page.evaluate(async () => {
+      const StorageManager = (await import('/storage/StorageManager.js')).default;
+      return StorageManager.getBoards();
+    });
+    expect(after).toEqual(before);
+  });
+
+  test('Runtime-only eviction: view storage (widgetState) is not mutated', async ({ page }) => {
+    const boards = [
+      {
+        id: 'b',
+        name: 'B',
+        order: 0,
+        views: [
+          {
+            id: 'v1',
+            name: 'V1',
+            widgetState: [
+              { order: '0', url: 'http://localhost:8000/asd/toolbox',   type: 'web', dataid: 'W1', serviceId: 'toolbox' },
+              { order: '1', url: 'http://localhost:8000/asd/terminal',  type: 'web', dataid: 'W2', serviceId: 'terminal' },
+              { order: '2', url: 'http://localhost:8000/asd/tunnel',    type: 'web', dataid: 'W3', serviceId: 'tunnel' }
+            ]
+          },
+          {
+            id: 'v2',
+            name: 'V2',
+            widgetState: [
+              { order: '0', url: 'http://localhost:8000/asd/toolbox',   type: 'web', dataid: 'W1', serviceId: 'toolbox' },
+              { order: '1', url: 'http://localhost:8000/asd/terminal',  type: 'web', dataid: 'W2', serviceId: 'terminal' },
+              { order: '2', url: 'http://localhost:8000/asd/containers',type: 'web', dataid: 'W4', serviceId: 'containers' }
+            ]
+          }
+        ]
+      }
+    ];
+
+    await routeLimits(page, boards, ciServices, 3, {
+      globalSettings: {
+        ...ciConfig.globalSettings,
+        localStorage: {
+          ...ciConfig.globalSettings.localStorage,
+          defaultBoard: 'b',
+          defaultView: 'v1',
+          loadDashboardFromConfig: 'true'
+        }
+      }
+    });
+
+    await page.goto('/');
+    await page.locator('.widget-wrapper').nth(2).waitFor();
+
+    // Switch to v2; confirm eviction (auto LRU)
+    await page.evaluate(async () => {
+      const { switchView } = await import('/component/board/boardManagement.js');
+      setTimeout(() => {
+        const auto = document.querySelector('#eviction-modal #evict-lru-btn') as HTMLButtonElement | null;
+        if (auto) auto.click(); // one-shot auto-select + commit
+      }, 50);
+      await switchView('b', 'v2');
+    });
+
+    // New DOM should reflect v2 widgets
+    const currentIds = await page.$$eval('.widget-wrapper', els => els.map(e => e.getAttribute('data-dataid')).filter(Boolean));
+    expect(currentIds.sort()).toEqual(['W1', 'W2', 'W4'].sort());
+
+    // BUT storage definitions for both views must remain as originally configured
+    const stored = await page.evaluate(async () => {
+      const StorageManager = (await import('/storage/StorageManager.js')).default;
+      return StorageManager.getBoards();
+    });
+    expect(stored[0].views.find(v => v.id === 'v1')!.widgetState.map(w => w.dataid).sort()).toEqual(['W1','W2','W3'].sort());
+    expect(stored[0].views.find(v => v.id === 'v2')!.widgetState.map(w => w.dataid).sort()).toEqual(['W1','W2','W4'].sort());
+  });
+});
+


### PR DESCRIPTION
## Summary
- add evictRuntimeOnly to widgetStore and ensure confirmCapacity uses non-destructive evictions
- guard switchView so canceling eviction leaves current view and storage intact
- test cancel behavior and runtime-only eviction storage invariants

## Testing
- `npx playwright test -g "Eviction cancel & runtime-only behavior"`


------
https://chatgpt.com/codex/tasks/task_b_68afa2a911d483259dd8c6c46e840f6f