### PR TITLE
ci: migrate to asd-engineering/artifact-nas@v1.4.1

### DIFF
--- a/.github/workflows/justfile-comment-runner.yml
+++ b/.github/workflows/justfile-comment-runner.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   run_justfile_commands:
     if: startsWith(github.event.comment.body, '/run')
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/linting-checks.yml
+++ b/.github/workflows/linting-checks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint_and_typecheck:
     name: linting-and-typecheck
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'ubuntu-latest' }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   check-changes:
     name: Check for changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'ubuntu-latest' }}
     outputs:
       should_deploy: ${{ steps.check.outputs.should_deploy }}
     steps:
@@ -46,7 +46,7 @@ jobs:
     name: Deploy to nightly repo
     needs: check-changes
     if: needs.check-changes.outputs.should_deploy == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout develop
         uses: actions/checkout@v4

--- a/.github/workflows/playwright-core.yml
+++ b/.github/workflows/playwright-core.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Restore Playwright browsers cache
       id: playwright-cache
-      uses: asd-engineering/artifact-nas/download@v1.4.2
+      uses: asd-engineering/artifact-nas/download@v1.4.3
       with:
         mode: cache
         name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -42,7 +42,7 @@ jobs:
 
     - name: Save Playwright browsers cache
       if: always()
-      uses: asd-engineering/artifact-nas/upload@v1.4.2
+      uses: asd-engineering/artifact-nas/upload@v1.4.3
       with:
         mode: cache
         name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
 
     - name: Upload Playwright report
       if: always()
-      uses: asd-engineering/artifact-nas/upload@v1.4.2
+      uses: asd-engineering/artifact-nas/upload@v1.4.3
       with:
         mode: nas-first
         name: playwright-report

--- a/.github/workflows/playwright-core.yml
+++ b/.github/workflows/playwright-core.yml
@@ -57,7 +57,7 @@ jobs:
       if: always()
       uses: asd-engineering/artifact-nas/upload@v1.4.1
       with:
-        mode: fallback
+        mode: nas-first
         name: playwright-report
         path: |
           playwright-report/

--- a/.github/workflows/playwright-core.yml
+++ b/.github/workflows/playwright-core.yml
@@ -13,6 +13,10 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
       cancel-in-progress: ${{ github.ref_name != 'main' }}
 
+    env:
+      RCLONE_CONF_B64: ${{ secrets.RCLONE_CONF_B64 }}
+      NAS_DEST: ${{ secrets.NAS_DEST }}
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -25,17 +29,24 @@ jobs:
 
     - name: Restore Playwright browsers cache
       id: playwright-cache
-      uses: actions/cache@v4
+      uses: asd-engineering/artifact-nas/download@v1.4.1
       with:
+        mode: cache
+        name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
         path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
 
     - name: Install deps & browsers
       run: |
         npm ci
         npx playwright install --with-deps
+
+    - name: Save Playwright browsers cache
+      if: always()
+      uses: asd-engineering/artifact-nas/upload@v1.4.1
+      with:
+        mode: cache
+        name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+        path: ~/.cache/ms-playwright
 
     - name: Run Playwright tests
       env:
@@ -44,8 +55,9 @@ jobs:
 
     - name: Upload Playwright report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: asd-engineering/artifact-nas/upload@v1.4.1
       with:
+        mode: fallback
         name: playwright-report
         path: |
           playwright-report/

--- a/.github/workflows/playwright-core.yml
+++ b/.github/workflows/playwright-core.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Restore Playwright browsers cache
       id: playwright-cache
-      uses: asd-engineering/artifact-nas/download@v1.4.3
+      uses: asd-engineering/artifact-nas/download@v1.4.4
       with:
         mode: cache
         name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -42,7 +42,7 @@ jobs:
 
     - name: Save Playwright browsers cache
       if: always()
-      uses: asd-engineering/artifact-nas/upload@v1.4.3
+      uses: asd-engineering/artifact-nas/upload@v1.4.4
       with:
         mode: cache
         name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
 
     - name: Upload Playwright report
       if: always()
-      uses: asd-engineering/artifact-nas/upload@v1.4.3
+      uses: asd-engineering/artifact-nas/upload@v1.4.4
       with:
         mode: nas-first
         name: playwright-report

--- a/.github/workflows/playwright-core.yml
+++ b/.github/workflows/playwright-core.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Restore Playwright browsers cache
       id: playwright-cache
-      uses: asd-engineering/artifact-nas/download@v1.4.1
+      uses: asd-engineering/artifact-nas/download@v1.4.2
       with:
         mode: cache
         name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -42,7 +42,7 @@ jobs:
 
     - name: Save Playwright browsers cache
       if: always()
-      uses: asd-engineering/artifact-nas/upload@v1.4.1
+      uses: asd-engineering/artifact-nas/upload@v1.4.2
       with:
         mode: cache
         name: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
 
     - name: Upload Playwright report
       if: always()
-      uses: asd-engineering/artifact-nas/upload@v1.4.1
+      uses: asd-engineering/artifact-nas/upload@v1.4.2
       with:
         mode: nas-first
         name: playwright-report

--- a/.github/workflows/playwright-core.yml
+++ b/.github/workflows/playwright-core.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     name: Playwright
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'ubuntu-latest' }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,7 +27,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.LINUX_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Bulk migration of this repo's CI to the NAS-aware artifact action.

## Changes

- \`actions/upload-artifact@v4\` -> \`asd-engineering/artifact-nas/upload@v1.4.1\` (Playwright report, \`mode: fallback\`)
- \`actions/cache@v4\` (Playwright browsers cache) -> matched \`download\` + \`upload\` pair in \`mode: cache\`, keyed on \`${{ hashFiles('package-lock.json') }}\`
- Org secrets \`RCLONE_CONF_B64\` + \`NAS_DEST\` wired at job \`env:\`

## Why

- GitHub artifact quota stops being a release-day surprise
- \`actions/cache@v4\` rate-limit / global-index collision goes away for self-hosted runners
- Reference: \`asd-engineering/.asd\` (parent rollout)

## Per-file mode rationale

- \`playwright-core.yml\`:
  - 1x \`mode: cache\` (Playwright browsers: \`~/.cache/ms-playwright\`, hashFiles-keyed)
  - 1x \`mode: fallback\` (Playwright HTML report + json, consumed-this-run + 30-day retention)

## Verification

- [x] All workflows parse (manual \`python3 yaml.safe_load\` passed for all 7 files)
- [x] No leftover \`actions/upload-artifact\` / \`actions/download-artifact\` references
- [x] No leftover \`actions/cache@\` references
- [x] Org secrets \`RCLONE_CONF_B64\` + \`NAS_DEST\` confirmed present at \`asd-engineering\` org level
- [x] Diff reviewed; cache producer step (\`npx playwright install\`) sits between the restore download and the save upload

## Notes

The cache save step uses \`if: always()\` so a flaky Playwright test still warms the browser cache for the next run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Playwright CI now depends on org NAS secrets and a custom artifact action; misconfiguration could break cache restore or report uploads without affecting app runtime.
> 
> **Overview**
> CI jobs now default to **`${{ vars.LINUX_RUNNER || 'ubuntu-latest' }}`** instead of hard-coded GitHub-hosted runners across comment-runner, lint, nightly, Pages, and Playwright workflows.
> 
> **Playwright** is the functional migration: browser caching moves from **`actions/cache@v4`** to paired **`asd-engineering/artifact-nas`** restore/save steps (`mode: cache`, keyed on `package-lock.json`), with a save step that runs **`if: always()`** so failed test runs still publish the cache. Test reports upload via **`artifact-nas/upload`** (`mode: nas-first`, 30-day retention) instead of **`actions/upload-artifact`**, with org secrets **`RCLONE_CONF_B64`** and **`NAS_DEST`** on the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69663ac35464341c8a5603d940066eeb2a11937c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->